### PR TITLE
RUI-90: color assign + map

### DIFF
--- a/.changeset/late-kiwis-wave.md
+++ b/.changeset/late-kiwis-wave.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Add color input for measures on single dimensions BarCharts + Introduce theme backgroundbackgroundColorMap and borderColorMap

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/BarChartDefaultHorizontalPro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/BarChartDefaultHorizontalPro.emb.ts
@@ -15,7 +15,7 @@ export const meta = {
   category: 'Bar Charts',
   inputs: [
     inputs.dataset,
-    inputs.measures,
+    { ...inputs.measures, inputs: [...inputs.measures.inputs, inputs.color] },
     { ...inputs.dimensionWithDateBounds, label: 'Y-axis' },
     inputs.title,
     inputs.description,

--- a/src/components/charts/bars/BarChartDefaultPro/BarChartDefaultPro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/BarChartDefaultPro.emb.ts
@@ -15,7 +15,7 @@ export const meta = {
   category: 'Bar Charts',
   inputs: [
     inputs.dataset,
-    inputs.measures,
+    { ...inputs.measures, inputs: [...inputs.measures.inputs, inputs.color] },
     { ...inputs.dimensionWithDateBounds, label: 'X-axis' },
     inputs.title,
     inputs.description,

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -4,9 +4,8 @@ import { remarkableTheme } from '../../../theme/theme.constants';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { groupTailAsOther } from '../charts.utils';
-import { getColor } from '../../../theme/styles/styles.utils';
-import { getChartColors, getChartContrastColors } from '@embeddable.com/remarkable-ui';
-import { getObjectStableKey } from '../../../utils.ts/object.utils';
+import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
+import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { Context } from 'chartjs-plugin-datalabels';
 
 export const getBarStackedChartProData = (
@@ -25,22 +24,25 @@ export const getBarStackedChartProData = (
   const groupDimensionName = `${groupDimension.name}${groupDimension.nativeType === CUBE_DIMENSION_TYPE_TIME && groupDimension.inputs?.granularity ? `.${groupDimension.inputs.granularity}` : ''}`;
   const groupBy = [...new Set(data.map((d) => d[groupDimensionName]))].filter((d) => d != null);
 
-  const themeKey = getObjectStableKey(theme);
-  const chartContrastColors = getChartContrastColors();
+  const chartColors = getChartColors();
   const datasets = groupBy.map((groupByItem, index) => {
-    const backgroundColor = getColor(
-      `${themeKey}.charts.backgroundColors`,
-      `${groupDimension.name}.${groupByItem}`,
-      theme.charts.backgroundColors ?? chartContrastColors,
+    const backgroundColor = getDimensionMeasureColor({
+      dimensionOrMeasure: groupDimension,
+      theme,
+      color: 'background',
+      value: `${groupDimension.name}.${groupByItem}`,
       index,
-    );
+      chartColors,
+    });
 
-    const borderColor = getColor(
-      `${themeKey}.charts.borderColors`,
-      `${groupDimension.name}.${groupByItem}`,
-      theme.charts.borderColors ?? chartContrastColors,
+    const borderColor = getDimensionMeasureColor({
+      dimensionOrMeasure: groupDimension,
+      theme,
+      color: 'border',
+      value: `${groupDimension.name}.${groupByItem}`,
       index,
-    );
+      chartColors,
+    });
 
     return {
       label: themeFormatter.data(groupDimension, groupByItem),
@@ -79,7 +81,6 @@ export const getBarChartProData = (
   }
 
   const themeFormatter = getThemeFormatter(theme);
-  const themeKey = getObjectStableKey(theme);
   const groupedData = groupTailAsOther(props.data, props.dimension, props.measures, props.maxItems);
   const chartColors = getChartColors();
 
@@ -88,19 +89,23 @@ export const getBarChartProData = (
       return item[props.dimension.name];
     }),
     datasets: props.measures.map((measure, index) => {
-      const backgroundColor = getColor(
-        `${themeKey}.charts.backgroundColors`,
-        measure.name,
-        theme.charts.backgroundColors ?? chartColors,
+      const backgroundColor = getDimensionMeasureColor({
+        dimensionOrMeasure: measure,
+        theme,
+        color: 'background',
+        value: measure.name,
         index,
-      );
+        chartColors,
+      });
 
-      const borderColor = getColor(
-        `${themeKey}.charts.borderColors`,
-        measure.name,
-        theme.charts.borderColors ?? chartColors,
+      const borderColor = getDimensionMeasureColor({
+        dimensionOrMeasure: measure,
+        theme,
+        color: 'border',
+        value: measure.name,
         index,
-      );
+        chartColors,
+      });
 
       return {
         label: themeFormatter.dimensionOrMeasureTitle(measure),

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.utils.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.utils.ts
@@ -1,15 +1,14 @@
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
-import { getObjectStableKey } from '../../../../utils.ts/object.utils';
 import {
-  getChartContrastColors,
+  getChartColors,
   getChartjsAxisOptionsScalesTicksDefault,
   getChartjsAxisOptionsScalesTitle,
   getStyleNumber,
 } from '@embeddable.com/remarkable-ui';
 import { Theme } from '../../../../theme/theme.types';
-import { getColor } from '../../../../theme/styles/styles.utils';
+import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
 import { i18n } from '../../../../theme/i18n/i18n';
 import { mergician } from 'mergician';
 import { isColorValid, setColorAlpha } from '../../../../utils.ts/color.utils';
@@ -43,21 +42,22 @@ const getLineChartComparisonDataset = (
     : data?.map((item) => item[measure.name] ?? (zeroFill ? 0 : null));
 
   const themeFormatter = getThemeFormatter(theme);
-  const themeKey = getObjectStableKey(theme);
 
   const isLineDashed = Boolean(
     measure.inputs?.[isPreviousPeriod ? 'previousLineDashed' : 'lineDashed'],
   );
-  const chartContrastColors = getChartContrastColors();
+  const chartColors = getChartColors();
   const lineColorTemp = measure.inputs?.[isPreviousPeriod ? 'previousLineColor' : 'lineColor'];
   const lineColor = isColorValid(lineColorTemp)
     ? lineColorTemp
-    : getColor(
-        `${themeKey}.charts.backgroundColors`,
-        measure.name,
-        theme.charts.backgroundColors ?? chartContrastColors,
+    : getDimensionMeasureColor({
+        dimensionOrMeasure: measure,
+        theme,
+        color: 'background',
+        value: measure.name,
+        chartColors,
         index,
-      );
+      });
 
   const rawLabel = themeFormatter.dimensionOrMeasureTitle(measure);
 

--- a/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.utils.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.utils.ts
@@ -2,9 +2,8 @@ import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { Theme } from '../../../../theme/theme.types';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
-import { getObjectStableKey } from '../../../../utils.ts/object.utils';
-import { getChartContrastColors, getStyleNumber } from '@embeddable.com/remarkable-ui';
-import { getColor } from '../../../../theme/styles/styles.utils';
+import { getChartColors, getStyleNumber } from '@embeddable.com/remarkable-ui';
+import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
 import { mergician } from 'mergician';
 import { isColorValid, setColorAlpha } from '../../../../utils.ts/color.utils';
 import { LineChartProOptionsClick } from '../lines.utils';
@@ -27,7 +26,6 @@ export const getLineChartProData = (
 
   const themeFormatter = getThemeFormatter(theme);
 
-  const themeKey = getObjectStableKey(theme);
   const groupedData = props.data;
 
   return {
@@ -39,24 +37,28 @@ export const getLineChartProData = (
       const values = groupedData.map((item) => item[measure.name] ?? (zeroFill ? 0 : null));
 
       const lineColor = measure.inputs?.['lineColor'];
-      const chartContrastColors = getChartContrastColors();
+      const chartColors = getChartColors();
       const backgroundColor = isColorValid(lineColor)
         ? lineColor
-        : getColor(
-            `${themeKey}.charts.backgroundColors`,
-            measure.name,
-            theme.charts.backgroundColors ?? chartContrastColors,
+        : getDimensionMeasureColor({
+            dimensionOrMeasure: measure,
+            theme,
+            color: 'background',
+            value: measure.name,
+            chartColors,
             index,
-          );
+          });
 
       const borderColor = isColorValid(lineColor)
         ? lineColor
-        : getColor(
-            `${themeKey}.charts.borderColors`,
-            measure.name,
-            theme.charts.borderColors ?? chartContrastColors,
+        : getDimensionMeasureColor({
+            dimensionOrMeasure: measure,
+            theme,
+            color: 'border',
+            value: measure.name,
+            chartColors,
             index,
-          );
+          });
 
       return {
         clip: props.hasMinMaxYAxisRange,

--- a/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.ts
@@ -3,10 +3,9 @@ import { Theme } from '../../../../theme/theme.types';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { mergician } from 'mergician';
-import { getObjectStableKey } from '../../../../utils.ts/object.utils';
-import { getColor } from '../../../../theme/styles/styles.utils';
+import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
 import { setColorAlpha } from '../../../../utils.ts/color.utils';
-import { getChartContrastColors } from '@embeddable.com/remarkable-ui';
+import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { getLineChartProOptions, LineChartProOptionsClick } from '../lines.utils';
 
 export const getLineChartGroupedProData = (
@@ -25,22 +24,25 @@ export const getLineChartGroupedProData = (
   const axis = [...new Set(data.map((d) => d[dimension.name]).filter((d) => d != null))].sort();
   const groupBy = [...new Set(data.map((d) => d[groupDimension.name]))].filter((d) => d != null);
 
-  const themeKey = getObjectStableKey(theme);
-  const chartContrastColors = getChartContrastColors();
+  const chartColors = getChartColors();
   const datasets: ChartData<'line'>['datasets'] = groupBy.map((groupByItem, index) => {
-    const backgroundColor = getColor(
-      `${themeKey}.charts.backgroundColors`,
-      `${groupDimension.name}.${groupByItem}`,
-      theme.charts.backgroundColors ?? chartContrastColors,
+    const backgroundColor = getDimensionMeasureColor({
+      dimensionOrMeasure: groupDimension,
+      theme,
+      color: 'background',
+      value: `${groupDimension.name}.${groupByItem}`,
+      chartColors,
       index,
-    );
+    });
 
-    const borderColor = getColor(
-      `${themeKey}.charts.borderColors`,
-      `${groupDimension.name}.${groupByItem}`,
-      theme.charts.borderColors ?? chartContrastColors,
+    const borderColor = getDimensionMeasureColor({
+      dimensionOrMeasure: groupDimension,
+      theme,
+      color: 'border',
+      value: `${groupDimension.name}.${groupByItem}`,
+      chartColors,
       index,
-    );
+    });
 
     const dataset = {
       clip: hasMinMaxYAxisRange,

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -4,10 +4,9 @@ import { groupTailAsOther } from '../charts.utils';
 import { Theme } from '../../../theme/theme.types';
 import { remarkableTheme } from '../../../theme/theme.constants';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
-import { getColor } from '../../../theme/styles/styles.utils';
+import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { i18n } from '../../../theme/i18n/i18n';
-import { getObjectStableKey } from '../../../utils.ts/object.utils';
 
 export const getPieChartProData = (
   props: {
@@ -33,24 +32,27 @@ export const getPieChartProData = (
     props.maxLegendItems,
   );
 
-  const themeKey = getObjectStableKey(theme);
   const chartColors = getChartColors();
-  const backgroundColor = groupedData.map((item, i) =>
-    getColor(
-      `${themeKey}.charts.backgroundColors`,
-      `${props.dimension.name}.${item[props.dimension.name]}`,
-      theme.charts.backgroundColors ?? chartColors,
-      i,
-    ),
+  const backgroundColor = groupedData.map((item, index) =>
+    getDimensionMeasureColor({
+      dimensionOrMeasure: props.dimension,
+      theme,
+      color: 'background',
+      value: `${props.dimension.name}.${item[props.dimension.name]}`,
+      chartColors,
+      index,
+    }),
   );
 
-  const borderColor = groupedData.map((item, i) =>
-    getColor(
-      `${themeKey}.charts.borderColors`,
-      `${props.dimension.name}.${item[props.dimension.name]}`,
-      theme.charts.borderColors ?? chartColors,
-      i,
-    ),
+  const borderColor = groupedData.map((item, index) =>
+    getDimensionMeasureColor({
+      dimensionOrMeasure: props.dimension,
+      theme,
+      color: 'border',
+      value: `${props.dimension.name}.${item[props.dimension.name]}`,
+      chartColors,
+      index,
+    }),
   );
 
   return {

--- a/src/components/charts/tables/tables.utils.tsx
+++ b/src/components/charts/tables/tables.utils.tsx
@@ -22,6 +22,7 @@ export const getTableHeaderAlign = (dimOrMeas: DimensionOrMeasure): TableHeaderI
   switch (dimOrMeas.nativeType) {
     case 'boolean':
     case 'time':
+    case 'number':
       return TableHeaderAlign.RIGHT;
     default:
       return TableHeaderAlign.LEFT;

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -11,7 +11,21 @@ export type ThemeI18n = { language: string; translations: Resource };
 
 export type ThemeChartsLegendPosition = 'top' | 'right' | 'bottom' | 'left';
 
+export type ThemeChartsColors = {
+  borderColor: string;
+  backgroundColor: string;
+};
+
+export type ThemeChartsColorMap = {
+  dimensionValue?: Record<string, string>;
+  measure?: Record<string, string>;
+};
+
 export type ThemeCharts = {
+  // Color mapping
+  backgroundColorMap?: ThemeChartsColorMap;
+  borderColorMap?: ThemeChartsColorMap;
+
   backgroundColors?: string[];
   borderColors?: string[];
   legendPosition: ThemeChartsLegendPosition;


### PR DESCRIPTION
# Why is this pull-request needed?

This PR brings the new color selection for the single dimension bar charts. And also allows setting the color maps for the background and borders via the theme.

# Main changes

- add the color inputs to the bar charts single dimension
- update theme to allow the background and border colors of the dimensions and measures
- create helper function that returns the color wanted

# Test evidence


https://github.com/user-attachments/assets/1597f420-7ef3-4519-b869-8c01245b8e85




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added theme types for chart color mapping to support enhanced color customization.

* **Refactor**
  * Updated bar, line, and pie chart color handling for improved consistency.
  * Enhanced chart component input composition to include expanded color configuration options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->