### PR TITLE
RUI-000: introduce dropdown collisions

### DIFF
--- a/.changeset/strict-rats-bow.md
+++ b/.changeset/strict-rats-bow.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Introduce drodown collisions

--- a/.changeset/strict-rats-bow.md
+++ b/.changeset/strict-rats-bow.md
@@ -2,4 +2,4 @@
 '@embeddable.com/remarkable-pro': patch
 ---
 
-Introduce drodown collisions
+Introduce dropdown collisions

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.4",
         "@embeddable.com/react": "^2.13.0",
-        "@embeddable.com/remarkable-ui": "^2.0.28",
+        "@embeddable.com/remarkable-ui": "^2.0.29",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "2.0.28",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.28.tgz",
-      "integrity": "sha512-wguxOXWO93oSVL8XR1fSrUA8mGyPL1fct5o7K5L9rtDwaj4gZr2U6KR8nh16Ig7b06cAf3ocqca8vokv3VE0FQ==",
+      "version": "2.0.29",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.29.tgz",
+      "integrity": "sha512-dYbPSv4ctaovDUE1mcwXEcI1R1DQrIc3h7NCF4/Mt9EmMw1Lnc9/05w4Vjdgx8mjUDKiXBc9XZ1BVmDSsFEwbw==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.4",
     "@embeddable.com/react": "^2.13.0",
-    "@embeddable.com/remarkable-ui": "^2.0.28",
+    "@embeddable.com/remarkable-ui": "^2.0.29",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -5,7 +5,7 @@ import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { groupTailAsOther } from '../charts.utils';
 import { getColor } from '../../../theme/styles/styles.utils';
-import { getChartColors, getChartContrastColors } from '@embeddable.com/remarkable-ui';
+import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { getObjectStableKey } from '../../../utils.ts/object.utils';
 import { Context } from 'chartjs-plugin-datalabels';
 
@@ -26,19 +26,19 @@ export const getBarStackedChartProData = (
   const groupBy = [...new Set(data.map((d) => d[groupDimensionName]))].filter((d) => d != null);
 
   const themeKey = getObjectStableKey(theme);
-  const chartContrastColors = getChartContrastColors();
+  const chartColors = getChartColors();
   const datasets = groupBy.map((groupByItem, index) => {
     const backgroundColor = getColor(
       `${themeKey}.charts.backgroundColors`,
       `${groupDimension.name}.${groupByItem}`,
-      theme.charts.backgroundColors ?? chartContrastColors,
+      theme.charts.backgroundColors ?? chartColors,
       index,
     );
 
     const borderColor = getColor(
       `${themeKey}.charts.borderColors`,
       `${groupDimension.name}.${groupByItem}`,
-      theme.charts.borderColors ?? chartContrastColors,
+      theme.charts.borderColors ?? chartColors,
       index,
     );
 

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.utils.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.utils.ts
@@ -3,7 +3,7 @@ import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { getObjectStableKey } from '../../../../utils.ts/object.utils';
 import {
-  getChartContrastColors,
+  getChartColors,
   getChartjsAxisOptionsScalesTicksDefault,
   getChartjsAxisOptionsScalesTitle,
   getStyleNumber,
@@ -48,14 +48,14 @@ const getLineChartComparisonDataset = (
   const isLineDashed = Boolean(
     measure.inputs?.[isPreviousPeriod ? 'previousLineDashed' : 'lineDashed'],
   );
-  const chartContrastColors = getChartContrastColors();
+  const chartColors = getChartColors();
   const lineColorTemp = measure.inputs?.[isPreviousPeriod ? 'previousLineColor' : 'lineColor'];
   const lineColor = isColorValid(lineColorTemp)
     ? lineColorTemp
     : getColor(
         `${themeKey}.charts.backgroundColors`,
         measure.name,
-        theme.charts.backgroundColors ?? chartContrastColors,
+        theme.charts.backgroundColors ?? chartColors,
         index,
       );
 

--- a/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.utils.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.utils.ts
@@ -3,7 +3,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { getObjectStableKey } from '../../../../utils.ts/object.utils';
-import { getChartContrastColors, getStyleNumber } from '@embeddable.com/remarkable-ui';
+import { getChartColors, getStyleNumber } from '@embeddable.com/remarkable-ui';
 import { getColor } from '../../../../theme/styles/styles.utils';
 import { mergician } from 'mergician';
 import { isColorValid, setColorAlpha } from '../../../../utils.ts/color.utils';
@@ -39,13 +39,13 @@ export const getLineChartProData = (
       const values = groupedData.map((item) => item[measure.name] ?? (zeroFill ? 0 : null));
 
       const lineColor = measure.inputs?.['lineColor'];
-      const chartContrastColors = getChartContrastColors();
+      const chartColors = getChartColors();
       const backgroundColor = isColorValid(lineColor)
         ? lineColor
         : getColor(
             `${themeKey}.charts.backgroundColors`,
             measure.name,
-            theme.charts.backgroundColors ?? chartContrastColors,
+            theme.charts.backgroundColors ?? chartColors,
             index,
           );
 
@@ -54,7 +54,7 @@ export const getLineChartProData = (
         : getColor(
             `${themeKey}.charts.borderColors`,
             measure.name,
-            theme.charts.borderColors ?? chartContrastColors,
+            theme.charts.borderColors ?? chartColors,
             index,
           );
 

--- a/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.ts
@@ -6,7 +6,7 @@ import { mergician } from 'mergician';
 import { getObjectStableKey } from '../../../../utils.ts/object.utils';
 import { getColor } from '../../../../theme/styles/styles.utils';
 import { setColorAlpha } from '../../../../utils.ts/color.utils';
-import { getChartContrastColors } from '@embeddable.com/remarkable-ui';
+import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { getLineChartProOptions, LineChartProOptionsClick } from '../lines.utils';
 
 export const getLineChartGroupedProData = (
@@ -26,19 +26,19 @@ export const getLineChartGroupedProData = (
   const groupBy = [...new Set(data.map((d) => d[groupDimension.name]))].filter((d) => d != null);
 
   const themeKey = getObjectStableKey(theme);
-  const chartContrastColors = getChartContrastColors();
+  const chartColors = getChartColors();
   const datasets: ChartData<'line'>['datasets'] = groupBy.map((groupByItem, index) => {
     const backgroundColor = getColor(
       `${themeKey}.charts.backgroundColors`,
       `${groupDimension.name}.${groupByItem}`,
-      theme.charts.backgroundColors ?? chartContrastColors,
+      theme.charts.backgroundColors ?? chartColors,
       index,
     );
 
     const borderColor = getColor(
       `${themeKey}.charts.borderColors`,
       `${groupDimension.name}.${groupByItem}`,
-      theme.charts.borderColors ?? chartContrastColors,
+      theme.charts.borderColors ?? chartColors,
       index,
     );
 

--- a/src/components/editors/ComparisonPeriodSelectFieldPro/index.tsx
+++ b/src/components/editors/ComparisonPeriodSelectFieldPro/index.tsx
@@ -69,6 +69,7 @@ const DateComparisonSelectFieldPro = (props: DateComparisonSelectFieldPro) => {
         onChange={onChange}
         options={options}
         noOptionsMessage={i18n.t('common.noOptionsAvailable')}
+        avoidCollisions={false}
       />
     </EditorCard>
   );

--- a/src/components/editors/GranularitySelectFieldPro/index.tsx
+++ b/src/components/editors/GranularitySelectFieldPro/index.tsx
@@ -65,6 +65,7 @@ const GranularitySelectFieldPro = (props: GranularitySelectFieldProProps) => {
         value={safeValue}
         options={availableOptions}
         onChange={onChange}
+        avoidCollisions={false}
       />
     </EditorCard>
   );

--- a/src/components/editors/MultiSelectFieldPro/index.tsx
+++ b/src/components/editors/MultiSelectFieldPro/index.tsx
@@ -58,6 +58,7 @@ const MultiSelectFieldPro = (props: MultiSelectFieldProProps) => {
         noOptionsMessage={showNoOptionsMessage ? i18n.t('common.noOptionsFound') : undefined}
         onChange={(newValues) => onChange?.(newValues)}
         onSearch={setSearchValue}
+        avoidCollisions={false}
       />
     </EditorCard>
   );

--- a/src/components/editors/SingleSelectFieldPro/index.tsx
+++ b/src/components/editors/SingleSelectFieldPro/index.tsx
@@ -59,6 +59,7 @@ const SingleSelectFieldPro = (props: SingleSelectFieldProProps) => {
         noOptionsMessage={showNoOptionsMessage ? i18n.t('common.noOptionsFound') : undefined}
         onChange={(newValue: string) => onChange?.(newValue)}
         onSearch={setSearchValue}
+        avoidCollisions={false}
       />
     </EditorCard>
   );

--- a/src/components/editors/dates/DateRangePickerCustomPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerCustomPro/index.tsx
@@ -58,6 +58,7 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
         value={getDateRangeFromTimeRange(selectedValue, dateRangeOptions)}
         onChange={handleChange}
         submitLabel={i18n.t('editors.dateRangePicker.apply')}
+        avoidCollisions={false}
       />
     </EditorCard>
   );

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -120,6 +120,7 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
       <Dropdown
         open={isOpen}
         onOpenChange={setIsOpen}
+        avoidCollisions={false}
         triggerComponent={
           <SelectFieldTrigger
             startIcon={IconCalendarFilled}


### PR DESCRIPTION
# Why is this pull-request needed?

This PR introduces the avoidCollision for all the components that rely on the dropdown. 
Context: In the dashboards, if the dropdown opens upwards, it might get covered by the above widget.



# Test evidence

https://github.com/user-attachments/assets/7e15627e-de9f-4297-9564-956e2416f7fc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dropdown collision handling for select fields and date pickers to prevent overlapping with other UI elements.

* **Bug Fixes**
  * Updated chart color rendering to use corrected color utilities for better visual consistency.

* **Chores**
  * Updated @embeddable.com/remarkable-ui dependency to latest patch version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->