### PR TITLE
RUI-233: show datalabel as percentage

### DIFF
--- a/.changeset/silent-seals-leave.md
+++ b/.changeset/silent-seals-leave.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Include display value as percentage for pie charts and simple bar charts

--- a/embeddable.config.ts
+++ b/embeddable.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   plugins: [react],
   lifecycleHooksFile: './embeddable.lifecycle.ts',
   pushModels: false,
+  region: 'US',
   // previewBaseUrl: 'https://app.dev.embeddable.com',
   // pushBaseUrl: 'https://api.dev.embeddable.com',
   // audienceUrl: 'https://api.dev.embeddable.com/',

--- a/embeddable.config.ts
+++ b/embeddable.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
   plugins: [react],
   lifecycleHooksFile: './embeddable.lifecycle.ts',
   pushModels: false,
-  region: 'US',
   // previewBaseUrl: 'https://app.dev.embeddable.com',
   // pushBaseUrl: 'https://api.dev.embeddable.com',
   // audienceUrl: 'https://api.dev.embeddable.com/',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.6",

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
@@ -11,6 +11,7 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { subInputs } from '../../../component.subinputs.constants';
 
 const meta = {
   name: 'BarChartDefaultHorizontalPro',
@@ -18,7 +19,10 @@ const meta = {
   category: 'Bar Charts',
   inputs: [
     inputs.dataset,
-    { ...inputs.measures, inputs: [...inputs.measures.inputs, inputs.color] },
+    {
+      ...inputs.measures,
+      inputs: [...inputs.measures.inputs, subInputs.color, subInputs.showValueAsPercentage],
+    },
     { ...inputs.dimensionWithGranularitySelectField, label: 'Y-axis' },
     inputs.title,
     inputs.description,

--- a/src/components/charts/bars/BarChartDefaultPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/definition.ts
@@ -11,6 +11,7 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { subInputs } from '../../../component.subinputs.constants';
 
 const meta = {
   name: 'BarChartDefaultPro',
@@ -18,7 +19,10 @@ const meta = {
   category: 'Bar Charts',
   inputs: [
     inputs.dataset,
-    { ...inputs.measures, inputs: [...inputs.measures.inputs, inputs.color] },
+    {
+      ...inputs.measures,
+      inputs: [...inputs.measures.inputs, subInputs.color, subInputs.showValueAsPercentage],
+    },
     {
       ...inputs.dimensionWithGranularitySelectField,
       label: 'X-axis',

--- a/src/components/charts/bars/bars.utils.test.ts
+++ b/src/components/charts/bars/bars.utils.test.ts
@@ -1,13 +1,13 @@
 import type { Dimension, Measure } from '@embeddable.com/core';
 import { getBarStackedChartProData, getBarChartProData, getBarChartProOptions } from './bars.utils';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
-import { groupTailAsOther } from '../charts.utils';
+import { getDatalabelPercentage, groupTailAsOther } from '../charts.utils';
 import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
 import type { Context } from 'chartjs-plugin-datalabels';
 
 vi.mock('../../../theme/formatter/formatter.utils', () => ({ getThemeFormatter: vi.fn() }));
-vi.mock('../charts.utils', () => ({ groupTailAsOther: vi.fn() }));
+vi.mock('../charts.utils', () => ({ groupTailAsOther: vi.fn(), getDatalabelPercentage: vi.fn() }));
 vi.mock('../../../theme/styles/styles.utils', () => ({ getDimensionMeasureColor: vi.fn() }));
 vi.mock('@embeddable.com/remarkable-ui', () => ({ getChartColors: vi.fn() }));
 vi.mock('../../../theme/theme.constants', () => ({ remarkableTheme: { charts: {} } }));
@@ -302,6 +302,17 @@ describe('getBarChartProData', () => {
 
     expect(mockFormatter.dimensionOrMeasureTitle).toHaveBeenCalledWith(measure);
   });
+
+  it('uses the default remarkableTheme when no theme argument is supplied', () => {
+    const dimension = makeDimension({ name: 'product' });
+    const data = [{ product: 'Widget', revenue: '100' }];
+
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarChartProData({ data, dimension, measures: [makeMeasure()] });
+
+    expect(result.datasets).toHaveLength(1);
+  });
 });
 
 // ----------------------------------------------------------------------------
@@ -392,6 +403,26 @@ describe('getBarChartProOptions', () => {
 
       expect(mockFormatter.data).toHaveBeenCalledWith(measures[0], 30);
     });
+
+    it('returns getDatalabelPercentage result when showValueAsPercentage is true', () => {
+      vi.mocked(getDatalabelPercentage).mockReturnValue('50%');
+
+      const measureWithPct = makeMeasure({
+        name: 'revenue',
+        inputs: { showValueAsPercentage: true },
+      });
+      const data = makeChartData(['A'], [[50]]);
+      const options = getBarChartProOptions(
+        { measures: [measureWithPct], dimension, horizontal: false, data: data as never },
+        makeTheme(),
+      );
+
+      const context = { datasetIndex: 0, dataset: { data: [50] } } as never;
+      const result = options.plugins!.datalabels!.labels!.value!.formatter!(50, context);
+
+      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
+      expect(result).toBe('50%');
+    });
   });
 
   // -- tooltip ---------------------------------------------------------------
@@ -427,6 +458,32 @@ describe('getBarChartProOptions', () => {
       options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
 
       expect(mockFormatter.data).toHaveBeenCalledWith(measures[0], 50);
+    });
+
+    it('appends percentage to label when showValueAsPercentage is true', () => {
+      vi.mocked(getDatalabelPercentage).mockReturnValue('50%');
+
+      const measureWithPct = makeMeasure({
+        name: 'revenue',
+        inputs: { showValueAsPercentage: true },
+      });
+      const data = makeChartData(['A'], [[50]]);
+      const options = getBarChartProOptions(
+        { measures: [measureWithPct], dimension, horizontal: false, data: data as never },
+        makeTheme(),
+      );
+
+      mockFormatter.data.mockImplementation((_, value) => `fmt:${value}`);
+
+      const context = {
+        datasetIndex: 0,
+        raw: 50,
+        dataset: { label: 'Revenue', data: [50] },
+      } as never;
+      const result = options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
+
+      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
+      expect(result).toBe('fmt:Revenue: fmt:50 (50%)');
     });
   });
 

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -3,7 +3,7 @@ import { Theme } from '../../../theme/theme.types';
 import { remarkableTheme } from '../../../theme/theme.constants';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
-import { groupTailAsOther } from '../charts.utils';
+import { getDatalabelPercentage, groupTailAsOther } from '../charts.utils';
 import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { Context } from 'chartjs-plugin-datalabels';
@@ -162,6 +162,10 @@ export const getBarChartProOptions = (
           value: {
             formatter: (value: string | number, context) => {
               const measure = measures[context.datasetIndex % measures.length]!;
+
+              if (measure.inputs?.showValuesAsPercentage) {
+                return getDatalabelPercentage(Number(value), context.dataset.data);
+              }
               return themeFormatter.data(measure, value);
             },
           },
@@ -173,10 +177,19 @@ export const getBarChartProOptions = (
             const label = context[0]?.label;
             return themeFormatter.data(dimension, label);
           },
+
           label: (context) => {
             const measure = measures[context.datasetIndex % measures.length]!;
             const raw = context.raw as number;
-            return `${themeFormatter.data(dimension, context.dataset.label) || ''}: ${themeFormatter.data(measure, raw)}`;
+
+            const dimensionLabel = themeFormatter.data(dimension, context.dataset.label) || '';
+            const measureValue = themeFormatter.data(measure, raw);
+
+            let percentage = '';
+            if (measure.inputs?.showValuesAsPercentage) {
+              percentage = `(${getDatalabelPercentage(raw, context.dataset.data)})`;
+            }
+            return `${dimensionLabel}: ${measureValue} ${percentage}`;
           },
         },
       },

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -163,7 +163,7 @@ export const getBarChartProOptions = (
             formatter: (value: string | number, context) => {
               const measure = measures[context.datasetIndex % measures.length]!;
 
-              if (measure.inputs?.showValuesAsPercentage) {
+              if (measure.inputs?.showValueAsPercentage) {
                 return getDatalabelPercentage(Number(value), context.dataset.data);
               }
               return themeFormatter.data(measure, value);
@@ -186,7 +186,7 @@ export const getBarChartProOptions = (
             const measureValue = themeFormatter.data(measure, raw);
 
             let percentage = '';
-            if (measure.inputs?.showValuesAsPercentage) {
+            if (measure.inputs?.showValueAsPercentage) {
               percentage = `(${getDatalabelPercentage(raw, context.dataset.data)})`;
             }
             return `${dimensionLabel}: ${measureValue} ${percentage}`;

--- a/src/components/charts/charts.utils.test.ts
+++ b/src/components/charts/charts.utils.test.ts
@@ -1,0 +1,142 @@
+import type { Dimension, Measure } from '@embeddable.com/core';
+import { getDatalabelPercentage, groupTailAsOther } from './charts.utils';
+import { i18n } from '../../theme/i18n/i18n';
+
+// -- mocks -------------------------------------------------------------------
+
+vi.mock('../../theme/i18n/i18n', () => ({
+  i18n: { t: vi.fn((key: string) => `t(${key})`) },
+}));
+
+// -- helpers -----------------------------------------------------------------
+
+const makeDimension = (name = 'category'): Dimension =>
+  ({ name, __type__: 'dimension', inputs: {} }) as unknown as Dimension;
+
+const makeMeasure = (name = 'value'): Measure =>
+  ({ name, __type__: 'measure', inputs: {} }) as unknown as Measure;
+
+describe('getDatalabelPercentage', () => {
+  it('returns 25% when value is 25 out of 100', () => {
+    expect(getDatalabelPercentage(25, [25, 25, 25, 25])).toBe('25%');
+  });
+
+  it('returns 33.33% for 1 out of 3', () => {
+    expect(getDatalabelPercentage(1, [1, 1, 1])).toBe('33.33%');
+  });
+
+  it('returns 66.67% for 2 out of 3', () => {
+    expect(getDatalabelPercentage(2, [1, 1, 1])).toBe('66.67%');
+  });
+
+  it('returns 100% when value equals the total', () => {
+    expect(getDatalabelPercentage(5, [5])).toBe('100%');
+  });
+
+  it('returns 0% when value is 0', () => {
+    expect(getDatalabelPercentage(0, [1, 2, 3])).toBe('0%');
+  });
+
+  it('strips trailing decimal zeros (25.00 → 25)', () => {
+    // toFixed(2) gives "25.00"; parseFloat strips it to 25
+    expect(getDatalabelPercentage(1, [4])).toBe('25%');
+  });
+
+  it('handles string numbers in the data array', () => {
+    // data is unknown[], so strings are valid — parseFloat handles them
+    expect(getDatalabelPercentage(50, ['50', '50'] as unknown[])).toBe('50%');
+  });
+});
+
+describe('groupTailAsOther', () => {
+  const dimension = makeDimension('category');
+  const measure = makeMeasure('value');
+
+  it('returns data unchanged when maxItems is not provided', () => {
+    const data = [
+      { category: 'A', value: 1 },
+      { category: 'B', value: 2 },
+      { category: 'C', value: 3 },
+    ];
+    expect(groupTailAsOther(data, dimension, [measure])).toBe(data);
+  });
+
+  it('returns data unchanged when data length is within maxItems', () => {
+    const data = [
+      { category: 'A', value: 1 },
+      { category: 'B', value: 2 },
+    ];
+    expect(groupTailAsOther(data, dimension, [measure], 3)).toBe(data);
+  });
+
+  it('returns data unchanged when data length equals maxItems', () => {
+    const data = [
+      { category: 'A', value: 1 },
+      { category: 'B', value: 2 },
+    ];
+    expect(groupTailAsOther(data, dimension, [measure], 2)).toBe(data);
+  });
+
+  it('groups tail rows into a single "Other" row when data exceeds maxItems', () => {
+    const data = [
+      { category: 'A', value: 10 },
+      { category: 'B', value: 20 },
+      { category: 'C', value: 30 },
+      { category: 'D', value: 40 },
+    ];
+
+    const result = groupTailAsOther(data, dimension, [measure], 3);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({ category: 'A', value: 10 });
+    expect(result[1]).toEqual({ category: 'B', value: 20 });
+    expect(result[2]).toEqual({ category: 't(common.other)', value: 70 }); // C(30) + D(40)
+  });
+
+  it('uses i18n.t("common.other") as the dimension value for the aggregated row', () => {
+    const data = [
+      { category: 'A', value: 1 },
+      { category: 'B', value: 2 },
+      { category: 'C', value: 3 },
+    ];
+
+    groupTailAsOther(data, dimension, [measure], 2);
+
+    expect(vi.mocked(i18n.t)).toHaveBeenCalledWith('common.other');
+  });
+
+  it('aggregates multiple measures independently in the "Other" row', () => {
+    const m1 = makeMeasure('sales');
+    const m2 = makeMeasure('units');
+    const data = [
+      { category: 'A', sales: 100, units: 5 },
+      { category: 'B', sales: 200, units: 10 },
+      { category: 'C', sales: 300, units: 15 },
+    ];
+
+    const result = groupTailAsOther(data, dimension, [m1, m2], 2);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]?.sales).toBe(500); // B(200) + C(300)
+    expect(result[1]?.units).toBe(25); // B(10) + C(15)
+  });
+
+  it('treats missing measure values as 0 during aggregation', () => {
+    const data = [
+      { category: 'A', value: 10 },
+      { category: 'B', value: 20 },
+      { category: 'C' }, // no value field
+    ];
+
+    const result = groupTailAsOther(data, dimension, [measure], 2);
+
+    // tail = B(20) + C(0) = 20
+    expect(result[1]?.value).toBe(20);
+  });
+
+  it('defaults data to an empty array when undefined', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result = groupTailAsOther(undefined as any, dimension, [measure], 3);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/components/charts/charts.utils.ts
+++ b/src/components/charts/charts.utils.ts
@@ -29,5 +29,6 @@ export const groupTailAsOther = (
 export const getDatalabelPercentage = (value: number, data: unknown[]): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const total = data.reduce((sum: number, v: any) => sum + Number.parseFloat(v), 0);
+  if (total === 0) return '0%';
   return `${Number.parseFloat(((value / total) * 100).toFixed(2))}%`;
 };

--- a/src/components/charts/charts.utils.ts
+++ b/src/components/charts/charts.utils.ts
@@ -25,3 +25,9 @@ export const groupTailAsOther = (
 
   return [...head, aggregatedRow];
 };
+
+export const getDatalabelPercentage = (value: number, data: unknown[]): string => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const total = data.reduce((sum: number, v: any) => sum + Number.parseFloat(v), 0);
+  return `${Number.parseFloat(((value / total) * 100).toFixed(2))}%`;
+};

--- a/src/components/charts/pies/DonutChartPro/definition.ts
+++ b/src/components/charts/pies/DonutChartPro/definition.ts
@@ -3,6 +3,7 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { subInputs } from '../../../component.subinputs.constants';
 
 const meta = {
   name: 'DonutChartPro',
@@ -10,7 +11,7 @@ const meta = {
   category: 'Pie Charts',
   inputs: [
     inputs.dataset,
-    inputs.measure,
+    { ...inputs.measure, inputs: [...inputs.measure.inputs, subInputs.showValueAsPercentage] },
     inputs.dimension,
     inputs.title,
     inputs.description,

--- a/src/components/charts/pies/DonutLabelChartPro/definition.ts
+++ b/src/components/charts/pies/DonutLabelChartPro/definition.ts
@@ -3,6 +3,7 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { subInputs } from '../../../component.subinputs.constants';
 
 const meta = {
   name: 'DonutLabelChartPro',
@@ -10,7 +11,7 @@ const meta = {
   category: 'Pie Charts',
   inputs: [
     inputs.dataset,
-    inputs.measure,
+    { ...inputs.measure, inputs: [...inputs.measure.inputs, subInputs.showValueAsPercentage] },
     inputs.dimension,
     { ...inputs.measure, name: 'innerLabelMeasure', label: 'Inner label measure' },
     {

--- a/src/components/charts/pies/PieChartPro/definition.ts
+++ b/src/components/charts/pies/PieChartPro/definition.ts
@@ -3,6 +3,7 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { subInputs } from '../../../component.subinputs.constants';
 
 const meta = {
   name: 'PieChartPro',
@@ -10,7 +11,7 @@ const meta = {
   category: 'Pie Charts',
   inputs: [
     inputs.dataset,
-    inputs.measure,
+    { ...inputs.measure, inputs: [...inputs.measure.inputs, subInputs.showValueAsPercentage] },
     inputs.dimension,
     inputs.title,
     inputs.description,

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -14,8 +14,9 @@ const PieChartPro = (props: PieChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
+  const { description, title } = resolveI18nProps(props);
+
   const {
-    description,
     dimension,
     maxLegendItems,
     measure,
@@ -23,9 +24,8 @@ const PieChartPro = (props: PieChartProProps) => {
     showLegend,
     showTooltips,
     showValueLabels,
-    title,
     onSegmentClick,
-  } = resolveI18nProps(props);
+  } = props;
 
   const { hideMenu } = props;
 

--- a/src/components/charts/pies/pies.types.ts
+++ b/src/components/charts/pies/pies.types.ts
@@ -9,6 +9,7 @@ export type DefaultPieChartProps = {
   showLegend?: boolean;
   showTooltips?: boolean;
   showValueLabels?: boolean;
+  showValueLabelsAsPercentage?: boolean;
 
   onSegmentClick?: (args: { dimensionValue: string | null }) => void;
 } & ChartCardHeaderProps;

--- a/src/components/charts/pies/pies.utils.test.ts
+++ b/src/components/charts/pies/pies.utils.test.ts
@@ -30,6 +30,10 @@ vi.mock('../../../theme/i18n/i18n', () => ({
 
 vi.mock('../charts.utils', () => ({
   groupTailAsOther: vi.fn((data: unknown[]) => data),
+  getDatalabelPercentage: vi.fn((value: number, data: number[]) => {
+    const total = data.reduce((sum, v) => sum + v, 0);
+    return `${Math.round((value / total) * 100)}%`;
+  }),
 }));
 
 // -- helpers -----------------------------------------------------------------

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -87,7 +87,7 @@ export const getPieChartProOptions = (
       legend: { position: theme.charts.legendPosition ?? 'bottom' },
       datalabels: {
         formatter: (value: string | number, context) => {
-          if (measure.inputs?.showValuesAsPercentage) {
+          if (measure.inputs?.showValueAsPercentage) {
             return getDatalabelPercentage(Number(value), context.dataset.data);
           }
           return themeFormatter.data(measure, value);

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -1,6 +1,6 @@
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { ChartData, ChartOptions } from 'chart.js';
-import { groupTailAsOther } from '../charts.utils';
+import { getDatalabelPercentage, groupTailAsOther } from '../charts.utils';
 import { Theme } from '../../../theme/theme.types';
 import { remarkableTheme } from '../../../theme/theme.constants';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
@@ -86,19 +86,18 @@ export const getPieChartProOptions = (
     plugins: {
       legend: { position: theme.charts.legendPosition ?? 'bottom' },
       datalabels: {
-        formatter: (value: string | number) => themeFormatter.data(measure, value),
+        formatter: (value: string | number, context) => {
+          if (measure.inputs?.showValuesAsPercentage) {
+            return getDatalabelPercentage(Number(value), context.dataset.data);
+          }
+          return themeFormatter.data(measure, value);
+        },
       },
       tooltip: {
         callbacks: {
           label(context) {
             const raw = context.raw as number;
-            const total = context.dataset.data.reduce(
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              (sum: number, v: any) => sum + parseFloat(v),
-              0,
-            );
-            const pct = Math.round((raw / total) * 100);
-            return `${themeFormatter.data(measure, raw)} (${pct}%)`;
+            return `${themeFormatter.data(measure, raw)} (${getDatalabelPercentage(raw, context.dataset.data)})`;
           },
         },
       },

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -136,6 +136,13 @@ const tableCellStyle = {
   label: 'Table cell style',
 } as const;
 
+const showValueAsPercentage = {
+  name: 'showValuesAsPercentage',
+  type: 'boolean',
+  label: 'Show values as percentage',
+  defaultValue: false,
+} as const;
+
 const showGranularityDropdown = {
   type: 'boolean',
   name: 'showGranularityDropdown',
@@ -211,4 +218,5 @@ export const subInputs = {
   displayFormat,
   tableCellStyle,
   showGranularityDropdown,
+  showValueAsPercentage,
 };

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -137,7 +137,7 @@ const tableCellStyle = {
 } as const;
 
 const showValueAsPercentage = {
-  name: 'showValuesAsPercentage',
+  name: 'showValueAsPercentage',
   type: 'boolean',
   label: 'Show values as percentage',
   defaultValue: false,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
     css: { modules: { classNameStrategy: 'non-scoped' } },
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov'],
+    },
   },
 });


### PR DESCRIPTION
# Why is this pull-request needed?

This PR improves the pie chart components, to include a showValueAsPercentage boolean subinput field on its measure.
Same goes for the simple bar charts

# Main changes

- create function getDatalabelPercentage to be reusable across chartjs components.
- update definition to include the new subinput field. 
- update pies.utils and bars.utils.

# Test evidence


https://github.com/user-attachments/assets/8ab0bbfa-8c6d-45f2-af12-e2a5f07acbbc




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Charts now support displaying values as percentages alongside raw numbers
  * Added percentage display toggle option for pie and bar chart components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->