### PR TITLE
TPS-1105: allow single select field to select from booleans 🚨do not merge

### DIFF
--- a/.changeset/late-laws-follow.md
+++ b/.changeset/late-laws-follow.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Fix SingleSelectField booleans

--- a/.changeset/tender-berries-hug.md
+++ b/.changeset/tender-berries-hug.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Allow SingleSelectField to select from boolean options

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.0.22",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.0.22",
+      "version": "0.0.25",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.4",
         "@embeddable.com/react": "^2.13.0",
-        "@embeddable.com/remarkable-ui": "^2.0.29",
+        "@embeddable.com/remarkable-ui": "^2.0.30",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.29.tgz",
-      "integrity": "sha512-dYbPSv4ctaovDUE1mcwXEcI1R1DQrIc3h7NCF4/Mt9EmMw1Lnc9/05w4Vjdgx8mjUDKiXBc9XZ1BVmDSsFEwbw==",
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.30.tgz",
+      "integrity": "sha512-Mty9xgH5XeTFFakRkvXA3Zl/CkLT6awGBvAQgvxB09ygjrpSbLCAOq1Kqc82oXjsFWwqLJPmVWLjUy7cF9QGkQ==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.4",
     "@embeddable.com/react": "^2.13.0",
-    "@embeddable.com/remarkable-ui": "^2.0.29",
+    "@embeddable.com/remarkable-ui": "^2.0.30",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/BarChartDefaultHorizontalPro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/BarChartDefaultHorizontalPro.emb.ts
@@ -65,7 +65,7 @@ export default defineComponent(BarChartDefaultHorizontalPro, meta, {
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartDefaultPro/BarChartDefaultPro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/BarChartDefaultPro.emb.ts
@@ -65,7 +65,7 @@ export default defineComponent(BarChartDefaultPro, meta, {
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/BarChartGroupedHorizontalPro.emb.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/BarChartGroupedHorizontalPro.emb.ts
@@ -73,8 +73,8 @@ export default defineComponent(BarChartGroupedHorizontalPro, meta, {
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartGroupedPro/BarChartGroupedPro.emb.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/BarChartGroupedPro.emb.ts
@@ -73,8 +73,8 @@ export default defineComponent(BarChartGroupedPro, meta, {
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/BarChartStackedHorizontalPro.emb.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/BarChartStackedHorizontalPro.emb.ts
@@ -74,8 +74,8 @@ export default defineComponent(BarChartStackedHorizontalPro, meta, {
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartStackedPro/BarChartStackedPro.emb.ts
+++ b/src/components/charts/bars/BarChartStackedPro/BarChartStackedPro.emb.ts
@@ -74,8 +74,8 @@ export default defineComponent(BarChartStackedPro, meta, {
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.emb.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.emb.ts
@@ -192,7 +192,7 @@ export default defineComponent(LineChartComparisonDefaultPro, meta, {
   events: {
     onLineClicked: (value: LineChartProOptionsClickArg) => {
       return {
-        axisDimensionValue: value.dimensionValue || Value.noFilter(),
+        axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.emb.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.emb.ts
@@ -91,7 +91,7 @@ export default defineComponent(LineChartDefaultPro, meta, {
   events: {
     onLineClicked: (value: LineChartProOptionsClickArg) => {
       return {
-        axisDimensionValue: value.dimensionValue || Value.noFilter(),
+        axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.emb.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.emb.ts
@@ -92,8 +92,8 @@ export default defineComponent(LineChartGroupedPro, meta, {
   events: {
     onLineClicked: (value: LineChartProOptionsClickArg) => {
       return {
-        axisDimensionValue: value.dimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/pies/DonutChartPro/DonutChartPro.emb.ts
+++ b/src/components/charts/pies/DonutChartPro/DonutChartPro.emb.ts
@@ -60,7 +60,7 @@ export default defineComponent(DonutChartPro, meta, {
   events: {
     onSegmentClick: (value) => {
       return {
-        dimensionValue: value.dimensionValue || Value.noFilter(),
+        dimensionValue: value.dimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/pies/DonutLabelChartPro/DonutLabelChartPro.emb.ts
+++ b/src/components/charts/pies/DonutLabelChartPro/DonutLabelChartPro.emb.ts
@@ -84,7 +84,7 @@ export default defineComponent(DonutLabelChartPro, meta, {
   events: {
     onSegmentClick: (value) => {
       return {
-        dimensionValue: value.dimensionValue || Value.noFilter(),
+        dimensionValue: value.dimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/pies/PieChartPro/PieChartPro.emb.ts
+++ b/src/components/charts/pies/PieChartPro/PieChartPro.emb.ts
@@ -60,7 +60,7 @@ export default defineComponent(PieChartPro, meta, {
   events: {
     onSegmentClick: (value) => {
       return {
-        dimensionValue: value.dimensionValue || Value.noFilter(),
+        dimensionValue: value.dimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/editors/ComparisonPeriodSelectFieldPro/ComparisonPeriodSelectFieldPro.emb.ts
+++ b/src/components/editors/ComparisonPeriodSelectFieldPro/ComparisonPeriodSelectFieldPro.emb.ts
@@ -65,7 +65,7 @@ export default defineComponent(ComparisonPeriodSelectFieldPro, meta, {
   events: {
     onChange: (value) => {
       return {
-        value: value || Value.noFilter(),
+        value: value ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/editors/ComparisonPeriodSelectFieldPro/index.tsx
+++ b/src/components/editors/ComparisonPeriodSelectFieldPro/index.tsx
@@ -19,7 +19,7 @@ type DateComparisonSelectFieldPro = {
   placeholder?: string;
   primaryDateRange?: TimeRange;
   comparisonPeriod?: string;
-  onChange: (newComparisonPeriod?: string) => void;
+  onChange: (newComparisonPeriod?: string | boolean | number | undefined) => void; // TODO: improve after hotfix on remarkable-ui
 } & ChartCardHeaderProps;
 
 const DateComparisonSelectFieldPro = (props: DateComparisonSelectFieldPro) => {

--- a/src/components/editors/GranularitySelectFieldPro/index.tsx
+++ b/src/components/editors/GranularitySelectFieldPro/index.tsx
@@ -15,7 +15,7 @@ import { TGranularityValue } from '../../../theme/defaults/defaults.GranularityO
 import { ChartCardHeaderProps } from '../../charts/shared/ChartCard/ChartCard';
 
 type GranularitySelectFieldProProps = {
-  onChange: (newGranularity: string) => void;
+  onChange: (newGranularity: string | boolean | number | undefined) => void; // TODO: improve after hotfix on remarkable-ui
   placeholder?: string;
   primaryTimeRange?: TimeRange;
   granularity?: TGranularityValue;

--- a/src/components/editors/MultiSelectFieldPro/index.tsx
+++ b/src/components/editors/MultiSelectFieldPro/index.tsx
@@ -18,7 +18,7 @@ type MultiSelectFieldProProps = {
   selectedValues?: string[];
   maxOptions?: number;
   setSearchValue?: (search: string) => void;
-  onChange?: (newValues: string[]) => void;
+  onChange?: (newValues: (string | number | boolean | undefined)[]) => void;
 } & ChartCardHeaderProps;
 
 const MultiSelectFieldPro = (props: MultiSelectFieldProProps) => {

--- a/src/components/editors/SingleSelectFieldPro/SingleSelectFieldPro.emb.ts
+++ b/src/components/editors/SingleSelectFieldPro/SingleSelectFieldPro.emb.ts
@@ -107,9 +107,9 @@ export default defineComponent(SingleSelectFieldPro, meta, {
     };
   },
   events: {
-    onChange: (selectedValue: string) => {
+    onChange: (selectedValue: number | string | boolean | undefined) => {
       return {
-        value: selectedValue || Value.noFilter(),
+        value: selectedValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/editors/SingleSelectFieldPro/index.tsx
+++ b/src/components/editors/SingleSelectFieldPro/index.tsx
@@ -18,7 +18,7 @@ type SingleSelectFieldProProps = {
   selectedValue?: string;
   maxOptions?: number;
   setSearchValue?: (search: string) => void;
-  onChange?: (selectedValue: string) => void;
+  onChange?: (selectedValue: string | boolean | number | undefined) => void;
 } & ChartCardHeaderProps;
 
 const SingleSelectFieldPro = (props: SingleSelectFieldProProps) => {
@@ -41,11 +41,29 @@ const SingleSelectFieldPro = (props: SingleSelectFieldProProps) => {
     results.data?.map((data) => {
       return {
         value: optionalSecondDimension ? data[optionalSecondDimension.name] : data[dimension.name],
-        label: themeFormatter.data(dimension, data[dimension.name]),
+        label: themeFormatter.data(
+          dimension,
+          data[optionalSecondDimension ? optionalSecondDimension.name : dimension.name],
+        ),
       };
     }) ?? [];
 
   const showNoOptionsMessage = Boolean(!results.isLoading && (results.data?.length ?? 0) === 0);
+
+  const selectedValueIsBoolean = optionalSecondDimension
+    ? optionalSecondDimension.nativeType === 'boolean'
+    : dimension.nativeType === 'boolean';
+
+  const safeValue = options.find((option) => {
+    let value: string | boolean | undefined = selectedValue;
+    if (selectedValueIsBoolean) {
+      value = selectedValue === 'true' ? true : selectedValue === 'false' ? false : undefined;
+    }
+
+    return option.value === value;
+  })?.value;
+
+  console.log('selectedValue', selectedValue, safeValue);
 
   return (
     <EditorCard title={title} subtitle={description}>
@@ -53,11 +71,11 @@ const SingleSelectFieldPro = (props: SingleSelectFieldProProps) => {
         clearable
         searchable
         isLoading={results.isLoading}
-        value={selectedValue}
+        value={safeValue}
         options={options}
         placeholder={placeholder}
         noOptionsMessage={showNoOptionsMessage ? i18n.t('common.noOptionsFound') : undefined}
-        onChange={(newValue: string) => onChange?.(newValue)}
+        onChange={(newValue) => onChange?.(newValue)}
         onSearch={setSearchValue}
         avoidCollisions={false}
       />

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -74,7 +74,8 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
 
   const options = getDateRangeSelectFieldProOptions(dateRangeOptions);
 
-  const handleOptionChange = (newValue: string | undefined) => {
+  // TODO: To improve after hotfix in remarkable-ui
+  const handleOptionChange = (newValue: string | number | boolean | undefined) => {
     const newTimeRange = getTimeRangeFromPresets(
       { relativeTimeString: newValue } as TimeRange,
       dateRangeOptions,
@@ -171,7 +172,7 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
               />
               {options.map((option) => (
                 <SelectListOption
-                  key={option.value}
+                  key={option.value?.toString()}
                   {...option}
                   isSelected={selectedValue?.relativeTimeString === option.value}
                   onClick={() => handleOptionChange(option.value)}


### PR DESCRIPTION
# Why is this pull-request needed?

This PR allows the Single and Multi Selectfield to work with strings, numbers and booleans.


This is an hotfix - we will need to go back on Remarkable ui and improve the types later.


If merged, please make sure it is properly tested.

After merged, a Version PR will be created on the Pull Requests tab. After that is approved and merged, a new version will be created, and we can tell the client this was sorted.

# Test evidence


https://github.com/user-attachments/assets/6e2659ba-48e1-49ec-859f-3f571082b112




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SingleSelectField to properly handle and select from boolean options.
  * Improved handling of empty strings, zeros, and false values across form components and chart interactions.

* **New Features**
  * Expanded SingleSelectField, MultiSelectField, GranularitySelectField, and DateRangePickerPresets to support boolean, numeric, and undefined option values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->