### PR TITLE
TPS-1171: prevent i18next namespace parsing for raw string values in dataOthersFormatter

### DIFF
--- a/.changeset/lovely-beans-crash.md
+++ b/.changeset/lovely-beans-crash.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Fix dataOtherFormatter namespace parsing for raw string values

--- a/src/components/charts/tables/tables.utils.tsx
+++ b/src/components/charts/tables/tables.utils.tsx
@@ -89,12 +89,14 @@ export const getTableHeaders = (
       },
       cell: hasCustomCellFormatter
         ? ({ value }) => {
-            const currentValue: string | undefined =
-              typeof value === 'string'
-                ? value
-                : value !== undefined && value !== null
-                  ? String(value)
-                  : undefined;
+            let currentValue: string | undefined;
+            if (typeof value === 'string') {
+              currentValue = value;
+            } else if (value !== undefined && value !== null) {
+              currentValue = String(value);
+            } else {
+              currentValue = undefined;
+            }
 
             return (
               <TableBodyCellWithCopy value={value}>

--- a/src/theme/formatter/formatter.constants.ts
+++ b/src/theme/formatter/formatter.constants.ts
@@ -158,6 +158,7 @@ const dataOthersFormatter = (theme: Theme, key: DimensionOrMeasure): StringForma
           stringValue, // e.g. 'Germany'
         ],
         {
+          defaultValue: stringValue,
           value: stringValue,
           type: key.nativeType,
           name: name,


### PR DESCRIPTION
# Why is this pull-request needed?

Values containing : (e.g. "10:15") were being misinterpreted by i18next as namespace:key pairs due to the default nsSeparator: ":" setting. When no matching namespace existed, i18next would return only the key portion (e.g. "15") instead of the original value.

Fixed by passing defaultValue: stringValue to i18n.t(). This ensures that if none of the translation keys resolve to a match, the raw value is returned as-is rather than being parsed as a namespace:key pair.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue with raw string value formatting in the data system, ensuring proper handling of all input types with appropriate fallback values.

* **Refactor**
  * Improved code clarity in the data formatting logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->