### PR TITLE
RUI-207: pivot sub rows

### DIFF
--- a/.changeset/major-trains-shop.md
+++ b/.changeset/major-trains-shop.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+PivotTable with subrows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.5",
         "@embeddable.com/react": "^2.13.2",
-        "@embeddable.com/remarkable-ui": "^2.0.39",
+        "@embeddable.com/remarkable-ui": "^2.0.41",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -676,9 +676,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "2.0.39",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.39.tgz",
-      "integrity": "sha512-Bu6AwEOoE/FIE3fvRSTPVs0i67KtmLyd80cYrSb4lxTu9viwJPXtw5Qp6bm8cuEYBYs8LU/ks1jo5W+liCM77Q==",
+      "version": "2.0.41",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.41.tgz",
+      "integrity": "sha512-FIap5mt55mov1L5ofWnh1aKQd5ohGpg4MTfalq2D4tRtv28e79PyXDo84/BgspUJznumCLtWf3O6f1o8Q0L8Sg==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.5",
     "@embeddable.com/react": "^2.13.2",
-    "@embeddable.com/remarkable-ui": "^2.0.39",
+    "@embeddable.com/remarkable-ui": "^2.0.41",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/charts/shared/ChartCard/ChartCard.module.css
+++ b/src/components/charts/shared/ChartCard/ChartCard.module.css
@@ -17,7 +17,7 @@
   position: absolute;
   display: flex;
   justify-content: end;
-  z-index: 2;
+  z-index: 3;
   top: calc(var(--em-card-padding, 2rem));
   right: calc(var(--em-card-padding, 2rem));
 }

--- a/src/components/charts/tables/PivotTablePro/PivotTablePro.emb.ts
+++ b/src/components/charts/tables/PivotTablePro/PivotTablePro.emb.ts
@@ -42,13 +42,21 @@ export const meta = {
     },
     {
       ...inputs.dimensionWithDateBounds,
-      label: 'Row dimension',
-      name: 'rowDimension',
+      label: 'Column dimension',
+      name: 'columnDimension',
     },
     {
       ...inputs.dimensionWithDateBounds,
-      label: 'Column dimension',
-      name: 'columnDimension',
+      label: 'Primary row dimension',
+      name: 'rowDimension',
+    },
+    {
+      ...inputs.dimension,
+      label: 'Secondary row dimension (optional)',
+      name: 'rowDimension2',
+      required: false,
+      description:
+        'When set, each primary row becomes expandable. Clicking a row loads a breakdown by the second dimension.',
     },
     inputs.title,
     inputs.description,
@@ -78,19 +86,54 @@ export const preview = definePreview(PivotTablePro, {
   columnDimension: previewData.dimensionGroup,
   results: previewData.results1Measure2Dimensions,
   hideMenu: true,
+  expandedRowKeys: [],
+  setExpandedRowKey: () => {},
 });
 
+export type PivotTableProState = {
+  expandedRowKeys?: string[];
+};
+
 export default defineComponent(PivotTablePro, meta, {
-  props: (inputs: Inputs<typeof meta>) => {
+  props: (
+    inputs: Inputs<typeof meta>,
+    [state, setState]: [PivotTableProState, (state: PivotTableProState) => void],
+  ) => {
+    const expandedRowKeys = state?.expandedRowKeys ?? [];
+
     return {
       ...inputs,
-
+      state,
+      expandedRowKeys,
+      setExpandedRowKey: (rowKey: string) =>
+        setState({ expandedRowKeys: [...expandedRowKeys, rowKey] }),
       results: loadData({
         from: inputs.dataset,
         select: [inputs.rowDimension, inputs.columnDimension, ...inputs.measures],
         limit: inputs.maxResults,
         countRows: true,
       }),
+      results2:
+        expandedRowKeys.length > 0
+          ? loadData({
+              from: inputs.dataset,
+              select: [
+                inputs.rowDimension,
+                inputs.rowDimension2,
+                inputs.columnDimension,
+                ...inputs.measures,
+              ],
+              limit: inputs.maxResults,
+              countRows: true,
+              filters: [
+                {
+                  property: inputs.rowDimension,
+                  operator: 'equals',
+                  value: expandedRowKeys,
+                },
+              ],
+            })
+          : undefined,
     };
   },
 });

--- a/src/components/charts/tables/PivotTablePro/PivotTablePro.emb.ts
+++ b/src/components/charts/tables/PivotTablePro/PivotTablePro.emb.ts
@@ -53,7 +53,7 @@ export const meta = {
     {
       ...inputs.dimension,
       label: 'Secondary row dimension (optional)',
-      name: 'rowDimension2',
+      name: 'subRowDimension',
       required: false,
       description:
         'When set, each primary row becomes expandable. Clicking a row loads a breakdown by the second dimension.',
@@ -113,13 +113,13 @@ export default defineComponent(PivotTablePro, meta, {
         limit: inputs.maxResults,
         countRows: true,
       }),
-      results2:
+      resultsSubRows:
         expandedRowKeys.length > 0
           ? loadData({
               from: inputs.dataset,
               select: [
                 inputs.rowDimension,
-                inputs.rowDimension2,
+                inputs.subRowDimension,
                 inputs.columnDimension,
                 ...inputs.measures,
               ],

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -107,15 +107,19 @@ const PivotTablePro = (props: PivotTableProProps) => {
 
     const subRowsByRowData = new Map<string, any[]>();
     expandedRowKeys.forEach((rowKey) => {
-      const containsSubRow = resultsSubRows.data?.some((row) => row[rowDimension.name] === rowKey);
-      if (!containsSubRow) return;
+      const containsSubRow = resultsSubRows.data?.some(
+        (row) => String(row[rowDimension.name]) === rowKey,
+      );
 
-      const subRows = resultsSubRows.data?.filter((row) => row[rowDimension.name] === rowKey) ?? [];
-      const subRowsSorted = subRowDimension
-        ? sortArrayByProp(subRows, subRowDimension.name, 'asc')
-        : subRows;
+      if (containsSubRow) {
+        const subRows =
+          resultsSubRows.data?.filter((row) => String(row[rowDimension.name]) === rowKey) ?? [];
+        const subRowsSorted = subRowDimension
+          ? sortArrayByProp(subRows, subRowDimension.name, 'asc')
+          : subRows;
 
-      subRowsByRowData.set(rowKey, subRowsSorted);
+        subRowsByRowData.set(rowKey, subRowsSorted);
+      }
 
       setLoadingRows((prev) => {
         const next = new Set(prev);
@@ -124,7 +128,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
       });
     });
     setSubRowsByRow(subRowsByRowData);
-  }, [resultsSubRows, expandedRowKeys, setLoadingRows]);
+  }, [resultsSubRows, expandedRowKeys, rowDimension, subRowDimension]);
 
   return (
     <ChartCard

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -5,7 +5,7 @@ import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCar
 import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { PivotTable } from '@embeddable.com/remarkable-ui';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import {
   getPivotColumnTotalsFor,
@@ -14,17 +14,22 @@ import {
   getPivotRowTotalsFor,
 } from './PivotPro.utils';
 import { useGetTableSortedResults } from '../tables.hooks';
+import { sortArrayByProp } from '../../../../utils/array.utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 type PivotTableProProps = {
   results: DataResponse;
+  results2?: DataResponse;
   measures: Measure[];
   rowDimension: Dimension;
+  rowDimension2?: Dimension;
   columnDimension: Dimension;
   displayNullAs?: string;
   columnWidth?: number;
   firstColumnWidth?: number;
+  expandedRowKeys: string[];
+  setExpandedRowKey: (expandedRowKeys: string) => void;
 } & ChartCardHeaderProps;
 
 const PivotTablePro = (props: PivotTableProProps) => {
@@ -33,13 +38,17 @@ const PivotTablePro = (props: PivotTableProProps) => {
 
   const { title, description, tooltip } = resolveI18nProps(props);
   const {
+    results2,
     measures,
     rowDimension,
+    rowDimension2,
     columnDimension,
     displayNullAs,
     columnWidth,
     firstColumnWidth,
     hideMenu,
+    expandedRowKeys,
+    setExpandedRowKey,
   } = props;
 
   const columnOrder = Array.from(
@@ -75,9 +84,48 @@ const PivotTablePro = (props: PivotTableProProps) => {
 
   const pivotMeasures = getPivotMeasures({ measures, displayNullAs }, theme);
   const pivotRowDimension = getPivotDimension({ dimension: rowDimension }, theme);
+  const pivotRowDimension2 = rowDimension2
+    ? getPivotDimension({ dimension: rowDimension2 }, theme)
+    : undefined;
   const pivotColumnDimension = getPivotDimension({ dimension: columnDimension }, theme);
   const pivotColumnTotalsFor = getPivotColumnTotalsFor(measures);
   const pivotRowTotalsFor = getPivotRowTotalsFor(measures);
+
+  const [loadingRows, setLoadingRows] = useState(new Set<string>());
+  const [subRowsByRow, setSubRowsByRow] = useState(new Map<string, any[]>());
+
+  const handleRowExpand = (rowKey: string) => {
+    setLoadingRows((prev) => new Set(prev).add(rowKey));
+    setExpandedRowKey(rowKey);
+  };
+
+  useEffect(() => {
+    // No results or no expandedRowKeys, nothing to load
+    if (!results2 || !results2?.data || expandedRowKeys.length === 0) {
+      return;
+    }
+
+    const subRowsByRowData = new Map<string, any[]>();
+    expandedRowKeys.forEach((rowKey) => {
+      const containsSubRow = results2.data?.some((row) => row[rowDimension.name] === rowKey);
+      if (!containsSubRow) return;
+
+      const subRows = results2.data?.filter((row) => row[rowDimension.name] === rowKey) ?? [];
+      const subRowsSorted = rowDimension2
+        ? sortArrayByProp(subRows, rowDimension2.name, 'asc')
+        : subRows;
+
+      subRowsByRowData.set(rowKey, subRowsSorted);
+
+      setLoadingRows((prev) => {
+        const next = new Set(prev);
+        next.delete(rowKey);
+        return next;
+      });
+    });
+    setSubRowsByRow(subRowsByRowData);
+  }, [results2, expandedRowKeys, setLoadingRows]);
+
   return (
     <ChartCard
       ref={cardContentRef}
@@ -99,6 +147,11 @@ const PivotTablePro = (props: PivotTableProProps) => {
         columnDimension={pivotColumnDimension}
         columnTotalsFor={pivotColumnTotalsFor}
         rowTotalsFor={pivotRowTotalsFor}
+        expandableRows={Boolean(rowDimension2)}
+        subRowsByRow={subRowsByRow}
+        loadingRows={loadingRows}
+        onRowExpand={handleRowExpand}
+        subRowDimension={pivotRowDimension2}
       />
     </ChartCard>
   );

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -20,10 +20,10 @@ import { sortArrayByProp } from '../../../../utils/array.utils';
 
 type PivotTableProProps = {
   results: DataResponse;
-  results2?: DataResponse;
+  resultsSubRows?: DataResponse;
   measures: Measure[];
   rowDimension: Dimension;
-  rowDimension2?: Dimension;
+  subRowDimension?: Dimension;
   columnDimension: Dimension;
   displayNullAs?: string;
   columnWidth?: number;
@@ -38,10 +38,10 @@ const PivotTablePro = (props: PivotTableProProps) => {
 
   const { title, description, tooltip } = resolveI18nProps(props);
   const {
-    results2,
+    resultsSubRows,
     measures,
     rowDimension,
-    rowDimension2,
+    subRowDimension,
     columnDimension,
     displayNullAs,
     columnWidth,
@@ -84,8 +84,8 @@ const PivotTablePro = (props: PivotTableProProps) => {
 
   const pivotMeasures = getPivotMeasures({ measures, displayNullAs }, theme);
   const pivotRowDimension = getPivotDimension({ dimension: rowDimension }, theme);
-  const pivotRowDimension2 = rowDimension2
-    ? getPivotDimension({ dimension: rowDimension2 }, theme)
+  const pivotSubRowDimension = subRowDimension
+    ? getPivotDimension({ dimension: subRowDimension }, theme)
     : undefined;
   const pivotColumnDimension = getPivotDimension({ dimension: columnDimension }, theme);
   const pivotColumnTotalsFor = getPivotColumnTotalsFor(measures);
@@ -101,18 +101,18 @@ const PivotTablePro = (props: PivotTableProProps) => {
 
   useEffect(() => {
     // No results or no expandedRowKeys, nothing to load
-    if (!results2 || !results2?.data || expandedRowKeys.length === 0) {
+    if (!resultsSubRows || !resultsSubRows?.data || expandedRowKeys.length === 0) {
       return;
     }
 
     const subRowsByRowData = new Map<string, any[]>();
     expandedRowKeys.forEach((rowKey) => {
-      const containsSubRow = results2.data?.some((row) => row[rowDimension.name] === rowKey);
+      const containsSubRow = resultsSubRows.data?.some((row) => row[rowDimension.name] === rowKey);
       if (!containsSubRow) return;
 
-      const subRows = results2.data?.filter((row) => row[rowDimension.name] === rowKey) ?? [];
-      const subRowsSorted = rowDimension2
-        ? sortArrayByProp(subRows, rowDimension2.name, 'asc')
+      const subRows = resultsSubRows.data?.filter((row) => row[rowDimension.name] === rowKey) ?? [];
+      const subRowsSorted = subRowDimension
+        ? sortArrayByProp(subRows, subRowDimension.name, 'asc')
         : subRows;
 
       subRowsByRowData.set(rowKey, subRowsSorted);
@@ -124,7 +124,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
       });
     });
     setSubRowsByRow(subRowsByRowData);
-  }, [results2, expandedRowKeys, setLoadingRows]);
+  }, [resultsSubRows, expandedRowKeys, setLoadingRows]);
 
   return (
     <ChartCard
@@ -147,11 +147,11 @@ const PivotTablePro = (props: PivotTableProProps) => {
         columnDimension={pivotColumnDimension}
         columnTotalsFor={pivotColumnTotalsFor}
         rowTotalsFor={pivotRowTotalsFor}
-        expandableRows={Boolean(rowDimension2)}
+        expandableRows={Boolean(subRowDimension)}
         subRowsByRow={subRowsByRow}
         loadingRows={loadingRows}
         onRowExpand={handleRowExpand}
-        subRowDimension={pivotRowDimension2}
+        subRowDimension={pivotSubRowDimension}
       />
     </ChartCard>
   );

--- a/src/utils/array.utils.ts
+++ b/src/utils/array.utils.ts
@@ -1,0 +1,11 @@
+export const sortArrayByProp = <T, K extends keyof T>(
+  arr: T[],
+  prop: K,
+  order: 'asc' | 'desc' = 'asc',
+): T[] => {
+  return [...arr].sort((a, b) => {
+    if (a[prop] < b[prop]) return order === 'asc' ? -1 : 1;
+    if (a[prop] > b[prop]) return order === 'asc' ? 1 : -1;
+    return 0;
+  });
+};


### PR DESCRIPTION
# Why is this pull-request needed?

This PR introduces the capability of a PivotTable to display subrows

# Main changes

- add new dimension subrow input
- update rui version

# Test evidence


https://github.com/user-attachments/assets/84e161c9-5adc-4723-ade9-98020204979f




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced expandable subrows in PivotTable. Users can now click primary rows to expand and view a breakdown by a secondary dimension, enabling detailed data exploration while maintaining a clean table view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->