### PR TITLE
RUI-167: Publish using trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: write
+
 jobs:
   publish:
     name: Publish
@@ -18,6 +22,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: ${{ vars.NPM_REGISTRY_URL }}
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -28,4 +36,3 @@ jobs:
           publish: npm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "@embeddable.com/remarkable-pro",
   "author": "embeddable (https://embeddable.com)",
   "version": "0.0.7",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/embeddable-hq/remarkable-pro"
+  },
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Why is this pull-request needed?

Migrates publishing to https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
