### PR TITLE
[EXAMPLE ONLY DO NOT MERGE] Example of user-defined custom hook in theme

### DIFF
--- a/embeddable.theme.ts
+++ b/embeddable.theme.ts
@@ -1,8 +1,35 @@
-import { Theme } from './src/theme/theme.types';
+import { BaseChartTypes, Theme } from './src/theme/theme.types';
 import { remarkableTheme } from './src/theme/theme.constants';
+import { defineTheme } from '@embeddable.com/core';
 
 const themeProvider = (): Theme => {
-  return remarkableTheme;
+  const theme = defineTheme<Theme>(remarkableTheme, {
+    useCustomProps: async <T extends BaseChartTypes>(props: T, chartName: string): Promise<T> => {
+      // Example of a custom props hook that manipulates data from the results prop before it is used in the chart.
+      if (chartName === 'BarChartDefaultPro' && typeof props === 'object' && props !== null) {
+        const data = props.results?.data || [];
+        // Simulate an API request or some data manipulation here. For example, we could filter out certain data points, or add additional data points based on the existing data.
+        const manipulatedData = data.map((row) => {
+          // Example manipulation: add a new field to each row based on existing fields
+          return {
+            ...row,
+            manipulatedValue: row[props.dimension.name] * 2, // Just an example manipulation
+          };
+        });
+        // Return the new props with the manipulated data. The chart will then use this manipulated data instead of the original data.
+        const newProps = {
+          ...props,
+          results: {
+            ...props.results,
+            data: manipulatedData,
+          },
+        };
+        return newProps as T;
+      }
+      return props as T;
+    },
+  });
+  return theme;
 };
 
 export default themeProvider;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.5",

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
@@ -32,6 +33,24 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
+  /*
+  Here we check the theme for a `useCustomProps` hook. This allows the end user to provide a hook that can manipulate the props before they are used in the chart. This is useful for things like hitting an outside API to get additional data, manipulating the data in some way, or even just providing default values for certain props.
+
+  The `useCustomProps` hook should take two arguments, the props, and an additional string telling it which chart is being rendered. This allows the hook to be used for multiple charts and manipulate the props differently based on the chart type.
+  */
+  const [customProps, setCustomProps] = useState<BarChartDefaultProProps>(props);
+
+  useEffect(() => {
+    const customPropsHook = theme.useCustomProps;
+    if (customPropsHook) {
+      customPropsHook<BarChartDefaultProProps>(props, 'BarChartDefaultPro').then((result) =>
+        setCustomProps(result || props),
+      );
+    } else {
+      setCustomProps(props);
+    }
+  }, [props, theme.useCustomProps]);
+
   const {
     measures,
     yAxisRangeMin,
@@ -46,12 +65,12 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
     dimension,
     setGranularity,
     onBarClicked,
-  } = props;
+  } = customProps;
 
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(customProps);
 
   const results = useFillGaps({
-    results: props.results,
+    results: customProps.results,
     dimension,
   });
 

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -6,6 +6,7 @@ import { ComparisonPeriodOption } from './defaults/defaults.ComparisonPeriods.co
 import { DateRangeOption } from './defaults/defaults.DateRanges.constants';
 import { ChartCardMenuOption } from './defaults/defaults.ChartCardMenu.constants';
 import { TableCellStyleOption } from './defaults/defaults.TableCellStyle.constants';
+import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 
 export type ThemeI18n = { language: string; translations: Resource };
 
@@ -52,10 +53,18 @@ export type ThemeDefaults = {
   tableCellStyleOptions?: TableCellStyleOption[];
 };
 
+export type BaseChartTypes = {
+  dimension: Dimension;
+  measures: Measure[];
+  results: DataResponse;
+};
+
 export type Theme = {
   i18n: ThemeI18n;
   charts: ThemeCharts;
   styles: ThemeStyles;
   formatter: ThemeFormatter;
   defaults: ThemeDefaults;
+  // Updated to use a generic type for custom props
+  useCustomProps?: <T extends BaseChartTypes>(props: T, chartName: string) => Promise<T>;
 };


### PR DESCRIPTION
This shows one way of implementing a custom hook that the user could define on the theme which would allow them access to the props for any given chart, and they could then manipulate those props as they like and return them.

Apologies, the typing for TS compatibility is a hack job, but speed's of the essence in this case! :grin:

This is related to an issue NOQ are having where they need to hit an external API, get some stuff from it, and then use that stuff to manipulate `props.results.data` returned by `loadData` before doing anything in the chart. They have to do this for virtually every chart, with the results from the external API being different for each individual user and dataset, meaning potentially tens of thousands of different results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added theme-level customization capability to enable dynamic prop transformation for charts.
  * Implemented data augmentation support for chart visualization.

* **Refactor**
  * Restructured chart prop flow to utilize theme-based customization system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->