### PR TITLE
RUI-44: built in granularity

### DIFF
--- a/.changeset/hot-emus-rest.md
+++ b/.changeset/hot-emus-rest.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Introduce built in granularity selector for bar and lin charts

--- a/.changeset/hot-emus-rest.md
+++ b/.changeset/hot-emus-rest.md
@@ -2,4 +2,4 @@
 '@embeddable.com/remarkable-pro': patch
 ---
 
-Introduce built in granularity selector for bar and lin charts
+Introduce built in granularity selector for bar and line charts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.0.22",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.0.22",
+      "version": "0.0.25",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.4",
         "@embeddable.com/react": "^2.13.0",
-        "@embeddable.com/remarkable-ui": "^2.0.29",
+        "@embeddable.com/remarkable-ui": "^2.0.32",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "2.0.29",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.29.tgz",
-      "integrity": "sha512-dYbPSv4ctaovDUE1mcwXEcI1R1DQrIc3h7NCF4/Mt9EmMw1Lnc9/05w4Vjdgx8mjUDKiXBc9XZ1BVmDSsFEwbw==",
+      "version": "2.0.32",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.32.tgz",
+      "integrity": "sha512-H4jAjoky+bumLpd2UEX93tGAF/qXKV9IIBNWs/6M38But6KXy32QO/CWBnIXAW7/isO3odlSgu5chdGY2MuRkA==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1614,31 +1614,31 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.7.5"
       },
       "peerDependencies": {
         "react": ">=16.8.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.4",
     "@embeddable.com/react": "^2.13.0",
-    "@embeddable.com/remarkable-ui": "^2.0.29",
+    "@embeddable.com/remarkable-ui": "^2.0.32",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/BarChartDefaultHorizontalPro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/BarChartDefaultHorizontalPro.emb.ts
@@ -1,4 +1,4 @@
-import { Value, loadData } from '@embeddable.com/core';
+import { Granularity, Value, loadData } from '@embeddable.com/core';
 import {
   defineComponent,
   definePreview,
@@ -8,6 +8,7 @@ import {
 import BarChartDefaultHorizontalPro from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'BarChartDefaultHorizontalPro',
@@ -16,7 +17,7 @@ export const meta = {
   inputs: [
     inputs.dataset,
     { ...inputs.measures, inputs: [...inputs.measures.inputs, inputs.color] },
-    { ...inputs.dimensionWithDateBounds, label: 'Y-axis' },
+    { ...inputs.dimensionWithGranularitySelectField, label: 'Y-axis' },
     inputs.title,
     inputs.description,
     inputs.showLegend,
@@ -50,15 +51,30 @@ export const preview = definePreview(BarChartDefaultHorizontalPro, {
   measures: [previewData.measure],
   results: previewData.results1Measure1Dimension,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type BarChartDefaultProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(BarChartDefaultHorizontalPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [BarChartDefaultProState, (state: BarChartDefaultProState) => void],
+  ) => {
+    const dimensionWithGranularity = getDimensionWithGranularity(
+      inputs.dimension,
+      state?.granularity,
+    );
+
     return {
       ...inputs,
+      dimension: dimensionWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
         from: inputs.dataset,
-        select: [...inputs.measures, inputs.dimension],
+        select: [...inputs.measures, dimensionWithGranularity],
       }),
     };
   },

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
@@ -6,8 +6,9 @@ import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProData, getBarChartProOptions } from '../bars.utils';
 import { mergician } from 'mergician';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type BarChartDefaultHorizontalProProps = {
   dimension: Dimension;
@@ -23,6 +24,7 @@ type BarChartDefaultHorizontalProProps = {
   xAxisRangeMin?: number;
   yAxisLabel?: string;
   yAxisMaxItems?: number;
+  setGranularity: (granularity: Granularity) => void;
   onBarClicked?: (args: { axisDimensionValue: string | null }) => void;
 } & ChartCardHeaderProps;
 
@@ -32,22 +34,22 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
 
   const {
     hideMenu,
-    description,
     dimension,
     measures,
+    showValueLabels,
     reverseYAxis,
     showLegend,
     showLogarithmicScale,
     showTooltips,
-    showValueLabels,
-    title,
-    xAxisLabel,
     xAxisRangeMax,
     xAxisRangeMin,
-    yAxisLabel,
     yAxisMaxItems,
+
+    setGranularity,
     onBarClicked,
-  } = resolveI18nProps(props);
+  } = props;
+
+  const { description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
 
   const results = useFillGaps({
     results: props.results,
@@ -73,6 +75,11 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={dimension}
+        onChange={setGranularity}
+      />
       <BarChart
         horizontal
         data={data}

--- a/src/components/charts/bars/BarChartDefaultPro/BarChartDefaultPro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/BarChartDefaultPro.emb.ts
@@ -1,4 +1,4 @@
-import { Value, loadData } from '@embeddable.com/core';
+import { Granularity, Value, loadData } from '@embeddable.com/core';
 import {
   defineComponent,
   definePreview,
@@ -8,6 +8,7 @@ import {
 import BarChartDefaultPro from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'BarChartDefaultPro',
@@ -16,7 +17,10 @@ export const meta = {
   inputs: [
     inputs.dataset,
     { ...inputs.measures, inputs: [...inputs.measures.inputs, inputs.color] },
-    { ...inputs.dimensionWithDateBounds, label: 'X-axis' },
+    {
+      ...inputs.dimensionWithGranularitySelectField,
+      label: 'X-axis',
+    },
     inputs.title,
     inputs.description,
     inputs.showLegend,
@@ -29,6 +33,7 @@ export const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.xAxisMaxItems,
+    inputs.maxResults,
   ],
   events: [
     {
@@ -50,22 +55,38 @@ export const preview = definePreview(BarChartDefaultPro, {
   measures: [previewData.measure],
   results: previewData.results1Measure1Dimension,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type BarChartDefaultProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(BarChartDefaultPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [BarChartDefaultProState, (state: BarChartDefaultProState) => void],
+  ) => {
+    const dimensionWithGranularity = getDimensionWithGranularity(
+      inputs.dimension,
+      state?.granularity,
+    );
+
     return {
       ...inputs,
+      dimension: dimensionWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
+        limit: inputs.maxResults,
         from: inputs.dataset,
-        select: [...inputs.measures, inputs.dimension],
+        select: [...inputs.measures, dimensionWithGranularity],
       }),
     };
   },
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -6,8 +6,9 @@ import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProData, getBarChartProOptions } from '../bars.utils';
 import { mergician } from 'mergician';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type BarChartDefaultProProps = {
   dimension: Dimension;
@@ -23,6 +24,7 @@ type BarChartDefaultProProps = {
   showTooltips?: boolean;
   showValueLabels?: boolean;
   reverseXAxis?: boolean;
+  setGranularity: (granularity: Granularity) => void;
   onBarClicked?: (args: { axisDimensionValue: string | null }) => void;
 } & ChartCardHeaderProps;
 
@@ -31,24 +33,22 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
   i18nSetup(theme);
 
   const {
-    description,
-    dimension,
     measures,
-    title,
-    xAxisLabel,
-    xAxisMaxItems,
-    yAxisLabel,
     yAxisRangeMin,
+    xAxisMaxItems,
     yAxisRangeMax,
     showLegend,
-    showLogarithmicScale,
     showTooltips,
+    showLogarithmicScale,
     showValueLabels,
     reverseXAxis,
+    hideMenu,
+    dimension,
+    setGranularity,
     onBarClicked,
-  } = resolveI18nProps(props);
+  } = props;
 
-  const { hideMenu } = props;
+  const { description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
 
   const results = useFillGaps({
     results: props.results,
@@ -74,6 +74,11 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={dimension}
+        onChange={setGranularity}
+      />
       <BarChart
         data={data}
         showLegend={showLegend}

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/BarChartGroupedHorizontalPro.emb.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/BarChartGroupedHorizontalPro.emb.ts
@@ -1,4 +1,4 @@
-import { Value, loadData } from '@embeddable.com/core';
+import { Granularity, Value, loadData } from '@embeddable.com/core';
 import {
   defineComponent,
   definePreview,
@@ -8,6 +8,7 @@ import {
 import BarChartGroupedHorizontalPro from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'BarChartGroupedHorizontalPro',
@@ -16,7 +17,7 @@ export const meta = {
   inputs: [
     inputs.dataset,
     inputs.measure,
-    { ...inputs.dimensionWithDateBounds, name: 'yAxis', label: 'Y-axis' },
+    { ...inputs.dimensionWithGranularitySelectField, name: 'yAxis', label: 'Y-axis' },
     { ...inputs.dimension, name: 'groupBy', label: 'Group by' },
     inputs.title,
     inputs.description,
@@ -57,24 +58,39 @@ export const preview = definePreview(BarChartGroupedHorizontalPro, {
   measure: previewData.measure,
   results: previewData.results1Measure2Dimensions,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type BarChartGroupedHorizontalProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(BarChartGroupedHorizontalPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [
+      BarChartGroupedHorizontalProState,
+      (state: BarChartGroupedHorizontalProState) => void,
+    ],
+  ) => {
+    const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
+
     return {
       ...inputs,
+      yAxis: yAxisWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
         limit: inputs.maxResults,
         from: inputs.dataset,
-        select: [inputs.yAxis, inputs.groupBy, inputs.measure],
+        select: [yAxisWithGranularity, inputs.groupBy, inputs.measure],
       }),
     };
   },
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -6,8 +6,9 @@ import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type BarChartGroupedHorizontalProProps = {
   groupBy: Dimension;
@@ -19,12 +20,12 @@ type BarChartGroupedHorizontalProProps = {
   showTooltips?: boolean;
   showTotalLabels?: boolean;
   showValueLabels?: boolean;
-
   yAxis: Dimension;
   xAxisLabel?: string;
   yAxisLabel?: string;
   xAxisRangeMax?: number;
   xAxisRangeMin?: number;
+  setGranularity: (granularity: Granularity) => void;
   onBarClicked?: (args: {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
@@ -35,8 +36,11 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
+  const { description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
   const {
-    description,
+    yAxis,
+    hideMenu,
     groupBy,
     measure,
     reverseYAxis,
@@ -45,20 +49,15 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
     showTooltips,
     showTotalLabels,
     showValueLabels,
-    title,
-    yAxis,
-    xAxisLabel,
-    yAxisLabel,
     xAxisRangeMax,
     xAxisRangeMin,
+    setGranularity,
     onBarClicked,
-  } = resolveI18nProps(props);
-
-  const { hideMenu } = props;
+  } = props;
 
   const results = useFillGaps({
     results: props.results,
-    dimension: props.yAxis,
+    dimension: yAxis,
   });
 
   const data = getBarStackedChartProData(
@@ -88,6 +87,11 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={yAxis}
+        onChange={setGranularity}
+      />
       <BarChart
         data={data}
         showLegend={showLegend}

--- a/src/components/charts/bars/BarChartGroupedPro/BarChartGroupedPro.emb.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/BarChartGroupedPro.emb.ts
@@ -1,4 +1,4 @@
-import { Value, loadData } from '@embeddable.com/core';
+import { Granularity, Value, loadData } from '@embeddable.com/core';
 import {
   defineComponent,
   definePreview,
@@ -8,6 +8,7 @@ import {
 import BarChartGroupedPro from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'BarChartGroupedPro',
@@ -16,7 +17,7 @@ export const meta = {
   inputs: [
     inputs.dataset,
     inputs.measure,
-    { ...inputs.dimensionWithDateBounds, name: 'xAxis', label: 'X-axis' },
+    { ...inputs.dimensionWithGranularitySelectField, name: 'xAxis', label: 'X-axis' },
     inputs.groupBy,
     inputs.title,
     inputs.description,
@@ -57,24 +58,36 @@ export const preview = definePreview(BarChartGroupedPro, {
   measure: previewData.measure,
   results: previewData.results1Measure2Dimensions,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type BarChartGroupedProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(BarChartGroupedPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [BarChartGroupedProState, (state: BarChartGroupedProState) => void],
+  ) => {
+    const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+
     return {
       ...inputs,
+      xAxis: xAxisWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
         limit: inputs.maxResults,
         from: inputs.dataset,
-        select: [inputs.xAxis, inputs.groupBy, inputs.measure],
+        select: [xAxisWithGranularity, inputs.groupBy, inputs.measure],
       }),
     };
   },
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -6,8 +6,9 @@ import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type BarChartGroupedProProps = {
   groupBy: Dimension;
@@ -19,12 +20,12 @@ type BarChartGroupedProProps = {
   showTooltips?: boolean;
   showTotalLabels?: boolean;
   showValueLabels?: boolean;
-
   xAxis: Dimension;
   xAxisLabel?: string;
   yAxisLabel?: string;
   yAxisRangeMax?: number;
   yAxisRangeMin?: number;
+  setGranularity: (granularity: Granularity) => void;
   onBarClicked?: (args: {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
@@ -36,7 +37,6 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
   i18nSetup(theme);
 
   const {
-    description,
     groupBy,
     measure,
     reverseXAxis,
@@ -45,14 +45,14 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
     showTooltips,
     showTotalLabels,
     showValueLabels,
-    title,
     xAxis,
-    xAxisLabel,
-    yAxisLabel,
     yAxisRangeMax,
     yAxisRangeMin,
+    setGranularity,
     onBarClicked,
-  } = resolveI18nProps(props);
+  } = props;
+
+  const { description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
 
   const { hideMenu } = props;
 
@@ -88,6 +88,11 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={xAxis}
+        onChange={setGranularity}
+      />
       <BarChart
         data={data}
         showLegend={showLegend}

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -6,8 +6,9 @@ import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type BarChartHorizontalStackedProProps = {
   groupBy: Dimension;
@@ -24,6 +25,7 @@ type BarChartHorizontalStackedProProps = {
   yAxisLabel?: string;
   xAxisRangeMax?: number;
   xAxisRangeMin?: number;
+  setGranularity: (granularity: Granularity) => void;
   onBarClicked?: (args: {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
@@ -34,8 +36,10 @@ const BarChartHorizontalStackedPro = (props: BarChartHorizontalStackedProProps) 
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
+  const { description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
   const {
-    description,
+    hideMenu,
     groupBy,
     measure,
     reverseYAxis,
@@ -44,16 +48,12 @@ const BarChartHorizontalStackedPro = (props: BarChartHorizontalStackedProProps) 
     showTooltips,
     showTotalLabels,
     showValueLabels,
-    title,
     yAxis,
-    xAxisLabel,
-    yAxisLabel,
     xAxisRangeMax,
     xAxisRangeMin,
+    setGranularity,
     onBarClicked,
-  } = resolveI18nProps(props);
-
-  const { hideMenu } = props;
+  } = props;
 
   const results = useFillGaps({
     results: props.results,
@@ -87,6 +87,11 @@ const BarChartHorizontalStackedPro = (props: BarChartHorizontalStackedProProps) 
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={yAxis}
+        onChange={setGranularity}
+      />
       <BarChart
         data={data}
         showLegend={showLegend}

--- a/src/components/charts/bars/BarChartStackedPro/BarChartStackedPro.emb.ts
+++ b/src/components/charts/bars/BarChartStackedPro/BarChartStackedPro.emb.ts
@@ -1,4 +1,4 @@
-import { Value, loadData } from '@embeddable.com/core';
+import { Granularity, Value, loadData } from '@embeddable.com/core';
 import {
   defineComponent,
   definePreview,
@@ -8,6 +8,7 @@ import {
 import BarChartStackedPro from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'BarChartStackedPro',
@@ -16,7 +17,7 @@ export const meta = {
   inputs: [
     inputs.dataset,
     inputs.measure,
-    { ...inputs.dimensionWithDateBounds, name: 'xAxis', label: 'X-axis' },
+    { ...inputs.dimensionWithGranularitySelectField, name: 'xAxis', label: 'X-axis' },
     inputs.groupBy,
     inputs.title,
     inputs.description,
@@ -58,24 +59,36 @@ export const preview = definePreview(BarChartStackedPro, {
   measure: previewData.measure,
   results: previewData.results1Measure2Dimensions,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type BarChartStackedProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(BarChartStackedPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [BarChartStackedProState, (state: BarChartStackedProState) => void],
+  ) => {
+    const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+
     return {
       ...inputs,
+      xAxis: xAxisWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
         limit: inputs.maxResults,
         from: inputs.dataset,
-        select: [inputs.xAxis, inputs.groupBy, inputs.measure],
+        select: [xAxisWithGranularity, inputs.groupBy, inputs.measure],
       }),
     };
   },
   events: {
     onBarClicked: (value) => {
       return {
-        axisDimensionValue: value.axisDimensionValue || Value.noFilter(),
-        groupingDimensionValue: value.groupingDimensionValue || Value.noFilter(),
+        axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+        groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -6,8 +6,9 @@ import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type BarChartStackedProProps = {
   groupBy: Dimension;
@@ -20,12 +21,12 @@ type BarChartStackedProProps = {
   showTotalLabels?: boolean;
   showTooltips?: boolean;
   showValueLabels?: boolean;
-
   xAxis: Dimension;
   xAxisLabel?: string;
   yAxisLabel?: string;
   yAxisRangeMax?: number;
   yAxisRangeMin?: number;
+  setGranularity: (granularity: Granularity) => void;
   onBarClicked?: (args: {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
@@ -35,8 +36,9 @@ type BarChartStackedProProps = {
 const BarChartStackedPro = (props: BarChartStackedProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
+  const { description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
   const {
-    description,
     groupBy,
     measure,
     reverseXAxis,
@@ -45,14 +47,12 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
     showTooltips,
     showTotalLabels,
     showValueLabels,
-    title,
     xAxis,
-    xAxisLabel,
-    yAxisLabel,
     yAxisRangeMax,
     yAxisRangeMin,
+    setGranularity,
     onBarClicked,
-  } = resolveI18nProps(props);
+  } = props;
 
   const { hideMenu } = props;
 
@@ -88,6 +88,11 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={xAxis}
+        onChange={setGranularity}
+      />
       <BarChart
         data={data}
         showLegend={showLegend}

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
-import { DataResponse, Dimension, Measure, TimeRange } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure, TimeRange } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
@@ -13,6 +13,7 @@ import {
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { LineChartProOptionsClick } from '../lines.utils';
 import { LineChart } from '@embeddable.com/remarkable-ui';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 type LineChartComparisonDefaultProProps = {
   xAxis: Dimension;
@@ -32,6 +33,7 @@ type LineChartComparisonDefaultProProps = {
   comparisonDateRange: TimeRange;
   showComparisonAxis?: boolean;
   primaryDateRange: TimeRange;
+  setGranularity: (granularity: Granularity) => void;
   setComparisonDateRange?: (dateRange: TimeRange) => void;
   onLineClicked?: LineChartProOptionsClick;
 } & ChartCardHeaderProps;
@@ -56,6 +58,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
     primaryDateRange,
     comparisonDateRange,
     showComparisonAxis,
+    setGranularity,
     setComparisonDateRange,
     onLineClicked,
   } = props;
@@ -123,6 +126,11 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={xAxis}
+        onChange={setGranularity}
+      />
       <LineChart
         data={data}
         reverseXAxis={reverseXAxis}

--- a/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.emb.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.emb.ts
@@ -5,11 +5,12 @@ import {
   Inputs,
 } from '@embeddable.com/react';
 import LineChartDefaultPro from './index';
-import { loadData, Value } from '@embeddable.com/core';
+import { Granularity, loadData, Value } from '@embeddable.com/core';
 import { LineChartProOptionsClickArg } from '../lines.utils';
 import { inputs } from '../../../component.inputs.constants';
 import { subInputs } from '../../../component.subinputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'LineChartDefaultPro',
@@ -41,7 +42,7 @@ export const meta = {
         },
       ],
     },
-    { ...inputs.dimensionWithDateBounds, label: 'X-axis', name: 'xAxis' },
+    { ...inputs.dimensionWithGranularitySelectField, label: 'X-axis', name: 'xAxis' },
     inputs.title,
     inputs.description,
     inputs.showLegend,
@@ -75,23 +76,35 @@ export const preview = definePreview(LineChartDefaultPro, {
   measures: [previewData.measure],
   results: previewData.results1Measure1Dimension,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type LineChartDefaultProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(LineChartDefaultPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [LineChartDefaultProState, (state: LineChartDefaultProState) => void],
+  ) => {
+    const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+
     return {
       ...inputs,
+      xAxis: xAxisWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
         limit: inputs.maxResults,
         from: inputs.dataset,
-        select: [...inputs.measures, inputs.xAxis],
+        select: [...inputs.measures, xAxisWithGranularity],
       }),
     };
   },
   events: {
     onLineClicked: (value: LineChartProOptionsClickArg) => {
       return {
-        axisDimensionValue: value.dimensionValue || Value.noFilter(),
+        axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/charts/lines/LineChartDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
@@ -8,6 +8,7 @@ import { getLineChartProData, getLineChartProOptions } from './LineChartDefaultP
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { LineChartProOptionsClick } from '../lines.utils';
 import { LineChart } from '@embeddable.com/remarkable-ui';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 export type LineChartProPropsOnLineClicked = { axisDimensionValue: string | null };
 
@@ -20,11 +21,11 @@ type LineChartProProp = {
   showLogarithmicScale?: boolean;
   showTooltips?: boolean;
   showValueLabels?: boolean;
-
   xAxisLabel?: string;
   yAxisLabel?: string;
   yAxisRangeMax?: number;
   yAxisRangeMin?: number;
+  setGranularity: (granularity: Granularity) => void;
   onLineClicked?: LineChartProOptionsClick;
 } & ChartCardHeaderProps;
 
@@ -33,6 +34,7 @@ const LineChartPro = (props: LineChartProProp) => {
   i18nSetup(theme);
 
   const { title, description, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
   const {
     hideMenu,
     measures,
@@ -44,6 +46,7 @@ const LineChartPro = (props: LineChartProProp) => {
     showValueLabels,
     yAxisRangeMax,
     yAxisRangeMin,
+    setGranularity,
     onLineClicked,
   } = props;
 
@@ -75,6 +78,11 @@ const LineChartPro = (props: LineChartProProp) => {
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={xAxis}
+        onChange={setGranularity}
+      />
       <LineChart
         data={data}
         reverseXAxis={reverseXAxis}

--- a/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.emb.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.emb.ts
@@ -5,10 +5,11 @@ import {
   Inputs,
 } from '@embeddable.com/react';
 import LineChartGroupedPro from './index';
-import { loadData, Value } from '@embeddable.com/core';
+import { Granularity, loadData, Value } from '@embeddable.com/core';
 import { LineChartProOptionsClickArg } from '../lines.utils';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 
 export const meta = {
   name: 'LineChartGroupedPro',
@@ -35,7 +36,7 @@ export const meta = {
         },
       ],
     },
-    { ...inputs.dimensionWithDateBounds, name: 'xAxis', label: 'X-axis' },
+    { ...inputs.dimensionWithGranularitySelectField, name: 'xAxis', label: 'X-axis' },
     inputs.groupBy,
     inputs.title,
     inputs.description,
@@ -76,16 +77,28 @@ export const preview = definePreview(LineChartGroupedPro, {
   measure: previewData.measure,
   results: previewData.results1Measure2Dimensions,
   hideMenu: true,
+  setGranularity: () => {},
 });
 
+type LineChartGroupedProState = {
+  granularity?: Granularity;
+};
+
 export default defineComponent(LineChartGroupedPro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [LineChartGroupedProState, (state: LineChartGroupedProState) => void],
+  ) => {
+    const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+
     return {
       ...inputs,
+      xAxis: xAxisWithGranularity,
+      setGranularity: (granularity) => setState({ granularity }),
       results: loadData({
         limit: inputs.maxResults,
         from: inputs.dataset,
-        select: [inputs.xAxis, inputs.groupBy, inputs.measure],
+        select: [xAxisWithGranularity, inputs.groupBy, inputs.measure],
       }),
     };
   },

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -1,6 +1,6 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
@@ -11,6 +11,7 @@ import {
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { LineChartProOptionsClick } from '../lines.utils';
 import { LineChart } from '@embeddable.com/remarkable-ui';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
 export type LineChartGroupedProPropsOnLineClicked = {
   axisDimensionValue: string | null;
@@ -27,11 +28,11 @@ type LineChartGroupedProProp = {
   showLogarithmicScale?: boolean;
   showTooltips?: boolean;
   showValueLabels?: boolean;
-
   xAxisLabel?: string;
   yAxisLabel?: string;
   yAxisRangeMax?: number;
   yAxisRangeMin?: number;
+  setGranularity: (granularity: Granularity) => void;
   onLineClicked?: LineChartProOptionsClick;
 } & ChartCardHeaderProps;
 
@@ -52,6 +53,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
     showValueLabels,
     yAxisRangeMax,
     yAxisRangeMin,
+    setGranularity,
     onLineClicked,
   } = props;
 
@@ -68,7 +70,6 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       measure,
       hasMinMaxYAxisRange: Boolean(yAxisRangeMin != null || yAxisRangeMax != null),
     },
-
     theme,
   );
   const options = getLineChartGroupedProOptions(
@@ -85,6 +86,11 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       title={title}
       hideMenu={hideMenu}
     >
+      <ChartGranularitySelectField
+        hasMarginTop={!title && !description}
+        dimension={xAxis}
+        onChange={setGranularity}
+      />
       <LineChart
         data={data}
         reverseXAxis={reverseXAxis}

--- a/src/components/charts/shared/ChartGranularitySelectField/ChartGranularitySelectField.module.css
+++ b/src/components/charts/shared/ChartGranularitySelectField/ChartGranularitySelectField.module.css
@@ -1,0 +1,9 @@
+.chartGranularitySelectFieldContainer {
+  display: flex;
+  justify-content: end;
+  margin-bottom: var(--em-chart-selectfield-padding-bottom, 1rem);
+}
+
+.marginTop {
+  margin-top: var(--em-chart-selectfield-padding-bottom, 1rem);
+}

--- a/src/components/charts/shared/ChartGranularitySelectField/ChartGranularitySelectField.tsx
+++ b/src/components/charts/shared/ChartGranularitySelectField/ChartGranularitySelectField.tsx
@@ -1,0 +1,48 @@
+import { Dimension, Granularity } from '@embeddable.com/core';
+import {
+  GranularitySelectField,
+  GranularitySelectFieldProps,
+} from '../../../editors/shared/GranularitySelectField/GranularitySelectField';
+import styles from './ChartGranularitySelectField.module.css';
+import clsx from 'clsx';
+
+type ChartGranularitySelectFieldProps = Pick<GranularitySelectFieldProps, 'onChange'> & {
+  dimension: Dimension;
+  hasMarginTop?: boolean;
+};
+
+const dimensionGranularities: Granularity[] = ['day', 'week', 'month', 'quarter', 'year'];
+
+export const ChartGranularitySelectField = ({
+  dimension,
+  hasMarginTop,
+  ...props
+}: ChartGranularitySelectFieldProps) => {
+  const showGranularitySelector = dimension?.inputs?.showGranularityDropdown;
+
+  if (!showGranularitySelector) {
+    return null;
+  }
+
+  const dimensionTimeRange = dimension.inputs?.dateBounds;
+  const dimensionGranularity = dimension.inputs?.granularity;
+
+  return (
+    <div
+      className={clsx(
+        styles.chartGranularitySelectFieldContainer,
+        hasMarginTop && styles.marginTop,
+      )}
+    >
+      <GranularitySelectField
+        {...props}
+        primaryTimeRange={dimensionTimeRange}
+        granularity={dimensionGranularity}
+        granularities={dimensionGranularities}
+        variant="ghost"
+        side="bottom"
+        align="end"
+      />
+    </div>
+  );
+};

--- a/src/components/charts/utils/granularity.utils.ts
+++ b/src/components/charts/utils/granularity.utils.ts
@@ -1,0 +1,13 @@
+import { Dimension, Granularity } from '@embeddable.com/core';
+
+export const getDimensionWithGranularity = (dimension: Dimension, granularity?: Granularity) => {
+  const currentGranularity = granularity ?? dimension.inputs?.granularity;
+
+  return {
+    ...dimension,
+    inputs: {
+      ...dimension.inputs,
+      granularity: currentGranularity,
+    },
+  };
+};

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,5 +1,10 @@
 import ColorType from '../editors/ColorEditor/Color.type.emb';
-import { dimensionMeasureSubInputs, timeDimensionSubInputs } from './component.subinputs.constants';
+import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
+import {
+  dimensionMeasureSubInputs,
+  timeDimensionSubInputs,
+  timeDimensionWithGranularitySelectFieldSubInputs,
+} from './component.subinputs.constants';
 import ComparisonPeriodType from './types/ComparisonPeriod.type.emb';
 
 /* -------------------- */
@@ -93,6 +98,15 @@ const granularities = {
   type: 'granularity',
   label: 'Granularities',
   array: true,
+  // Ignore seconds and minutes
+  defaultValue: [
+    Granularity.hour,
+    Granularity.day,
+    Granularity.week,
+    Granularity.month,
+    Granularity.quarter,
+    Granularity.year,
+  ],
 } as const;
 
 const dimensionSimple = {
@@ -130,6 +144,18 @@ const dimensionWithDateBounds = {
   required: true,
   category: 'Component Data',
   inputs: timeDimensionSubInputs,
+} as const;
+
+const dimensionWithGranularitySelectField = {
+  name: 'dimension',
+  type: 'dimension',
+  label: 'Dimension',
+  config: {
+    dataset: 'dataset',
+  },
+  required: true,
+  category: 'Component Data',
+  inputs: timeDimensionWithGranularitySelectFieldSubInputs,
 } as const;
 
 const dimensions = {
@@ -378,6 +404,7 @@ export const inputs = {
   dimensionSimple,
   dimensionTime,
   dimensionWithDateBounds,
+  dimensionWithGranularitySelectField,
   dimensions,
   dimensionOrMeasure,
   dimensionsAndMeasures,

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -1,4 +1,5 @@
 import ColorType from '../editors/ColorEditor/Color.type.emb';
+import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import AlignType from './types/Align.type.emb';
 import DisplayFormatType from './types/DisplayFormat.type.emb';
 import TableCellStyleType from './types/TableCellStyle.type.emb';
@@ -97,12 +98,30 @@ const granularity = {
   type: 'granularity',
   label: 'Granularity',
   supportedTypes: ['time'],
+  defaultValue: Granularity.day,
 } as const;
 
 const color = {
   type: ColorType,
   name: 'color',
   label: 'Color',
+} as const;
+
+const granularities = {
+  name: 'granularities',
+  type: 'granularity',
+  label: 'Granularities',
+  supportedTypes: ['time'],
+  array: true,
+  // Ignore seconds and minutes
+  defaultValue: [
+    Granularity.hour,
+    Granularity.day,
+    Granularity.week,
+    Granularity.month,
+    Granularity.quarter,
+    Granularity.year,
+  ],
 } as const;
 
 const displayFormat = {
@@ -115,6 +134,16 @@ const tableCellStyle = {
   type: TableCellStyleType,
   name: 'tableCellStyle',
   label: 'Table cell style',
+} as const;
+
+const showGranularityDropdown = {
+  type: 'boolean',
+  name: 'showGranularityDropdown',
+  label: 'Show granularity dropdown',
+  description:
+    'Display a granularity selector inside the chart. The Granularity input above is used only as the default when this option is enabled.',
+  supportedTypes: ['time'],
+  defaultValue: false,
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -141,6 +170,26 @@ export const timeDimensionSubInputs: any[] = [
   dateBounds,
 ];
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const timeDimensionWithGranularitySelectFieldSubInputs: any[] = [
+  prefix,
+  suffix,
+  displayName,
+  maxCharacters,
+  decimalPlaces,
+  currency,
+  abbreviateLargeNumber,
+  granularity,
+  showGranularityDropdown,
+  // Not required for now - defaults to day, week, month, quarter, year
+  // granularities,
+  {
+    ...dateBounds,
+    description:
+      'Set a date range or connect your primary date-range variable to define the x-axis min and max. If “Show granularity dropdown” is enabled, this also enables auto-selection of the most appropriate granularity',
+  },
+];
+
 export const subInputs = {
   boolean,
   timeRange,
@@ -157,7 +206,9 @@ export const subInputs = {
   abbreviateLargeNumber,
   dateBounds,
   granularity,
+  granularities,
   color,
   displayFormat,
   tableCellStyle,
+  showGranularityDropdown,
 };

--- a/src/components/editors/GranularitySelectFieldPro/GranularitySelectFieldPro.emb.ts
+++ b/src/components/editors/GranularitySelectFieldPro/GranularitySelectFieldPro.emb.ts
@@ -23,15 +23,6 @@ export const meta = {
       ...inputs.granularities,
       label: 'Available granularities',
       category: 'Pre-configured variables',
-      // Ignore seconds and minutes
-      defaultValue: [
-        Granularity.hour,
-        Granularity.day,
-        Granularity.week,
-        Granularity.month,
-        Granularity.quarter,
-        Granularity.year,
-      ],
     },
     {
       ...inputs.granularity,

--- a/src/components/editors/GranularitySelectFieldPro/index.tsx
+++ b/src/components/editors/GranularitySelectFieldPro/index.tsx
@@ -1,18 +1,12 @@
-import { useEffect, useMemo } from 'react';
 import { useTheme } from '@embeddable.com/react';
-import { SingleSelectField } from '@embeddable.com/remarkable-ui';
 import { TimeRange } from '@embeddable.com/core';
 import { Theme } from '../../../theme/theme.types';
 import { i18nSetup } from '../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../component.utils';
 import { EditorCard } from '../shared/EditorCard/EditorCard';
-import {
-  getAvailableGranularityOptionsFromTimeRange,
-  getGranularitySelectFieldOptions,
-  getSafeSelection,
-} from './GranularitySelectFieldPro.utils';
 import { TGranularityValue } from '../../../theme/defaults/defaults.GranularityOptions.constants';
 import { ChartCardHeaderProps } from '../../charts/shared/ChartCard/ChartCard';
+import { GranularitySelectField } from '../shared/GranularitySelectField/GranularitySelectField';
 
 type GranularitySelectFieldProProps = {
   onChange: (newGranularity: string) => void;
@@ -27,45 +21,18 @@ const GranularitySelectFieldPro = (props: GranularitySelectFieldProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { granularity, granularities, clearable, onChange } = props;
-  const { description, placeholder, title, primaryTimeRange } = resolveI18nProps(props);
-
-  const granularitySelectFieldOptions = getGranularitySelectFieldOptions();
-
-  const availableOptions = useMemo(() => {
-    return getAvailableGranularityOptionsFromTimeRange(
-      primaryTimeRange,
-      granularitySelectFieldOptions.filter((opt) =>
-        granularities?.includes(opt.value as TGranularityValue),
-      ),
-    );
-  }, [primaryTimeRange, granularities]);
-
-  useEffect(() => {
-    if (granularity) {
-      // Selected granularity is not available
-      // Select 1st available option when number of options is =< 2
-      // Select 2nd option to avoid when number of options > 2
-      if (!availableOptions.some((opt) => opt.value === granularity)) {
-        const newGranularity = getSafeSelection(availableOptions, granularity);
-        if (newGranularity) {
-          onChange(newGranularity);
-        }
-      }
-    }
-  }, [availableOptions, granularity, onChange]);
-
-  const safeValue = getSafeSelection(availableOptions, granularity);
+  const { granularity, granularities, clearable, primaryTimeRange, onChange } = props;
+  const { description, placeholder, title } = resolveI18nProps(props);
 
   return (
     <EditorCard title={title} subtitle={description}>
-      <SingleSelectField
+      <GranularitySelectField
         clearable={clearable}
         placeholder={placeholder}
-        value={safeValue}
-        options={availableOptions}
+        granularity={granularity}
+        granularities={granularities}
+        primaryTimeRange={primaryTimeRange}
         onChange={onChange}
-        avoidCollisions={false}
       />
     </EditorCard>
   );

--- a/src/components/editors/shared/GranularitySelectField/GranularitySelectField.tsx
+++ b/src/components/editors/shared/GranularitySelectField/GranularitySelectField.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 import { useTheme } from '@embeddable.com/react';
-import { SingleSelectField } from '@embeddable.com/remarkable-ui';
+import { SingleSelectField, SingleSelectFieldProps } from '@embeddable.com/remarkable-ui';
 import { Granularity, TimeRange } from '@embeddable.com/core';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
@@ -11,7 +11,6 @@ import {
 } from './GranularitySelectField.utils';
 import { TGranularityValue } from '../../../../theme/defaults/defaults.GranularityOptions.constants';
 import { ChartCardHeaderProps } from '../../../charts/shared/ChartCard/ChartCard';
-import { SingleSelectFieldProps } from '@embeddable.com/remarkable-ui';
 
 export type GranularitySelectFieldProps = {
   onChange: (newGranularity: Granularity) => void;

--- a/src/components/editors/shared/GranularitySelectField/GranularitySelectField.tsx
+++ b/src/components/editors/shared/GranularitySelectField/GranularitySelectField.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useMemo } from 'react';
+import { useTheme } from '@embeddable.com/react';
+import { SingleSelectField } from '@embeddable.com/remarkable-ui';
+import { Granularity, TimeRange } from '@embeddable.com/core';
+import { Theme } from '../../../../theme/theme.types';
+import { i18nSetup } from '../../../../theme/i18n/i18n';
+import {
+  getAvailableGranularityOptionsFromTimeRange,
+  getGranularitySelectFieldOptions,
+  getSafeSelection,
+} from './GranularitySelectField.utils';
+import { TGranularityValue } from '../../../../theme/defaults/defaults.GranularityOptions.constants';
+import { ChartCardHeaderProps } from '../../../charts/shared/ChartCard/ChartCard';
+import { SingleSelectFieldProps } from '@embeddable.com/remarkable-ui';
+
+export type GranularitySelectFieldProps = {
+  onChange: (newGranularity: Granularity) => void;
+  primaryTimeRange?: TimeRange;
+  granularity?: TGranularityValue;
+  granularities?: TGranularityValue[];
+} & ChartCardHeaderProps &
+  Pick<SingleSelectFieldProps, 'variant' | 'side' | 'align' | 'clearable' | 'placeholder'>;
+
+export const GranularitySelectField = (props: GranularitySelectFieldProps) => {
+  const theme: Theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const {
+    granularity,
+    granularities,
+    clearable,
+    placeholder,
+    primaryTimeRange,
+    variant,
+    side,
+    align,
+    onChange,
+  } = props;
+
+  const granularitySelectFieldOptions = getGranularitySelectFieldOptions();
+
+  const availableOptions = useMemo(() => {
+    return getAvailableGranularityOptionsFromTimeRange(
+      primaryTimeRange,
+      granularitySelectFieldOptions.filter((opt) =>
+        granularities?.includes(opt.value as TGranularityValue),
+      ),
+    );
+  }, [primaryTimeRange, granularities]);
+
+  useEffect(() => {
+    if (granularity) {
+      // Selected granularity is not available
+      // Select 1st available option when number of options is =< 2
+      // Select 2nd option to avoid when number of options > 2
+      if (!availableOptions.some((opt) => opt.value === granularity)) {
+        const newGranularity = getSafeSelection(availableOptions, granularity);
+        if (newGranularity) {
+          onChange(newGranularity as Granularity);
+        }
+      }
+    }
+  }, [availableOptions, granularity, onChange]);
+
+  const safeValue = getSafeSelection(availableOptions, granularity);
+
+  return (
+    <SingleSelectField
+      variant={variant}
+      clearable={clearable}
+      placeholder={placeholder}
+      value={safeValue}
+      options={availableOptions}
+      onChange={(newValue) => onChange(newValue as Granularity)}
+      avoidCollisions={false}
+      side={side}
+      align={align}
+    />
+  );
+};

--- a/src/components/editors/shared/GranularitySelectField/GranularitySelectField.utils.ts
+++ b/src/components/editors/shared/GranularitySelectField/GranularitySelectField.utils.ts
@@ -18,10 +18,10 @@ export const getGranularitySelectFieldOptions = (): SelectListOptionProps[] => {
 
 // Convert possibly-string timestamps to Date safely.
 const toDate = (d: unknown): Date | null => {
-  if (d instanceof Date) return isNaN(d.getTime()) ? null : d;
+  if (d instanceof Date) return Number.isNaN(d.getTime()) ? null : d;
   if (typeof d === 'string' || typeof d === 'number') {
     const parsed = new Date(d);
-    return isNaN(parsed.getTime()) ? null : parsed;
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
   return null;
 };

--- a/src/components/editors/shared/GranularitySelectField/GranularitySelectField.utils.ts
+++ b/src/components/editors/shared/GranularitySelectField/GranularitySelectField.utils.ts
@@ -1,12 +1,10 @@
 import { SelectListOptionProps } from '@embeddable.com/remarkable-ui';
-import { TimeRange } from '@embeddable.com/core';
+import { Granularity, TimeRange } from '@embeddable.com/core';
 import {
   defaultGranularitySelectFieldOptions,
-  Granularity,
-  TGranularity,
   TGranularityValue,
-} from '../../../theme/defaults/defaults.GranularityOptions.constants';
-import { resolveI18nString } from '../../component.utils';
+} from '../../../../theme/defaults/defaults.GranularityOptions.constants';
+import { resolveI18nString } from '../../../component.utils';
 
 const DEFAULT_MIN_BUCKETS = 1;
 const DEFAULT_MAX_BUCKETS = 100;
@@ -36,32 +34,32 @@ const bucketCountByUnit = (start: Date, endExclusive: Date, unitMs: number): num
 };
 
 // Bucket counting (treat end as INCLUSIVE)
-function bucketCount(start: Date, endInclusive: Date, granularity: TGranularity): number {
+function bucketCount(start: Date, endInclusive: Date, granularity: Granularity): number {
   if (start > endInclusive) return 0;
 
   switch (granularity) {
-    case Granularity.second:
+    case 'second':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 1000);
 
-    case Granularity.minute:
+    case 'minute':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 60 * 1000);
 
-    case Granularity.hour:
+    case 'hour':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 60 * 60 * 1000);
 
-    case Granularity.day:
+    case 'day':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 24 * 60 * 60 * 1000);
 
-    case Granularity.week:
+    case 'week':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 7 * 24 * 60 * 60 * 1000);
 
-    case Granularity.month:
+    case 'month':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 28 * 24 * 60 * 60 * 1000); // shortest month
 
-    case Granularity.quarter:
+    case 'quarter':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 90 * 24 * 60 * 60 * 1000); // shortest quarter
 
-    case Granularity.year:
+    case 'year':
       return bucketCountByUnit(start, toExclusiveEnd(endInclusive), 365 * 24 * 60 * 60 * 1000); // shortest year
   }
 }
@@ -104,8 +102,8 @@ export const getAvailableGranularityOptionsFromTimeRange = (
 
 export const getSafeSelection = (
   availableOptions: SelectListOptionProps[],
-  granularity?: string,
-): string | undefined => {
+  granularity?: Granularity,
+): Granularity | undefined => {
   if (!granularity) {
     return undefined;
   }
@@ -116,5 +114,5 @@ export const getSafeSelection = (
 
   const optionToSelect = availableOptions.length > 2 ? 1 : 0;
 
-  return availableOptions[optionToSelect]?.value as string;
+  return availableOptions[optionToSelect]?.value as Granularity;
 };

--- a/src/theme/defaults/defaults.GranularityOptions.constants.ts
+++ b/src/theme/defaults/defaults.GranularityOptions.constants.ts
@@ -24,3 +24,5 @@ export const defaultGranularitySelectFieldOptions: SelectListOptionProps[] = [
   { value: Granularity.quarter, label: 'defaults.granularityOptions.quarter|Quarter' },
   { value: Granularity.year, label: 'defaults.granularityOptions.year|Year' },
 ];
+
+export const granularities = Object.values(Granularity);


### PR DESCRIPTION
# Why is this pull-request needed?

This PR introduces the built-in granularity selector for the bar and line charts.

# Main changes

- create new input dimensionWithGranularitySelectField
- update the dimensionWithDateBounds to be dimensionWithGranularitySelectField on the line and bar charts
- create state to keep the current granularity selection
- organize prop desctructuring


# Test evidence


https://github.com/user-attachments/assets/089a8ed5-7ecc-459f-bc57-5f1837d3e6ad





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in granularity selector for bar and line charts, enabling users to dynamically adjust time-based data aggregation levels (hourly, daily, weekly, monthly, quarterly, and yearly) for enhanced visualization and analysis capabilities.

* **Dependencies**
  * Updated @embeddable.com/remarkable-ui dependency to version ^2.0.32.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->