### PR TITLE
RUI-157: paginated table load data

### DIFF
--- a/.changeset/smooth-rules-warn.md
+++ b/.changeset/smooth-rules-warn.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Separate loadData for PaginatedTable totals

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.0",

--- a/src/components/charts/tables/TableChartPaginated/TableChartPaginated.emb.ts
+++ b/src/components/charts/tables/TableChartPaginated/TableChartPaginated.emb.ts
@@ -63,6 +63,7 @@ const defaultState: TableChartPaginatedProState = {
   pageSize: undefined,
   sort: undefined,
   isLoadingDownloadData: false,
+  hasTotalResults: false,
 };
 
 export default defineComponent(TablePaginatedChart, meta, {
@@ -106,8 +107,16 @@ export default defineComponent(TablePaginatedChart, meta, {
             select: dimensionsAndMeasuresToLoad,
             offset: state.page * state.pageSize,
             limit: state.pageSize,
-            countRows: true,
             orderBy,
+          })
+        : undefined,
+      totalResults: !state?.hasTotalResults
+        ? loadData({
+            from: inputs.dataset,
+            select: dimensionsAndMeasuresToLoad,
+            offset: 0,
+            limit: 0,
+            countRows: true,
           })
         : undefined,
       allResults: state?.isLoadingDownloadData

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -154,7 +154,7 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
       ...prevState,
       hasTotalResults: false,
     }));
-  }, [dimensionsAndMeasures]);
+  }, [dimensionsAndMeasures, pageSize]);
 
   useEffect(() => {
     if (totalResults?.total) {

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -43,32 +43,34 @@ export type TableChartPaginatedProState = {
   pageSize?: number;
   sort?: { id: string; direction: OrderDirection } | undefined;
   isLoadingDownloadData: boolean;
+  hasTotalResults: boolean;
 };
 
 type TableChartPaginatedProProps = {
-  embeddableState: TableChartPaginatedProState;
-  title: string;
-  description: string;
-  displayNullAs?: string;
-  results: DataResponse;
-  dimensionsAndMeasures: DimensionOrMeasure[];
-  showIndex: boolean;
   allResults?: DataResponse;
   clickDimension?: Dimension;
+  description: string;
+  dimensionsAndMeasures: DimensionOrMeasure[];
+  displayNullAs?: string;
+  embeddableState: TableChartPaginatedProState;
+  results: DataResponse;
+  showIndex: boolean;
   state: TableChartPaginatedProState;
-  setState: React.Dispatch<React.SetStateAction<TableChartPaginatedProState>>;
+  title: string;
+  totalResults?: DataResponse;
   onRowClicked: (rowDimensionValue: TableChartPaginatedProOnRowClickArg) => void;
+  setState: React.Dispatch<React.SetStateAction<TableChartPaginatedProState>>;
 };
 
 const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const [total, setTotal] = useState<number | undefined>(undefined);
   const [isDownloadingData, setIsDownloadingData] = useState(false);
 
   const { description, title } = resolveI18nProps(props);
   const {
+    totalResults,
     results,
     allResults,
     dimensionsAndMeasures,
@@ -148,10 +150,20 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
 
   // Sync total from results
   useEffect(() => {
-    if (results?.total && results.total !== total) {
-      setTotal(results.total);
+    setState((prevState) => ({
+      ...prevState,
+      hasTotalResults: false,
+    }));
+  }, [dimensionsAndMeasures]);
+
+  useEffect(() => {
+    if (totalResults?.total) {
+      setState((prevState) => ({
+        ...prevState,
+        hasTotalResults: true,
+      }));
     }
-  }, [results, total]);
+  }, [totalResults]);
 
   // Handle data download when allResults is ready
   useEffect(() => {
@@ -186,9 +198,9 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
         pageSize={pageSize}
         paginationLabel={i18n.t('charts.tablePaginated.pagination', {
           page: state.page + 1,
-          totalPages: getTableTotalPages(total, pageSize) ?? '?',
+          totalPages: getTableTotalPages(totalResults?.total, pageSize) ?? '?',
         })}
-        total={total}
+        total={totalResults?.total}
         sort={localSort}
         onSortChange={(newSort) => {
           setLocalSort(newSort as TableChartPaginatedProState['sort']);


### PR DESCRIPTION
# Why is this pull-request needed?

This PR fixes the TablePaginated component, so it only fetches the total of rows once on a different loadData. Only get the loadData total of rows when:

1. number of displayed rows change
2. measures or dimensions change

# Test evidence


https://github.com/user-attachments/assets/aa67ee56-922a-4063-9ed2-1eaa6c331c1e



