### PR TITLE
RUI-197: single select field dimension and measure

### DIFF
--- a/.changeset/rich-zebras-cut.md
+++ b/.changeset/rich-zebras-cut.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+New MeasureSingleSelectField and DimensionSingleSelectField

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -2,6 +2,7 @@ import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {
   dimensionMeasureSubInputs,
+  subInputs,
   timeDimensionSubInputs,
   timeDimensionWithGranularitySelectFieldSubInputs,
 } from './component.subinputs.constants';
@@ -165,6 +166,7 @@ const dimensions = {
   config: {
     dataset: 'dataset',
   },
+  array: true,
   required: true,
   category: 'Component Data',
   inputs: dimensionMeasureSubInputs,
@@ -218,6 +220,20 @@ const measures = {
   category: 'Component Data',
   inputs: dimensionMeasureSubInputs,
 } as const;
+
+const measureOptions = {
+  ...measures,
+  name: 'measureOptions',
+  label: 'Measure options',
+  inputs: [subInputs.displayName],
+};
+
+const dimensionOptions = {
+  ...dimensions,
+  name: 'dimensionOptions',
+  label: 'Dimension options',
+  inputs: [subInputs.displayName],
+};
 
 const comparisonPeriod = {
   name: 'comparisonPeriod',
@@ -410,6 +426,8 @@ export const inputs = {
   dimensionsAndMeasures,
   measure,
   measures,
+  measureOptions,
+  dimensionOptions,
   comparisonPeriod,
   maxResults,
   placeholder,

--- a/src/components/editors/DimensionSingleSelectFieldPro/DimensionSingleSelectFieldPro.emb.ts
+++ b/src/components/editors/DimensionSingleSelectFieldPro/DimensionSingleSelectFieldPro.emb.ts
@@ -58,7 +58,7 @@ export const meta = {
 } as const satisfies EmbeddedComponentMeta;
 
 export const preview = definePreview(DimensionSingleSelectFieldPro, {
-  dimensionOptions: [previewData.dimension, previewData.dimension],
+  dimensionOptions: [previewData.dimension, previewData.dimensionGroup],
   onChange: () => null,
 });
 

--- a/src/components/editors/DimensionSingleSelectFieldPro/DimensionSingleSelectFieldPro.emb.ts
+++ b/src/components/editors/DimensionSingleSelectFieldPro/DimensionSingleSelectFieldPro.emb.ts
@@ -64,12 +64,6 @@ export const preview = definePreview(DimensionSingleSelectFieldPro, {
 
 export default defineComponent(DimensionSingleSelectFieldPro, meta, {
   props: (inputs: Inputs<typeof meta>) => {
-    if (!inputs.dataset)
-      return {
-        ...inputs,
-        dimensionOptions: [],
-      };
-
     return {
       ...inputs,
       dimensionOptions: inputs.dimensionOptions ?? [],

--- a/src/components/editors/DimensionSingleSelectFieldPro/DimensionSingleSelectFieldPro.emb.ts
+++ b/src/components/editors/DimensionSingleSelectFieldPro/DimensionSingleSelectFieldPro.emb.ts
@@ -1,0 +1,85 @@
+import { Value } from '@embeddable.com/core';
+import {
+  EmbeddedComponentMeta,
+  Inputs,
+  defineComponent,
+  definePreview,
+} from '@embeddable.com/react';
+import DimensionSingleSelectFieldPro from './index';
+import { inputs } from '../../component.inputs.constants';
+import { previewData } from '../../preview.data.constants';
+
+export const meta = {
+  name: 'DimensionSingleSelectFieldPro',
+  label: 'Dimension Single Select Field',
+  category: 'Dropdowns',
+  defaultWidth: 300,
+  defaultHeight: 120,
+  inputs: [
+    inputs.dataset,
+    inputs.title,
+    inputs.description,
+    { ...inputs.placeholder, defaultValue: 'Select value...' },
+    inputs.dimensionOptions,
+    {
+      ...inputs.dimension,
+      name: 'selectedDimension',
+      label: 'Selected dimension',
+      category: 'Pre-configured variables',
+      required: false,
+      config: {
+        dataset: 'dataset',
+      },
+    },
+    { ...inputs.clearable, defaultValue: false },
+  ],
+  events: [
+    {
+      name: 'onChange',
+      label: 'Selected dimension updated',
+      properties: [
+        {
+          name: 'value',
+          label: 'Selected dimension',
+          type: 'dimension',
+        },
+      ],
+    },
+  ],
+  variables: [
+    {
+      name: 'dimension single-select value',
+      type: 'dimension',
+      defaultValue: Value.noFilter(),
+      inputs: ['selectedDimension'],
+      events: [{ name: 'onChange', property: 'value' }],
+    },
+  ],
+} as const satisfies EmbeddedComponentMeta;
+
+export const preview = definePreview(DimensionSingleSelectFieldPro, {
+  dimensionOptions: [previewData.dimension, previewData.dimension],
+  onChange: () => null,
+});
+
+export default defineComponent(DimensionSingleSelectFieldPro, meta, {
+  props: (inputs: Inputs<typeof meta>) => {
+    if (!inputs.dataset)
+      return {
+        ...inputs,
+        dimensionOptions: [],
+      };
+
+    return {
+      ...inputs,
+      dimensionOptions: inputs.dimensionOptions ?? [],
+    };
+  },
+  events: {
+    onChange: (value) => {
+      return {
+        value: value ?? Value.noFilter(),
+      };
+    },
+  },
+});

--- a/src/components/editors/DimensionSingleSelectFieldPro/index.tsx
+++ b/src/components/editors/DimensionSingleSelectFieldPro/index.tsx
@@ -1,0 +1,38 @@
+import { Dimension } from '@embeddable.com/core';
+import { EditorCard } from '../shared/EditorCard/EditorCard';
+import { resolveI18nProps } from '../../component.utils';
+import { ChartCardHeaderProps } from '../../charts/shared/ChartCard/ChartCard';
+import { Theme } from '../../../theme/theme.types';
+import { useTheme } from '@embeddable.com/react';
+import { i18nSetup } from '../../../theme/i18n/i18n';
+import { DimensionAndMeasureSingleSelectField } from '../shared/DimensionAndMeasureSingleSelectField/DimensionAndMeasureSingleSelectField';
+
+type DimensionSingleSelectFieldProProps = {
+  selectedDimension?: Dimension;
+  dimensionOptions: Dimension[];
+  placeholder?: string;
+  clearable?: boolean;
+  onChange: (value: Dimension | undefined) => void;
+} & ChartCardHeaderProps;
+
+const DimensionSingleSelectFieldPro = (props: DimensionSingleSelectFieldProProps) => {
+  const theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const { selectedDimension, dimensionOptions, clearable, onChange } = props;
+  const { title, description, placeholder } = resolveI18nProps(props);
+
+  return (
+    <EditorCard title={title} subtitle={description}>
+      <DimensionAndMeasureSingleSelectField<Dimension>
+        selectedValue={selectedDimension}
+        options={dimensionOptions}
+        placeholder={placeholder}
+        clearable={clearable}
+        onChange={onChange}
+      />
+    </EditorCard>
+  );
+};
+
+export default DimensionSingleSelectFieldPro;

--- a/src/components/editors/MeasureSingleSelectFieldPro/MeasureSingleSelectFieldPro.emb.ts
+++ b/src/components/editors/MeasureSingleSelectFieldPro/MeasureSingleSelectFieldPro.emb.ts
@@ -64,12 +64,6 @@ export const preview = definePreview(MeasureSingleSelectFieldPro, {
 
 export default defineComponent(MeasureSingleSelectFieldPro, meta, {
   props: (inputs: Inputs<typeof meta>) => {
-    if (!inputs.dataset)
-      return {
-        ...inputs,
-        measureOptions: [],
-      };
-
     return {
       ...inputs,
       measureOptions: inputs.measureOptions ?? [],

--- a/src/components/editors/MeasureSingleSelectFieldPro/MeasureSingleSelectFieldPro.emb.ts
+++ b/src/components/editors/MeasureSingleSelectFieldPro/MeasureSingleSelectFieldPro.emb.ts
@@ -1,0 +1,85 @@
+import { Value } from '@embeddable.com/core';
+import {
+  EmbeddedComponentMeta,
+  Inputs,
+  defineComponent,
+  definePreview,
+} from '@embeddable.com/react';
+import MeasureSingleSelectFieldPro from './index';
+import { inputs } from '../../component.inputs.constants';
+import { previewData } from '../../preview.data.constants';
+
+export const meta = {
+  name: 'MeasureSingleSelectFieldPro',
+  label: 'Measure Single Select Field',
+  category: 'Dropdowns',
+  defaultWidth: 300,
+  defaultHeight: 120,
+  inputs: [
+    inputs.dataset,
+    inputs.title,
+    inputs.description,
+    { ...inputs.placeholder, defaultValue: 'Select value...' },
+    inputs.measureOptions,
+    {
+      ...inputs.measure,
+      name: 'selectedMeasure',
+      label: 'Selected measure',
+      category: 'Pre-configured variables',
+      required: false,
+      config: {
+        dataset: 'dataset',
+      },
+    },
+    { ...inputs.clearable, defaultValue: false },
+  ],
+  events: [
+    {
+      name: 'onChange',
+      label: 'Selected measure updated',
+      properties: [
+        {
+          name: 'value',
+          label: 'Selected measure',
+          type: 'measure',
+        },
+      ],
+    },
+  ],
+  variables: [
+    {
+      name: 'measure single-select value',
+      type: 'measure',
+      defaultValue: Value.noFilter(),
+      inputs: ['selectedMeasure'],
+      events: [{ name: 'onChange', property: 'value' }],
+    },
+  ],
+} as const satisfies EmbeddedComponentMeta;
+
+export const preview = definePreview(MeasureSingleSelectFieldPro, {
+  measureOptions: [previewData.measure, previewData.measure],
+  onChange: () => null,
+});
+
+export default defineComponent(MeasureSingleSelectFieldPro, meta, {
+  props: (inputs: Inputs<typeof meta>) => {
+    if (!inputs.dataset)
+      return {
+        ...inputs,
+        measureOptions: [],
+      };
+
+    return {
+      ...inputs,
+      measureOptions: inputs.measureOptions ?? [],
+    };
+  },
+  events: {
+    onChange: (value) => {
+      return {
+        value: value ?? Value.noFilter(),
+      };
+    },
+  },
+});

--- a/src/components/editors/MeasureSingleSelectFieldPro/MeasureSingleSelectFieldPro.emb.ts
+++ b/src/components/editors/MeasureSingleSelectFieldPro/MeasureSingleSelectFieldPro.emb.ts
@@ -58,7 +58,7 @@ export const meta = {
 } as const satisfies EmbeddedComponentMeta;
 
 export const preview = definePreview(MeasureSingleSelectFieldPro, {
-  measureOptions: [previewData.measure, previewData.measure],
+  measureOptions: [previewData.measure, previewData.measureVariant],
   onChange: () => null,
 });
 

--- a/src/components/editors/MeasureSingleSelectFieldPro/index.tsx
+++ b/src/components/editors/MeasureSingleSelectFieldPro/index.tsx
@@ -1,0 +1,38 @@
+import { Measure } from '@embeddable.com/core';
+import { EditorCard } from '../shared/EditorCard/EditorCard';
+import { resolveI18nProps } from '../../component.utils';
+import { ChartCardHeaderProps } from '../../charts/shared/ChartCard/ChartCard';
+import { Theme } from '../../../theme/theme.types';
+import { useTheme } from '@embeddable.com/react';
+import { i18nSetup } from '../../../theme/i18n/i18n';
+import { DimensionAndMeasureSingleSelectField } from '../shared/DimensionAndMeasureSingleSelectField/DimensionAndMeasureSingleSelectField';
+
+type MeasureSingleSelectFieldProProps = {
+  selectedMeasure?: Measure;
+  measureOptions: Measure[];
+  placeholder?: string;
+  clearable?: boolean;
+  onChange: (value: Measure | undefined) => void;
+} & ChartCardHeaderProps;
+
+const MeasureSingleSelectFieldPro = (props: MeasureSingleSelectFieldProProps) => {
+  const theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const { selectedMeasure, measureOptions, clearable, onChange } = props;
+  const { title, description, placeholder } = resolveI18nProps(props);
+
+  return (
+    <EditorCard title={title} subtitle={description}>
+      <DimensionAndMeasureSingleSelectField<Measure>
+        selectedValue={selectedMeasure}
+        options={measureOptions}
+        placeholder={placeholder}
+        clearable={clearable}
+        onChange={onChange}
+      />
+    </EditorCard>
+  );
+};
+
+export default MeasureSingleSelectFieldPro;

--- a/src/components/editors/SingleSelectFieldPro/SingleSelectFieldPro.emb.ts
+++ b/src/components/editors/SingleSelectFieldPro/SingleSelectFieldPro.emb.ts
@@ -109,7 +109,7 @@ export default defineComponent(SingleSelectFieldPro, meta, {
   events: {
     onChange: (selectedValue: string) => {
       return {
-        value: selectedValue || Value.noFilter(),
+        value: selectedValue ?? Value.noFilter(),
       };
     },
   },

--- a/src/components/editors/shared/DimensionAndMeasureSingleSelectField/DimensionAndMeasureSingleSelectField.tsx
+++ b/src/components/editors/shared/DimensionAndMeasureSingleSelectField/DimensionAndMeasureSingleSelectField.tsx
@@ -38,7 +38,7 @@ export const DimensionAndMeasureSingleSelectField = <T extends Dimension | Measu
     if (firstDimension) {
       onChange(firstDimension);
     }
-  }, [clearable, selectedValue, onChange]);
+  }, [clearable, selectedValue, options, onChange]);
 
   return (
     <SingleSelectField

--- a/src/components/editors/shared/DimensionAndMeasureSingleSelectField/DimensionAndMeasureSingleSelectField.tsx
+++ b/src/components/editors/shared/DimensionAndMeasureSingleSelectField/DimensionAndMeasureSingleSelectField.tsx
@@ -1,0 +1,59 @@
+import { useTheme } from '@embeddable.com/react';
+import { Theme } from '../../../../theme/theme.types';
+import { useEffect, useState } from 'react';
+import { SingleSelectField } from '@embeddable.com/remarkable-ui';
+import { getDimensionAndMeasureOptions } from '../../utils/dimensionsAndMeasures.utils';
+import { Dimension, Measure } from '@embeddable.com/core';
+
+type DimensionAndMeasureSingleSelectFieldProps<T> = {
+  selectedValue?: T;
+  options: T[];
+  placeholder?: string;
+  clearable?: boolean;
+  onChange: (value: T | undefined) => void;
+};
+
+export const DimensionAndMeasureSingleSelectField = <T extends Dimension | Measure>(
+  props: DimensionAndMeasureSingleSelectFieldProps<T>,
+) => {
+  const theme = useTheme() as Theme;
+
+  const [searchValue, setSearchValue] = useState<string>('');
+
+  const { selectedValue, options, clearable, placeholder, onChange } = props;
+
+  const handleChange = (newValue: string) => {
+    const newSelection = options.find((option) => option.name === newValue);
+    onChange(newSelection);
+  };
+
+  // Auto-select first dimensionOrMeasure when is not clearable and there is no selection
+  useEffect(() => {
+    const autoSelectActive = !clearable && !selectedValue;
+
+    if (!autoSelectActive) return;
+
+    const firstDimension = options?.[0];
+
+    if (firstDimension) {
+      onChange(firstDimension);
+    }
+  }, [clearable, selectedValue, onChange]);
+
+  return (
+    <SingleSelectField
+      searchable
+      clearable={clearable}
+      placeholder={placeholder}
+      value={selectedValue?.name}
+      onChange={handleChange}
+      onSearch={setSearchValue}
+      options={getDimensionAndMeasureOptions({
+        dimensionsAndMeasures: options,
+        searchValue,
+        theme,
+      })}
+      avoidCollisions={false}
+    />
+  );
+};

--- a/src/components/editors/utils/dimensionsAndMeasures.utils.ts
+++ b/src/components/editors/utils/dimensionsAndMeasures.utils.ts
@@ -1,0 +1,29 @@
+import { DimensionOrMeasure } from '@embeddable.com/core';
+import { Theme } from '../../../theme/theme.types';
+import { SelectListOptionProps } from '@embeddable.com/remarkable-ui';
+import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
+
+export const getDimensionAndMeasureOptions = ({
+  dimensionsAndMeasures,
+  searchValue,
+  theme,
+}: {
+  dimensionsAndMeasures: DimensionOrMeasure[];
+  searchValue: string;
+  theme: Theme;
+}): SelectListOptionProps[] => {
+  const themeFormatter = getThemeFormatter(theme);
+
+  return dimensionsAndMeasures
+    .filter((dimensionOrMeasure) => {
+      return themeFormatter
+        .dimensionOrMeasureTitle(dimensionOrMeasure)
+        .includes(searchValue.toLowerCase());
+    })
+    .map((dimensionOrMeasure) => {
+      return {
+        value: dimensionOrMeasure.name,
+        label: themeFormatter.dimensionOrMeasureTitle(dimensionOrMeasure),
+      };
+    });
+};

--- a/src/components/editors/utils/dimensionsAndMeasures.utils.ts
+++ b/src/components/editors/utils/dimensionsAndMeasures.utils.ts
@@ -18,6 +18,7 @@ export const getDimensionAndMeasureOptions = ({
     .filter((dimensionOrMeasure) => {
       return themeFormatter
         .dimensionOrMeasureTitle(dimensionOrMeasure)
+        .toLowerCase()
         .includes(searchValue.toLowerCase());
     })
     .map((dimensionOrMeasure) => {

--- a/src/components/preview.data.constants.ts
+++ b/src/components/preview.data.constants.ts
@@ -2,10 +2,12 @@ import { mockDataResponse, mockDimension, mockMeasure } from '@embeddable.com/co
 
 const dimensionName = 'country';
 const measureName = 'count';
+const measureVariantName = 'average';
 const dimensionGroupName = 'category';
 
 const dimension = mockDimension(dimensionName, 'string', { title: 'Country' });
 const measure = mockMeasure(measureName, 'number', { title: 'Count' });
+const measureVariant = mockMeasure(measureVariantName, 'number', { title: 'Average' });
 const dimensionGroup = mockDimension(dimensionGroupName, 'string', {
   title: 'Category',
 });
@@ -87,6 +89,7 @@ export const previewData = {
   dimension,
   dimensionGroup,
   measure,
+  measureVariant,
   results1Measure,
   results1MeasureVariant,
   results1Measure1Dimension,


### PR DESCRIPTION
# Why is this pull-request needed?

This PR introduces 2 new editor components - DimensionSingleSelectField and MeasureSingleSelectField

# Main changes

- create reusable component DimensionAndMeasureSingleSelectField that serves both DimensionSingleSelectField and MeasureSingleSelectField
- if clearable and there is no default value - automatically select the 1st available 1.

# Test evidence



https://github.com/user-attachments/assets/20df0c64-c4ba-4b28-914f-3d1cb58e5be0






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new dimension and measure single-select field types for enhanced data selection and filtering
  * Added dedicated UI components with real-time search filtering, customizable options, and intelligent defaults
  * Enabled automatic selection of first available option and built-in field clearing capability for improved user experience

* **Bug Fixes**
  * Fixed handling of empty string values in single-select fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->