### PR TITLE
RUI-233: markdown

### DIFF
--- a/.changeset/fair-pugs-melt.md
+++ b/.changeset/fair-pugs-melt.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+MarkdownPro component, MarkdownEditor and markdown type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.6",
         "@embeddable.com/react": "^2.13.4",
-        "@embeddable.com/remarkable-ui": "^2.0.43",
+        "@embeddable.com/remarkable-ui": "^2.0.44",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -22,8 +22,6 @@
         "fast-equals": "^6.0.0",
         "i18next": "^25.3.2",
         "mergician": "^2.0.2",
-        "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1",
         "xlsx": "npm:@e965/xlsx@^0.20.3"
       },
       "devDependencies": {
@@ -471,12 +469,12 @@
       }
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.14.tgz",
-      "integrity": "sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.1.0.tgz",
+      "integrity": "sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==",
       "license": "MIT",
       "dependencies": {
-        "@changesets/config": "^3.1.2",
+        "@changesets/config": "^3.1.3",
         "@changesets/get-version-range-type": "^0.4.0",
         "@changesets/git": "^3.0.4",
         "@changesets/should-skip-package": "^0.1.2",
@@ -530,33 +528,31 @@
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.29.8",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.29.8.tgz",
-      "integrity": "sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.30.0.tgz",
+      "integrity": "sha512-5D3Nk2JPqMI1wK25pEymeWRSlSMdo5QOGlyfrKg0AOufrUcjEE3RQgaCpHoBiM31CSNrtSgdJ0U6zL1rLDDfBA==",
       "license": "MIT",
       "dependencies": {
-        "@changesets/apply-release-plan": "^7.0.14",
+        "@changesets/apply-release-plan": "^7.1.0",
         "@changesets/assemble-release-plan": "^6.0.9",
         "@changesets/changelog-git": "^0.2.1",
-        "@changesets/config": "^3.1.2",
+        "@changesets/config": "^3.1.3",
         "@changesets/errors": "^0.2.0",
         "@changesets/get-dependents-graph": "^2.1.3",
-        "@changesets/get-release-plan": "^4.0.14",
+        "@changesets/get-release-plan": "^4.0.15",
         "@changesets/git": "^3.0.4",
         "@changesets/logger": "^0.1.1",
         "@changesets/pre": "^2.0.2",
-        "@changesets/read": "^0.6.6",
+        "@changesets/read": "^0.6.7",
         "@changesets/should-skip-package": "^0.1.2",
         "@changesets/types": "^6.1.0",
         "@changesets/write": "^0.4.0",
         "@inquirer/external-editor": "^1.0.2",
         "@manypkg/get-packages": "^1.1.3",
         "ansi-colors": "^4.1.3",
-        "ci-info": "^3.7.0",
         "enquirer": "^2.4.1",
         "fs-extra": "^7.0.1",
         "mri": "^1.2.0",
-        "p-limit": "^2.2.0",
         "package-manager-detector": "^0.2.0",
         "picocolors": "^1.1.0",
         "resolve-from": "^5.0.0",
@@ -569,14 +565,15 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.2.tgz",
-      "integrity": "sha512-CYiRhA4bWKemdYi/uwImjPxqWNpqGPNbEBdX1BdONALFIDK7MCUj6FPkzD+z9gJcvDFUQJn9aDVf4UG7OT6Kog==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.1.3.tgz",
+      "integrity": "sha512-vnXjcey8YgBn2L1OPWd3ORs0bGC4LoYcK/ubpgvzNVr53JXV5GiTVj7fWdMRsoKUH7hhhMAQnsJUqLr21EncNw==",
       "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.2.0",
         "@changesets/get-dependents-graph": "^2.1.3",
         "@changesets/logger": "^0.1.1",
+        "@changesets/should-skip-package": "^0.1.2",
         "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
@@ -605,15 +602,15 @@
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.14.tgz",
-      "integrity": "sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.15.tgz",
+      "integrity": "sha512-Q04ZaRPuEVZtA+auOYgFaVQQSA98dXiVe/yFaZfY7hoSmQICHGvP0TF4u3EDNHWmmCS4ekA/XSpKlSM2PyTS2g==",
       "license": "MIT",
       "dependencies": {
         "@changesets/assemble-release-plan": "^6.0.9",
-        "@changesets/config": "^3.1.2",
+        "@changesets/config": "^3.1.3",
         "@changesets/pre": "^2.0.2",
-        "@changesets/read": "^0.6.6",
+        "@changesets/read": "^0.6.7",
         "@changesets/types": "^6.1.0",
         "@manypkg/get-packages": "^1.1.3"
       }
@@ -647,9 +644,9 @@
       }
     },
     "node_modules/@changesets/parse": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.2.tgz",
-      "integrity": "sha512-Uo5MC5mfg4OM0jU3up66fmSn6/NE9INK+8/Vn/7sMVcdWg46zfbvvUSjD9EMonVqPi9fbrJH9SXHn48Tr1f2yA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.4.3.tgz",
+      "integrity": "sha512-ZDmNc53+dXdWEv7fqIUSgRQOLYoUom5Z40gmLgmATmYR9NbL6FJJHwakcCpzaeCy+1D0m0n7mT4jj2B/MQPl7A==",
       "license": "MIT",
       "dependencies": {
         "@changesets/types": "^6.1.0",
@@ -669,14 +666,14 @@
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.6.tgz",
-      "integrity": "sha512-P5QaN9hJSQQKJShzzpBT13FzOSPyHbqdoIBUd2DJdgvnECCyO6LmAOWSV+O8se2TaZJVwSXjL+v9yhb+a9JeJg==",
+      "version": "0.6.7",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.7.tgz",
+      "integrity": "sha512-D1G4AUYGrBEk8vj8MGwf75k9GpN6XL3wg8i42P2jZZwFLXnlr2Pn7r9yuQNbaMCarP7ZQWNJbV6XLeysAIMhTA==",
       "license": "MIT",
       "dependencies": {
         "@changesets/git": "^3.0.4",
         "@changesets/logger": "^0.1.1",
-        "@changesets/parse": "^0.4.2",
+        "@changesets/parse": "^0.4.3",
         "@changesets/types": "^6.1.0",
         "fs-extra": "^7.0.1",
         "p-filter": "^2.1.0",
@@ -822,9 +819,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.28",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
-      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "version": "1.0.29",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.29.tgz",
+      "integrity": "sha512-jx9GjkkP5YHuTmko2eWAvpPnb0mB4mGRr2U7XwVNwevm8nlpobZEVk+GNmiYMk2VuA75v+plfXWyroWKmICZXg==",
       "dev": true,
       "funding": [
         {
@@ -888,9 +885,9 @@
       }
     },
     "node_modules/@embeddable.com/react": {
-      "version": "2.13.4",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.13.4.tgz",
-      "integrity": "sha512-ZrjRm8rL1y4X10cTlbD5Q0GbrlEmqSUlD/rmQ9NI5ECXRrNmmiVPHg3NITsNejtnk8qoZGPz1iUq44gLZBQpHg==",
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.13.5.tgz",
+      "integrity": "sha512-63yGki/V5UBbgDrApOhcX9haBSTeyNPHPLEO78xSZDb3LB59SJ9JZ5xttOpLHwkulO+Z2Y7kThWmDC+u0BLoVA==",
       "license": "MIT",
       "dependencies": {
         "@embeddable.com/core": "2.13.6"
@@ -900,9 +897,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "2.0.43",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.43.tgz",
-      "integrity": "sha512-Slwh7c03FTCHBeDLr08s3MpW3YPfMEu3p6l/kbbpU5p+ooPtSrtpztDHpX6UJQlQJuoyLfiSI/nMdV4r1hevcQ==",
+      "version": "2.0.44",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-2.0.44.tgz",
+      "integrity": "sha512-jrpXc4nijlmtYmRU7EOhz+eN4IDhsXa/wW6Fz9H89xrbptlp4h/lrQH9XRZGkydA3WsY9jCRNdbM5N7SEtvEjQ==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -916,7 +913,9 @@
         "dayjs": "^1.11.19",
         "mergician": "^2.0.2",
         "react-chartjs-2": "^5.3.0",
-        "react-day-picker": "^9.12.0"
+        "react-day-picker": "^9.12.0",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -928,9 +927,9 @@
       }
     },
     "node_modules/@embeddable.com/sdk-core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.2.0.tgz",
-      "integrity": "sha512-/YTvk7T5pFZhpMUU7X8pi3Kt86+m9PJUBfVbP3xwg8a0lPgSezuEmJ/dppxIrFQTFGBDlsf8y5+R8q9xehC2Iw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.3.1.tgz",
+      "integrity": "sha512-SnX6O1ALYSsDlSnCFoRwYQvB0E6vZjCgXrLgcbFweeySeWC3Oi3feV6hLfmZZsBFym2Mz/DXYowQy4UCjGroWA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -988,6 +987,49 @@
         "ora": "^8.0.1",
         "vite": "^6.2.2",
         "zod": "^3.24.2"
+      }
+    },
+    "node_modules/@embeddable.com/sdk-react/node_modules/@embeddable.com/sdk-core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.2.0.tgz",
+      "integrity": "sha512-/YTvk7T5pFZhpMUU7X8pi3Kt86+m9PJUBfVbP3xwg8a0lPgSezuEmJ/dppxIrFQTFGBDlsf8y5+R8q9xehC2Iw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@embeddable.com/core": "2.13.6",
+        "@embeddable.com/sdk-utils": "0.9.0",
+        "@inquirer/prompts": "^7.2.1",
+        "@stencil/core": "^4.23.0",
+        "@swc-node/register": "^1.10.9",
+        "axios": "^1.7.9",
+        "chokidar": "^4.0.3",
+        "dotenv": "^16.4.7",
+        "fast-glob": "^3.3.2",
+        "finalhandler": "^1.3.1",
+        "formdata-node": "^6.0.3",
+        "minimist": "^1.2.8",
+        "open": "^10.1.2",
+        "ora": "^8.1.1",
+        "serve-static": "^1.16.2",
+        "sorcery": "^1.0.0",
+        "vite": "^6.2.2",
+        "ws": "^8.18.0",
+        "yaml": "^2.6.1",
+        "yazl": "^2.5.1"
+      },
+      "bin": {
+        "embeddable": "bin/embeddable"
+      },
+      "engines": {
+        "node": ">=20.1.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@embeddable.com/sdk-utils": {
@@ -1734,31 +1776,31 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
-      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
-      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.4",
-        "@floating-ui/utils": "^0.2.10"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
-      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.5"
+        "@floating-ui/dom": "^1.7.6"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -1766,20 +1808,20 @@
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
-      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
     },
     "node_modules/@happy-dom/global-registrator": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.7.0.tgz",
-      "integrity": "sha512-JdsfSUVeWDP8klYL4y4C4Fae0nAv2V/2W+gHhdiuktyKGZvbSZfJpsk4loakPhTtxt91KHdDroXCCZcFIJrfYQ==",
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.8.3.tgz",
+      "integrity": "sha512-9z6lLr6K6dIFLiB9jI0tKTlYzCComn5RL7L1mN3EdMSCyRQB8I6A0FO/On8yYKkXuunexzPDC98zDflvv2wDrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
-        "happy-dom": "^20.7.0"
+        "happy-dom": "^20.8.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2361,9 +2403,9 @@
       }
     },
     "node_modules/@oxc-resolver/binding-android-arm-eabi": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.18.0.tgz",
-      "integrity": "sha512-EhwJNzbfLwQQIeyak3n08EB3UHknMnjy1dFyL98r3xlorje2uzHOT2vkB5nB1zqtTtzT31uSot3oGZFfODbGUg==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm-eabi/-/binding-android-arm-eabi-11.19.1.tgz",
+      "integrity": "sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==",
       "cpu": [
         "arm"
       ],
@@ -2375,9 +2417,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-android-arm64": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.18.0.tgz",
-      "integrity": "sha512-esOPsT9S9B6vEMMp1qR9Yz5UepQXljoWRJYoyp7GV/4SYQOSTpN0+V2fTruxbMmzqLK+fjCEU2x3SVhc96LQLQ==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-android-arm64/-/binding-android-arm64-11.19.1.tgz",
+      "integrity": "sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==",
       "cpu": [
         "arm64"
       ],
@@ -2389,9 +2431,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-darwin-arm64": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.18.0.tgz",
-      "integrity": "sha512-iJknScn8fRLRhGR6VHG31bzOoyLihSDmsJHRjHwRUL0yF1MkLlvzmZ+liKl9MGl+WZkZHaOFT5T1jNlLSWTowQ==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-arm64/-/binding-darwin-arm64-11.19.1.tgz",
+      "integrity": "sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==",
       "cpu": [
         "arm64"
       ],
@@ -2403,9 +2445,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-darwin-x64": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.18.0.tgz",
-      "integrity": "sha512-3rMweF2GQLzkaUoWgFKy1fRtk0dpj4JDqucoZLJN9IZG+TC+RZg7QMwG5WKMvmEjzdYmOTw1L1XqZDVXF2ksaQ==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-darwin-x64/-/binding-darwin-x64-11.19.1.tgz",
+      "integrity": "sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==",
       "cpu": [
         "x64"
       ],
@@ -2417,9 +2459,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-freebsd-x64": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.18.0.tgz",
-      "integrity": "sha512-TfXsFby4QvpGwmUP66+X+XXQsycddZe9ZUUu/vHhq2XGI1EkparCSzjpYW1Nz5fFncbI5oLymQLln/qR+qxyOw==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-freebsd-x64/-/binding-freebsd-x64-11.19.1.tgz",
+      "integrity": "sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==",
       "cpu": [
         "x64"
       ],
@@ -2431,9 +2473,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm-gnueabihf": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.18.0.tgz",
-      "integrity": "sha512-WolOILquy9DJsHcfFMHeA5EjTCI9A7JoERFJru4UI2zKZcnfNPo5GApzYwiloscEp/s+fALPmyRntswUns0qHg==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-11.19.1.tgz",
+      "integrity": "sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==",
       "cpu": [
         "arm"
       ],
@@ -2445,9 +2487,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm-musleabihf": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.18.0.tgz",
-      "integrity": "sha512-r+5nHJyPdiBqOGTYAFyuq5RtuAQbm4y69GYWNG/uup9Cqr7RG9Ak0YZgGEbkQsc+XBs00ougu/D1+w3UAYIWHA==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-11.19.1.tgz",
+      "integrity": "sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==",
       "cpu": [
         "arm"
       ],
@@ -2459,9 +2501,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-gnu": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.18.0.tgz",
-      "integrity": "sha512-bUzg6QxljqMLLwsxYajAQEHW1LYRLdKOg/aykt14PSqUUOmfnOJjPdSLTiHIZCluVzPCQxv1LjoyRcoTAXfQaQ==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-11.19.1.tgz",
+      "integrity": "sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==",
       "cpu": [
         "arm64"
       ],
@@ -2473,9 +2515,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-arm64-musl": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.18.0.tgz",
-      "integrity": "sha512-l43GVwls5+YR8WXOIez5x7Pp/MfhdkMOZOOjFUSWC/9qMnSLX1kd95j9oxDrkWdD321JdHTyd4eau5KQPxZM9w==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-arm64-musl/-/binding-linux-arm64-musl-11.19.1.tgz",
+      "integrity": "sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==",
       "cpu": [
         "arm64"
       ],
@@ -2487,9 +2529,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-ppc64-gnu": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.18.0.tgz",
-      "integrity": "sha512-ayj7TweYWi/azxWmRpUZGz41kKNvfkXam20UrFhaQDrSNGNqefQRODxhJn0iv6jt4qChh7TUxDIoavR6ftRsjw==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-11.19.1.tgz",
+      "integrity": "sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2501,9 +2543,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-gnu": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.18.0.tgz",
-      "integrity": "sha512-2Jz7jpq6BBNlBBup3usZB6sZWEZOBbjWn++/bKC2lpAT+sTEwdTonnf3rNcb+XY7+v53jYB9pM8LEKVXZfr8BA==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-11.19.1.tgz",
+      "integrity": "sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==",
       "cpu": [
         "riscv64"
       ],
@@ -2515,9 +2557,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-riscv64-musl": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.18.0.tgz",
-      "integrity": "sha512-omw8/ISOc6ubR247iEMma4/JRfbY2I+nGJC59oKBhCIEZoyqEg/NmDSBc4ToMH+AsZDucqQUDOCku3k7pBiEag==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-11.19.1.tgz",
+      "integrity": "sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==",
       "cpu": [
         "riscv64"
       ],
@@ -2529,9 +2571,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-s390x-gnu": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.18.0.tgz",
-      "integrity": "sha512-uFipBXaS+honSL5r5G/rlvVrkffUjpKwD3S/aIiwp64bylK3+RztgV+mM1blk+OT5gBRG864auhH6jCfrOo3ZA==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-11.19.1.tgz",
+      "integrity": "sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==",
       "cpu": [
         "s390x"
       ],
@@ -2543,9 +2585,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-x64-gnu": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.18.0.tgz",
-      "integrity": "sha512-bY4uMIoKRv8Ine3UiKLFPWRZ+fPCDamTHZFf5pNOjlfmTJIANtJo0mzWDUdFZLYhVgQdegrDL9etZbTMR8qieg==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-gnu/-/binding-linux-x64-gnu-11.19.1.tgz",
+      "integrity": "sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==",
       "cpu": [
         "x64"
       ],
@@ -2557,9 +2599,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-linux-x64-musl": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.18.0.tgz",
-      "integrity": "sha512-40IicL/aitfNOWur06x7Do41WcqFJ9VUNAciFjZCXzF6wR2i6uVsi6N19ecqgSRoLYFCAoRYi9F50QteIxCwKQ==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-linux-x64-musl/-/binding-linux-x64-musl-11.19.1.tgz",
+      "integrity": "sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==",
       "cpu": [
         "x64"
       ],
@@ -2571,9 +2613,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-openharmony-arm64": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.18.0.tgz",
-      "integrity": "sha512-DJIzYjUnSJtz4Trs/J9TnzivtPcUKn9AeL3YjHlM5+RvK27ZL9xISs3gg2VAo2nWU7ThuadC1jSYkWaZyONMwg==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-openharmony-arm64/-/binding-openharmony-arm64-11.19.1.tgz",
+      "integrity": "sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==",
       "cpu": [
         "arm64"
       ],
@@ -2585,9 +2627,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-wasm32-wasi": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.18.0.tgz",
-      "integrity": "sha512-57+R8Ioqc8g9k80WovoupOoyIOfLEceHTizkUcwOXspXLhiZ67ScM7Q8OuvhDoRRSZzH6yI0qML3WZwMFR3s7g==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-wasm32-wasi/-/binding-wasm32-wasi-11.19.1.tgz",
+      "integrity": "sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==",
       "cpu": [
         "wasm32"
       ],
@@ -2602,9 +2644,9 @@
       }
     },
     "node_modules/@oxc-resolver/binding-win32-arm64-msvc": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.18.0.tgz",
-      "integrity": "sha512-t9Oa4BPptJqVlHTT1cV1frs+LY/vjsKhHI6ltj2EwoGM1TykJ0WW43UlQaU4SC8N+oTY8JRbAywVMNkfqjSu9w==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-11.19.1.tgz",
+      "integrity": "sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==",
       "cpu": [
         "arm64"
       ],
@@ -2616,9 +2658,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-win32-ia32-msvc": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.18.0.tgz",
-      "integrity": "sha512-4maf/f6ea5IEtIXqGwSw38srRtVHTre9iKShG4gjzat7c3Iq6B1OppXMj8gNmTuM4n8Xh1hQM9z2hBELccJr1g==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-11.19.1.tgz",
+      "integrity": "sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==",
       "cpu": [
         "ia32"
       ],
@@ -2630,9 +2672,9 @@
       ]
     },
     "node_modules/@oxc-resolver/binding-win32-x64-msvc": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.18.0.tgz",
-      "integrity": "sha512-EhW8Su3AEACSw5HfzKMmyCtV0oArNrVViPdeOfvVYL9TrkL+/4c8fWHFTBtxUMUyCjhSG5xYNdwty1D/TAgL0Q==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/@oxc-resolver/binding-win32-x64-msvc/-/binding-win32-x64-msvc-11.19.1.tgz",
+      "integrity": "sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==",
       "cpu": [
         "x64"
       ],
@@ -3611,9 +3653,9 @@
       "license": "MIT"
     },
     "node_modules/@stencil/core": {
-      "version": "4.43.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.1.tgz",
-      "integrity": "sha512-sohOiS8XMJXQnMsxhCgT6Ex8Kl0e0PAzDH9ExYXpDn/5Wo5rliSmABkqU9/dz/l945O/mpeG10rn6jToZJFjKQ==",
+      "version": "4.43.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.2.tgz",
+      "integrity": "sha512-hOprMw/n1fyu5OOtZG7N8sqiKxPshR1oss/y1qr6r98cVV9NcVoCMz2x2TT2enkHan6pCMpiQgUU7vmN90lIVw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3696,9 +3738,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.13.tgz",
-      "integrity": "sha512-0l1gl/72PErwUZuavcRpRAQN9uSst+Nk++niC5IX6lmMWpXoScYx3oq/narT64/sKv/eRiPTaAjBFGDEQiWJIw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.18.tgz",
+      "integrity": "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3715,16 +3757,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.13",
-        "@swc/core-darwin-x64": "1.15.13",
-        "@swc/core-linux-arm-gnueabihf": "1.15.13",
-        "@swc/core-linux-arm64-gnu": "1.15.13",
-        "@swc/core-linux-arm64-musl": "1.15.13",
-        "@swc/core-linux-x64-gnu": "1.15.13",
-        "@swc/core-linux-x64-musl": "1.15.13",
-        "@swc/core-win32-arm64-msvc": "1.15.13",
-        "@swc/core-win32-ia32-msvc": "1.15.13",
-        "@swc/core-win32-x64-msvc": "1.15.13"
+        "@swc/core-darwin-arm64": "1.15.18",
+        "@swc/core-darwin-x64": "1.15.18",
+        "@swc/core-linux-arm-gnueabihf": "1.15.18",
+        "@swc/core-linux-arm64-gnu": "1.15.18",
+        "@swc/core-linux-arm64-musl": "1.15.18",
+        "@swc/core-linux-x64-gnu": "1.15.18",
+        "@swc/core-linux-x64-musl": "1.15.18",
+        "@swc/core-win32-arm64-msvc": "1.15.18",
+        "@swc/core-win32-ia32-msvc": "1.15.18",
+        "@swc/core-win32-x64-msvc": "1.15.18"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -3736,9 +3778,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.13.tgz",
-      "integrity": "sha512-ztXusRuC5NV2w+a6pDhX13CGioMLq8CjX5P4XgVJ21ocqz9t19288Do0y8LklplDtwcEhYGTNdMbkmUT7+lDTg==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.18.tgz",
+      "integrity": "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ==",
       "cpu": [
         "arm64"
       ],
@@ -3754,9 +3796,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.13.tgz",
-      "integrity": "sha512-cVifxQUKhaE7qcO/y9Mq6PEhoyvN9tSLzCnnFZ4EIabFHBuLtDDO6a+vLveOy98hAs5Qu1+bb5Nv0oa1Pihe3Q==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.18.tgz",
+      "integrity": "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg==",
       "cpu": [
         "x64"
       ],
@@ -3772,9 +3814,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.13.tgz",
-      "integrity": "sha512-t+xxEzZ48enl/wGGy7SRYd7kImWQ/+wvVFD7g5JZo234g6/QnIgZ+YdfIyjHB+ZJI3F7a2IQHS7RNjxF29UkWw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.18.tgz",
+      "integrity": "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw==",
       "cpu": [
         "arm"
       ],
@@ -3790,9 +3832,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.13.tgz",
-      "integrity": "sha512-VndeGvKmTXFn6AGwjy0Kg8i7HccOCE7Jt/vmZwRxGtOfNZM1RLYRQ7MfDLo6T0h1Bq6eYzps3L5Ma4zBmjOnOg==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.18.tgz",
+      "integrity": "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg==",
       "cpu": [
         "arm64"
       ],
@@ -3808,9 +3850,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.13.tgz",
-      "integrity": "sha512-SmZ9m+XqCB35NddHCctvHFLqPZDAs5j8IgD36GoutufDJmeq2VNfgk5rQoqNqKmAK3Y7iFdEmI76QoHIWiCLyw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.18.tgz",
+      "integrity": "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw==",
       "cpu": [
         "arm64"
       ],
@@ -3826,9 +3868,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.13.tgz",
-      "integrity": "sha512-5rij+vB9a29aNkHq72EXI2ihDZPszJb4zlApJY4aCC/q6utgqFA6CkrfTfIb+O8hxtG3zP5KERETz8mfFK6A0A==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.18.tgz",
+      "integrity": "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA==",
       "cpu": [
         "x64"
       ],
@@ -3844,9 +3886,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.13.tgz",
-      "integrity": "sha512-OlSlaOK9JplQ5qn07WiBLibkOw7iml2++ojEXhhR3rbWrNEKCD7sd8+6wSavsInyFdw4PhLA+Hy6YyDBIE23Yw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.18.tgz",
+      "integrity": "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g==",
       "cpu": [
         "x64"
       ],
@@ -3862,9 +3904,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.13.tgz",
-      "integrity": "sha512-zwQii5YVdsfG8Ti9gIKgBKZg8qMkRZxl+OlYWUT5D93Jl4NuNBRausP20tfEkQdAPSRrMCSUZBM6FhW7izAZRg==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.18.tgz",
+      "integrity": "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ==",
       "cpu": [
         "arm64"
       ],
@@ -3880,9 +3922,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.13.tgz",
-      "integrity": "sha512-hYXvyVVntqRlYoAIDwNzkS3tL2ijP3rxyWQMNKaxcCxxkCDto/w3meOK/OB6rbQSkNw0qTUcBfU9k+T0ptYdfQ==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.18.tgz",
+      "integrity": "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg==",
       "cpu": [
         "ia32"
       ],
@@ -3898,9 +3940,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.13",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.13.tgz",
-      "integrity": "sha512-XTzKs7c/vYCcjmcwawnQvlHHNS1naJEAzcBckMI5OJlnrcgW8UtcX9NHFYvNjGtXuKv0/9KvqL4fuahdvlNGKw==",
+      "version": "1.15.18",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.18.tgz",
+      "integrity": "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg==",
       "cpu": [
         "x64"
       ],
@@ -3934,10 +3976,19 @@
         "@swc/counter": "^0.1.3"
       }
     },
+    "node_modules/@tabby_ai/hijri-converter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@tabby_ai/hijri-converter/-/hijri-converter-1.0.5.tgz",
+      "integrity": "sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/@tabler/icons": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.37.1.tgz",
-      "integrity": "sha512-neLCWkuyNHEPXCyYu6nbN4S3g/59BTa4qyITAugYVpq1YzYNDOZooW7/vRWH98ZItXAudxdKU8muFT7y1PqzuA==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.38.0.tgz",
+      "integrity": "sha512-FdETQSpQ3lN7BEjEUzjKhsfTDCamrvMDops4HEMphTm3DmkIFpThoODn8XXZ8Q9MhjshIvphIYVHHB7zpq167w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3945,12 +3996,12 @@
       }
     },
     "node_modules/@tabler/icons-react": {
-      "version": "3.37.1",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.37.1.tgz",
-      "integrity": "sha512-R7UE71Jji7i4Su56Y9zU1uYEBakUejuDJvyuYVmBuUoqp/x3Pn4cv2huarexR3P0GJ2eHg4rUj9l5zccqS6K/Q==",
+      "version": "3.38.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.38.0.tgz",
+      "integrity": "sha512-kR5wv+m4+GgmnSszg3rQd6SrTFAQ/XnQC/yTwIfuRJSfqB12KoIC7fPbIijFgOHTFlBN5DARnN0IVrR7KYG6/A==",
       "license": "MIT",
       "dependencies": {
-        "@tabler/icons": ""
+        "@tabler/icons": "3.38.0"
       },
       "funding": {
         "type": "github",
@@ -4288,9 +4339,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4538,9 +4589,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4551,9 +4602,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
-      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4679,43 +4730,6 @@
         }
       }
     },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/coverage-v8/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -4732,6 +4746,47 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/mocker": {
@@ -4762,26 +4817,14 @@
         }
       }
     },
-    "node_modules/@vitest/mocker/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4801,43 +4844,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/@vitest/runner/node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/runner/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@vitest/snapshot": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
@@ -4851,29 +4857,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/@vitest/snapshot/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@vitest/spy": {
@@ -4891,16 +4874,14 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -4919,6 +4900,13 @@
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
       }
+    },
+    "node_modules/@vue/compiler-core/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
       "version": "3.5.29",
@@ -4948,6 +4936,13 @@
         "postcss": "^8.5.6",
         "source-map-js": "^1.2.1"
       }
+    },
+    "node_modules/@vue/compiler-sfc/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
       "version": "3.5.29",
@@ -5292,25 +5287,15 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
-      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.31",
         "estree-walker": "^3.0.3",
         "js-tokens": "^10.0.0"
-      }
-    },
-    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
       }
     },
     "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
@@ -5373,9 +5358,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5720,9 +5705,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001774",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001774.tgz",
-      "integrity": "sha512-DDdwPGz99nmIEv216hKSgLD+D4ikHQHjBC/seF98N9CPqRX4M5mSxT9eTV6oyisnJcuzxtZy4n17yKKQYmYQOA==",
+      "version": "1.0.30001776",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001776.tgz",
+      "integrity": "sha512-sg01JDPzZ9jGshqKSckOQthXnYwOEP50jeVFhaSFbZcOy05TiuuaffDOfcwtCisJ9kNQuLBFibYywv2Bgm9osw==",
       "dev": true,
       "funding": [
         {
@@ -5894,21 +5879,6 @@
       "integrity": "sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==",
       "license": "(BSD-3-Clause AND Apache-2.0)"
     },
-    "node_modules/ci-info": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -5939,14 +5909,14 @@
       }
     },
     "node_modules/cli-truncate": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.1.1.tgz",
-      "integrity": "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "slice-ansi": "^7.1.0",
-        "string-width": "^8.0.0"
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
       },
       "engines": {
         "node": ">=20"
@@ -6109,13 +6079,13 @@
       "peer": true
     },
     "node_modules/cssstyle": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
-      "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.0.0",
+        "@asamuzakjp/css-color": "^5.0.1",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
         "css-tree": "^3.1.0",
         "lru-cache": "^11.2.6"
@@ -6418,14 +6388,14 @@
       }
     },
     "node_modules/dependency-tree": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.3.0.tgz",
-      "integrity": "sha512-T893F3p48rblazo45S/5jkFEvU8mzZ8obtNSyP2S1QCA8e9PpVH+hIakHnQYdnhitwQ8wo9btYJpQxnjiGm0Qg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/dependency-tree/-/dependency-tree-11.4.0.tgz",
+      "integrity": "sha512-r4wZ1pfv8eQrnoWbIGdrJTVmlb0dkXdwBjKsotKO4gmfqrOsAMG+0+cfA5EZ3NO8umc85twXOl1eO27E5pjTzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
-        "filing-cabinet": "^5.1.0",
+        "filing-cabinet": "^5.2.0",
         "precinct": "^12.2.0",
         "typescript": "^5.9.3"
       },
@@ -6710,9 +6680,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.302.tgz",
-      "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
+      "version": "1.5.307",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
+      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
       "dev": true,
       "license": "ISC"
     },
@@ -6734,9 +6704,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.19.0.tgz",
-      "integrity": "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz",
+      "integrity": "sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7444,11 +7414,14 @@
       }
     },
     "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -7587,17 +7560,17 @@
       }
     },
     "node_modules/filing-cabinet": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.1.0.tgz",
-      "integrity": "sha512-xA3nKuR0N762AtUloSEbq4T+tOqNf1rZ3vgPW8Sijurqz9rvArjTpZhfrV1OxSrhX6OUoDGAONXo6liKZTNXKQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.2.0.tgz",
+      "integrity": "sha512-eNrCJGdYQY0tV+ACNesQ7vb2aMxD76NM7THayMn0Z5XBt1Tonr4vbVN+FbhHfekKGQG9O5UaciDDR7+dw8P9ZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "app-module-path": "^2.2.0",
         "commander": "^12.1.0",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.20.0",
         "module-definition": "^6.0.1",
-        "module-lookup-amd": "^9.1.0",
+        "module-lookup-amd": "^9.1.1",
         "resolve": "^1.22.11",
         "resolve-dependency-path": "^4.0.1",
         "sass-lookup": "^6.1.0",
@@ -7719,9 +7692,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
+      "integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
       "dev": true,
       "license": "ISC"
     },
@@ -8102,9 +8075,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.7.0",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.7.0.tgz",
-      "integrity": "sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==",
+      "version": "20.8.3",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.3.tgz",
+      "integrity": "sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9360,19 +9333,18 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.2.7",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.7.tgz",
-      "integrity": "sha512-lDIj4RnYmK7/kXMya+qJsmkRFkGolciXjrsZ6PC25GdTfWOAWetR0ZbsNXRAj1EHHImRSalc+whZFg56F5DVow==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.3.1.tgz",
+      "integrity": "sha512-bqvvquXzFBAlSbluugR4KXAe4XnO/QZcKVszpkBtqLWa2KEiVy8n6Xp38OeUbv/gOJOX4Vo9u5pFt/ADvbm42Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "commander": "^14.0.2",
+        "commander": "^14.0.3",
         "listr2": "^9.0.5",
         "micromatch": "^4.0.8",
-        "nano-spawn": "^2.0.0",
-        "pidtree": "^0.6.0",
         "string-argv": "^0.3.2",
-        "yaml": "^2.8.1"
+        "tinyexec": "^1.0.2",
+        "yaml": "^2.8.2"
       },
       "bin": {
         "lint-staged": "bin/lint-staged.js"
@@ -9447,13 +9419,13 @@
       }
     },
     "node_modules/listr2/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -9594,6 +9566,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/log-update/node_modules/string-width": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
@@ -9613,13 +9602,13 @@
       }
     },
     "node_modules/log-update/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -10873,9 +10862,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -10963,19 +10952,6 @@
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/nano-spawn": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-2.0.0.tgz",
-      "integrity": "sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.17"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
       }
     },
     "node_modules/nanoid": {
@@ -11307,13 +11283,13 @@
       }
     },
     "node_modules/ora/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -11347,35 +11323,35 @@
       }
     },
     "node_modules/oxc-resolver": {
-      "version": "11.18.0",
-      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.18.0.tgz",
-      "integrity": "sha512-Fv/b05AfhpYoCDvsog6tgsDm2yIwIeJafpMFLncNwKHRYu+Y1xQu5Q/rgUn7xBfuhNgjtPO7C0jCf7p2fLDj1g==",
+      "version": "11.19.1",
+      "resolved": "https://registry.npmjs.org/oxc-resolver/-/oxc-resolver-11.19.1.tgz",
+      "integrity": "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==",
       "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       },
       "optionalDependencies": {
-        "@oxc-resolver/binding-android-arm-eabi": "11.18.0",
-        "@oxc-resolver/binding-android-arm64": "11.18.0",
-        "@oxc-resolver/binding-darwin-arm64": "11.18.0",
-        "@oxc-resolver/binding-darwin-x64": "11.18.0",
-        "@oxc-resolver/binding-freebsd-x64": "11.18.0",
-        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.18.0",
-        "@oxc-resolver/binding-linux-arm-musleabihf": "11.18.0",
-        "@oxc-resolver/binding-linux-arm64-gnu": "11.18.0",
-        "@oxc-resolver/binding-linux-arm64-musl": "11.18.0",
-        "@oxc-resolver/binding-linux-ppc64-gnu": "11.18.0",
-        "@oxc-resolver/binding-linux-riscv64-gnu": "11.18.0",
-        "@oxc-resolver/binding-linux-riscv64-musl": "11.18.0",
-        "@oxc-resolver/binding-linux-s390x-gnu": "11.18.0",
-        "@oxc-resolver/binding-linux-x64-gnu": "11.18.0",
-        "@oxc-resolver/binding-linux-x64-musl": "11.18.0",
-        "@oxc-resolver/binding-openharmony-arm64": "11.18.0",
-        "@oxc-resolver/binding-wasm32-wasi": "11.18.0",
-        "@oxc-resolver/binding-win32-arm64-msvc": "11.18.0",
-        "@oxc-resolver/binding-win32-ia32-msvc": "11.18.0",
-        "@oxc-resolver/binding-win32-x64-msvc": "11.18.0"
+        "@oxc-resolver/binding-android-arm-eabi": "11.19.1",
+        "@oxc-resolver/binding-android-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-arm64": "11.19.1",
+        "@oxc-resolver/binding-darwin-x64": "11.19.1",
+        "@oxc-resolver/binding-freebsd-x64": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-arm64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1",
+        "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-gnu": "11.19.1",
+        "@oxc-resolver/binding-linux-x64-musl": "11.19.1",
+        "@oxc-resolver/binding-openharmony-arm64": "11.19.1",
+        "@oxc-resolver/binding-wasm32-wasi": "11.19.1",
+        "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1",
+        "@oxc-resolver/binding-win32-x64-msvc": "11.19.1"
       }
     },
     "node_modules/p-filter": {
@@ -11598,19 +11574,6 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
-    "node_modules/pidtree": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-      "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pidtree": "bin/pidtree.js"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -11651,9 +11614,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
       "dev": true,
       "funding": [
         {
@@ -11806,14 +11769,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/pretty-format/node_modules/react-is": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
@@ -11841,6 +11796,13 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/property-information": {
       "version": "7.1.0",
@@ -11968,14 +11930,15 @@
       }
     },
     "node_modules/react-day-picker": {
-      "version": "9.13.2",
-      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.13.2.tgz",
-      "integrity": "sha512-IMPiXfXVIAuR5Yk58DDPBC8QKClrhdXV+Tr/alBrwrHUw0qDDYB1m5zPNuTnnPIr/gmJ4ChMxmtqPdxm8+R4Eg==",
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.14.0.tgz",
+      "integrity": "sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==",
       "license": "MIT",
       "dependencies": {
         "@date-fns/tz": "^1.4.1",
+        "@tabby_ai/hijri-converter": "1.0.5",
         "date-fns": "^4.1.0",
-        "date-fns-jalali": "^4.1.0-0"
+        "date-fns-jalali": "4.1.0-0"
       },
       "engines": {
         "node": ">=18"
@@ -12001,11 +11964,12 @@
       }
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-markdown": {
       "version": "10.1.0",
@@ -13010,17 +12974,17 @@
       }
     },
     "node_modules/slice-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
-      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "is-fullwidth-code-point": "^5.0.0"
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
@@ -13771,13 +13735,13 @@
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
-      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -14165,12 +14129,11 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -14187,22 +14150,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
-      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "version": "7.0.24",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.24.tgz",
+      "integrity": "sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.23"
+        "tldts-core": "^7.0.24"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.23",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "version": "7.0.24",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.24.tgz",
+      "integrity": "sha512-pj7yygNMoMRqG7ML2SDQ0xNIOfN3IBDUcPVM2Sg6hP96oFNN2nqnzHreT3z9xLq85IWJyNTvD38O002DdOrPMw==",
       "dev": true,
       "license": "MIT"
     },
@@ -15437,39 +15400,12 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tinyrainbow": "^3.0.3"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/spy": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
       "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
-    "node_modules/vitest/node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
@@ -15484,16 +15420,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/vitest/node_modules/estree-walker": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
-      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "^1.0.0"
-      }
-    },
     "node_modules/vitest/node_modules/picomatch": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
@@ -15505,16 +15431,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/vitest/node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.6",
     "@embeddable.com/react": "^2.13.4",
-    "@embeddable.com/remarkable-ui": "^2.0.43",
+    "@embeddable.com/remarkable-ui": "^2.0.44",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",
@@ -74,8 +74,6 @@
     "fast-equals": "^6.0.0",
     "i18next": "^25.3.2",
     "mergician": "^2.0.2",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
     "xlsx": "npm:@e965/xlsx@^0.20.3"
   },
   "devDependencies": {

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.host.url=https://sonarcloud.io
 sonar.projectKey=embeddable-hq_remarkable-pro
 sonar.organization=embeddable-com
 sonar.sources=.
-sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx
+sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx, **/**emb.ts, **/**.css
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.host.url=https://sonarcloud.io
 sonar.projectKey=embeddable-hq_remarkable-pro
 sonar.organization=embeddable-com
 sonar.sources=.
-sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx, **/**emb.ts, **/**.css
+sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx, **/**emb.ts, **/**.css, **/**.definition.ts
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,6 @@ sonar.host.url=https://sonarcloud.io
 sonar.projectKey=embeddable-hq_remarkable-pro
 sonar.organization=embeddable-com
 sonar.sources=.
-sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx, **/**emb.ts, **/**.css, **/**.definition.ts
+sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx, **/**emb.ts, **/**.css, **/**definition.ts
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info

--- a/src/components/charts/tables/tables.utils.tsx
+++ b/src/components/charts/tables/tables.utils.tsx
@@ -1,6 +1,6 @@
 import { DataResponse, Dimension, DimensionOrMeasure } from '@embeddable.com/core';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
-import { CssSize, TableBodyCellWithCopy } from '@embeddable.com/remarkable-ui';
+import { CssSize, Markdown, TableBodyCellWithCopy } from '@embeddable.com/remarkable-ui';
 import { Theme } from '../../../theme/theme.types';
 import {
   getStyleNumber,
@@ -8,8 +8,6 @@ import {
   TableHeaderItem,
   TableHeaderItemAlign,
 } from '@embeddable.com/remarkable-ui';
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import { DisplayFormatTypeOptions } from '../../types/DisplayFormat.type.emb';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -102,7 +100,7 @@ export const getTableHeaders = (
               <TableBodyCellWithCopy value={value}>
                 {displayFormat === DisplayFormatTypeOptions.MARKDOWN ? (
                   // Markdown
-                  <ReactMarkdown remarkPlugins={[remarkGfm]}>{currentValue}</ReactMarkdown>
+                  <Markdown content={currentValue} />
                 ) : (
                   // JSON
                   <pre>{currentValue}</pre>

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,4 +1,5 @@
-import ColorType from '../editors/ColorEditor/Color.type.emb'; // NOSONAR
+/* istanbul ignore file */
+import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {
   dimensionMeasureSubInputs,

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -6,6 +6,7 @@ import {
   timeDimensionWithGranularitySelectFieldSubInputs,
 } from './component.subinputs.constants';
 import ComparisonPeriodType from './types/ComparisonPeriod.type.emb';
+import MarkdownType from '../editors/MarkdownEditor/Markdown.type.emb';
 
 /* -------------------- */
 /* ----- Generics ----- */
@@ -412,6 +413,15 @@ const yAxisMaxItems = {
   category: 'Axes Settings',
 } as const;
 
+const markdown = {
+  name: 'markdown',
+  type: MarkdownType,
+  label: 'Markdown',
+  description:
+    'All markdown features are supported, including tables, images, links, etc. You can also access translations using {{translation_key|fallback value}}.',
+  category: 'Component Settings',
+} as const;
+
 export const inputs = {
   boolean,
   timeRange,
@@ -460,4 +470,5 @@ export const inputs = {
   yAxisMaxItems,
   granularity,
   granularities,
+  markdown,
 } as const;

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,6 +1,4 @@
-// NOSONAR
-
-import ColorType from '../editors/ColorEditor/Color.type.emb';
+import ColorType from '../editors/ColorEditor/Color.type.emb'; // NOSONAR
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {
   dimensionMeasureSubInputs,

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,3 +1,5 @@
+// NOSONAR
+
 import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import AlignType from './types/Align.type.emb';

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -1,4 +1,5 @@
-import ColorType from '../editors/ColorEditor/Color.type.emb'; // NOSONAR
+/* istanbul ignore file */
+import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import AlignType from './types/Align.type.emb';
 import DisplayFormatType from './types/DisplayFormat.type.emb';

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -1,3 +1,5 @@
+// NOSONAR
+
 import ColorType from '../editors/ColorEditor/Color.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import AlignType from './types/Align.type.emb';

--- a/src/components/component.subinputs.constants.ts
+++ b/src/components/component.subinputs.constants.ts
@@ -1,6 +1,4 @@
-// NOSONAR
-
-import ColorType from '../editors/ColorEditor/Color.type.emb';
+import ColorType from '../editors/ColorEditor/Color.type.emb'; // NOSONAR
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import AlignType from './types/Align.type.emb';
 import DisplayFormatType from './types/DisplayFormat.type.emb';

--- a/src/components/shared/MarkdownPro/MarkdownPro.emb.ts
+++ b/src/components/shared/MarkdownPro/MarkdownPro.emb.ts
@@ -1,0 +1,9 @@
+import { defineComponent } from '@embeddable.com/react';
+import { markdownPro } from './definition';
+
+export const preview = markdownPro.preview;
+
+export const meta = markdownPro.meta;
+
+// @ts-expect-error - to be fixed in @embeddable.com/react
+export default defineComponent(markdownPro.Component, meta, markdownPro.config);

--- a/src/components/shared/MarkdownPro/MarkdownPro.module.css
+++ b/src/components/shared/MarkdownPro/MarkdownPro.module.css
@@ -1,4 +1,4 @@
-.markdownContainer {
+.container {
   height: 100%;
   width: 100%;
   overflow-y: auto;

--- a/src/components/shared/MarkdownPro/MarkdownPro.module.css
+++ b/src/components/shared/MarkdownPro/MarkdownPro.module.css
@@ -1,0 +1,5 @@
+.markdownContainer {
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
+}

--- a/src/components/shared/MarkdownPro/MarkdownPro.utils.test.ts
+++ b/src/components/shared/MarkdownPro/MarkdownPro.utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveI18nInMarkdown, resolveParagraphBreaksInMarkdown } from './MarkdownPro.utils';
+
+vi.mock('../../component.utils', () => ({
+  resolveI18nString: (key: string) => `resolved:${key}`,
+}));
+
+describe('resolveParagraphBreaksInMarkdown', () => {
+  it('returns undefined when input is undefined', () => {
+    expect(resolveParagraphBreaksInMarkdown(undefined)).toBeUndefined();
+  });
+
+  it('replaces literal \\n with actual newline', () => {
+    expect(resolveParagraphBreaksInMarkdown('line1\\nline2')).toBe('line1\nline2');
+  });
+
+  it('replaces multiple literal \\n occurrences', () => {
+    expect(resolveParagraphBreaksInMarkdown('a\\nb\\nc')).toBe('a\nb\nc');
+  });
+
+  it('leaves real newlines unchanged', () => {
+    expect(resolveParagraphBreaksInMarkdown('line1\nline2')).toBe('line1\nline2');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(resolveParagraphBreaksInMarkdown('')).toBe('');
+  });
+
+  it('returns string with no \\n unchanged', () => {
+    expect(resolveParagraphBreaksInMarkdown('hello world')).toBe('hello world');
+  });
+});
+
+describe('resolveI18nInMarkdown', () => {
+  it('replaces {{key}} placeholders with resolved i18n values', () => {
+    expect(resolveI18nInMarkdown('Hello {{name}}')).toBe('Hello resolved:name');
+  });
+
+  it('replaces multiple placeholders', () => {
+    expect(resolveI18nInMarkdown('{{greeting}} {{name}}')).toBe('resolved:greeting resolved:name');
+  });
+
+  it('leaves text without placeholders unchanged', () => {
+    expect(resolveI18nInMarkdown('no placeholders here')).toBe('no placeholders here');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(resolveI18nInMarkdown('')).toBe('');
+  });
+
+  it('does not match nested braces like {{{key}}}', () => {
+    // outer braces remain, inner key is resolved
+    expect(resolveI18nInMarkdown('{{{key}}}')).toBe('{resolved:key}');
+  });
+
+  it('does not match empty braces {{}}', () => {
+    expect(resolveI18nInMarkdown('{{  }}')).toBe('resolved:  ');
+  });
+});

--- a/src/components/shared/MarkdownPro/MarkdownPro.utils.ts
+++ b/src/components/shared/MarkdownPro/MarkdownPro.utils.ts
@@ -1,0 +1,7 @@
+import { resolveI18nString } from '../../component.utils';
+
+export const resolveI18nInMarkdown = (markdown: string): string =>
+  markdown.replaceAll(/\{\{([^{}]+)\}\}/g, (_, key) => resolveI18nString(key));
+
+export const resolveParagraphBreaksInMarkdown = (markdown?: string): string | undefined =>
+  markdown?.replaceAll(String.raw`\n`, '\n');

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -1,4 +1,6 @@
-import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react'; // NOSONAR
+// NOSONAR
+
+import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
 import Component from './index';
 import { inputs } from '../../component.inputs.constants';
 

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -1,0 +1,28 @@
+import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
+import Component from './index';
+import { inputs } from '../../component.inputs.constants';
+
+const meta = {
+  name: 'MarkdownPro',
+  label: 'Markdown',
+  category: 'Layout',
+  defaultWidth: 600,
+  defaultHeight: 300,
+  inputs: [inputs.markdown],
+} as const satisfies EmbeddedComponentMeta;
+
+const preview = definePreview(Component, {
+  markdown:
+    '# Markdown editor\n\nWrite **bold**, *italic*, and `inline code`.\n\n- Bullet lists\n- [Links](https://example.com)',
+});
+
+const props = (inputs: Inputs<typeof meta>) => ({ ...inputs });
+
+export const markdownPro = {
+  Component,
+  meta,
+  preview,
+  config: {
+    props,
+  },
+} as const;

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -1,4 +1,5 @@
-import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react'; // NOSONAR
+/* istanbul ignore file */
+import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
 import Component from './index';
 import { inputs } from '../../component.inputs.constants';
 

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -1,4 +1,4 @@
-import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
+import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react'; // NOSONAR
 import Component from './index';
 import { inputs } from '../../component.inputs.constants';
 

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -1,4 +1,3 @@
-/* istanbul ignore file */
 import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
 import Component from './index';
 import { inputs } from '../../component.inputs.constants';

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -1,6 +1,4 @@
-// NOSONAR
-
-import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
+import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react'; // NOSONAR
 import Component from './index';
 import { inputs } from '../../component.inputs.constants';
 

--- a/src/components/shared/MarkdownPro/index.test.tsx
+++ b/src/components/shared/MarkdownPro/index.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import MarkdownPro from './index';
+import { resolveParagraphBreaksInMarkdown, resolveI18nInMarkdown } from './MarkdownPro.utils';
+import { i18nSetup } from '../../../theme/i18n/i18n';
+
+const mockTheme = { colors: { primary: '#000' } };
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: () => mockTheme,
+}));
+
+vi.mock('../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  Markdown: ({ content }: { content?: string }) => (
+    <div data-testid="markdown-content">{content}</div>
+  ),
+}));
+
+vi.mock('./MarkdownPro.module.css', () => ({
+  default: { container: 'container' },
+}));
+
+vi.mock('./MarkdownPro.utils', () => ({
+  resolveParagraphBreaksInMarkdown: vi.fn((md?: string) => md),
+  resolveI18nInMarkdown: vi.fn((md: string) => `i18n:${md}`),
+}));
+
+describe('MarkdownPro', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(resolveParagraphBreaksInMarkdown).mockImplementation((md?: string) => md);
+    vi.mocked(resolveI18nInMarkdown).mockImplementation((md: string) => `i18n:${md}`);
+  });
+
+  it('calls i18nSetup with the theme', () => {
+    render(<MarkdownPro />);
+    expect(vi.mocked(i18nSetup)).toHaveBeenCalledWith(mockTheme);
+  });
+
+  it('calls resolveParagraphBreaksInMarkdown with the markdown prop', () => {
+    render(<MarkdownPro markdown={String.raw`line1\nline2`} />);
+    expect(vi.mocked(resolveParagraphBreaksInMarkdown)).toHaveBeenCalledWith(
+      String.raw`line1\nline2`,
+    );
+  });
+
+  it('calls resolveI18nInMarkdown with the paragraph-resolved result', () => {
+    vi.mocked(resolveParagraphBreaksInMarkdown).mockReturnValue('line1\nline2');
+    render(<MarkdownPro markdown={String.raw`line1\nline2`} />);
+    expect(vi.mocked(resolveI18nInMarkdown)).toHaveBeenCalledWith('line1\nline2');
+  });
+
+  it('passes the fully resolved markdown to Markdown', () => {
+    vi.mocked(resolveParagraphBreaksInMarkdown).mockReturnValue('resolved');
+    vi.mocked(resolveI18nInMarkdown).mockReturnValue('i18n:resolved');
+    render(<MarkdownPro markdown="original" />);
+    expect(screen.getByTestId('markdown-content')).toHaveTextContent('i18n:resolved');
+  });
+
+  it('does not call resolveI18nInMarkdown when markdown is undefined', () => {
+    render(<MarkdownPro />);
+    expect(vi.mocked(resolveI18nInMarkdown)).not.toHaveBeenCalled();
+  });
+
+  it('does not call resolveI18nInMarkdown when markdown is empty string', () => {
+    render(<MarkdownPro markdown="" />);
+    expect(vi.mocked(resolveI18nInMarkdown)).not.toHaveBeenCalled();
+  });
+
+  it('renders the container div', () => {
+    const { container } = render(<MarkdownPro />);
+    expect(container.firstChild).toHaveClass('container');
+  });
+});

--- a/src/components/shared/MarkdownPro/index.tsx
+++ b/src/components/shared/MarkdownPro/index.tsx
@@ -1,0 +1,33 @@
+import { useMemo } from 'react';
+import { useTheme } from '@embeddable.com/react';
+import { resolveI18nString } from '../../component.utils';
+import { i18nSetup } from '../../../theme/i18n/i18n';
+import { Theme } from '../../../theme/theme.types';
+import styles from './MarkdownPro.module.css';
+import { Markdown } from '@embeddable.com/remarkable-ui';
+
+type MarkdownProProps = {
+  markdown?: string;
+};
+
+const resolveI18nInMarkdown = (markdown: string): string =>
+  markdown.replaceAll(/\{\{([^{}]+)\}\}/g, (_, key) => resolveI18nString(key));
+
+const MarkdownPro = (props: MarkdownProProps) => {
+  const { markdown } = props;
+  const theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const resolvedMarkdown = useMemo(() => {
+    const markdownString = markdown?.replaceAll(String.raw`\n`, '\n');
+    return markdownString ? resolveI18nInMarkdown(markdownString) : markdownString;
+  }, [markdown, theme]);
+
+  return (
+    <div className={styles.markdownContainer}>
+      <Markdown content={resolvedMarkdown} />
+    </div>
+  );
+};
+
+export default MarkdownPro;

--- a/src/components/shared/MarkdownPro/index.tsx
+++ b/src/components/shared/MarkdownPro/index.tsx
@@ -1,17 +1,14 @@
 import { useMemo } from 'react';
 import { useTheme } from '@embeddable.com/react';
-import { resolveI18nString } from '../../component.utils';
 import { i18nSetup } from '../../../theme/i18n/i18n';
 import { Theme } from '../../../theme/theme.types';
 import styles from './MarkdownPro.module.css';
 import { Markdown } from '@embeddable.com/remarkable-ui';
+import { resolveI18nInMarkdown, resolveParagraphBreaksInMarkdown } from './MarkdownPro.utils';
 
 type MarkdownProProps = {
   markdown?: string;
 };
-
-const resolveI18nInMarkdown = (markdown: string): string =>
-  markdown.replaceAll(/\{\{([^{}]+)\}\}/g, (_, key) => resolveI18nString(key));
 
 const MarkdownPro = (props: MarkdownProProps) => {
   const { markdown } = props;
@@ -19,12 +16,12 @@ const MarkdownPro = (props: MarkdownProProps) => {
   i18nSetup(theme);
 
   const resolvedMarkdown = useMemo(() => {
-    const markdownString = markdown?.replaceAll(String.raw`\n`, '\n');
+    const markdownString = resolveParagraphBreaksInMarkdown(markdown);
     return markdownString ? resolveI18nInMarkdown(markdownString) : markdownString;
   }, [markdown, theme]);
 
   return (
-    <div className={styles.markdownContainer}>
+    <div className={styles.container}>
       <Markdown content={resolvedMarkdown} />
     </div>
   );

--- a/src/editors/ColorEditor/index.test.tsx
+++ b/src/editors/ColorEditor/index.test.tsx
@@ -3,7 +3,7 @@ import { vi, describe, it, expect } from 'vitest';
 import ColorInput from './index';
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({
-  ActionIcon: ({ onClick }: { onClick: () => void }) => (
+  GhostButtonIcon: ({ onClick }: { onClick: () => void }) => (
     <button onClick={onClick} data-testid="clear-button" />
   ),
 }));

--- a/src/editors/ColorEditor/index.tsx
+++ b/src/editors/ColorEditor/index.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, FC } from 'react';
 import styles from './ColorEditor.module.css';
-import { ActionIcon } from '@embeddable.com/remarkable-ui';
+import { GhostButtonIcon } from '@embeddable.com/remarkable-ui';
 import { IconX } from '@tabler/icons-react';
 
 type ColorInputProps = {
@@ -23,7 +23,7 @@ const ColorInput: FC<ColorInputProps> = ({ value, onChange }) => {
         value={color ?? '#FFFFFF'}
         onChange={(e) => onChange(e.target.value)}
       />
-      {color && <ActionIcon icon={IconX} onClick={() => onChange(undefined)} />}
+      {color && <GhostButtonIcon icon={IconX} onClick={() => onChange(undefined)} />}
     </div>
   );
 };

--- a/src/editors/MarkdownEditor/Markdown.type.emb.ts
+++ b/src/editors/MarkdownEditor/Markdown.type.emb.ts
@@ -1,0 +1,8 @@
+import { defineType } from '@embeddable.com/core';
+
+const MarkdownType = defineType('markdown', {
+  label: 'Markdown',
+  optionLabel: (value: string) => value.toUpperCase(),
+});
+
+export default MarkdownType;

--- a/src/editors/MarkdownEditor/MarkdownEditor.emb.ts
+++ b/src/editors/MarkdownEditor/MarkdownEditor.emb.ts
@@ -1,0 +1,21 @@
+import { defineEditor } from '@embeddable.com/react';
+import { Value } from '@embeddable.com/core';
+
+import Component from './index';
+import MarkdownType from './Markdown.type.emb';
+
+export const meta = {
+  name: 'MarkdownEditor',
+  label: 'Markdown editor',
+  type: MarkdownType,
+};
+
+/* @ts-expect-error - to be fixed in @embeddable.com/react */
+export default defineEditor(Component, meta, {
+  inputs: (value, setter) => {
+    return {
+      value,
+      onChange: (val: string) => setter(Value.of(val)),
+    };
+  },
+});

--- a/src/editors/MarkdownEditor/index.test.tsx
+++ b/src/editors/MarkdownEditor/index.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import MarkdownInput from './index';
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  MarkdownEditor: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => (
+    <textarea
+      data-testid="markdown-editor"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+describe('MarkdownInput', () => {
+  it('renders the markdown editor', () => {
+    render(<MarkdownInput value="hello" onChange={vi.fn()} />);
+    expect(screen.getByTestId('markdown-editor')).toBeInTheDocument();
+  });
+
+  it('passes the value prop to the editor', () => {
+    render(<MarkdownInput value="# Title" onChange={vi.fn()} />);
+    expect(screen.getByDisplayValue('# Title')).toBeInTheDocument();
+  });
+
+  it('calls onChange when the editor value changes', () => {
+    const onChange = vi.fn();
+    render(<MarkdownInput value="" onChange={onChange} />);
+    fireEvent.change(screen.getByTestId('markdown-editor'), {
+      target: { value: 'new content' },
+    });
+    expect(onChange).toHaveBeenCalledWith('new content');
+  });
+
+  it('updates the displayed value when the value prop changes', () => {
+    const { rerender } = render(<MarkdownInput value="first" onChange={vi.fn()} />);
+    rerender(<MarkdownInput value="second" onChange={vi.fn()} />);
+    expect(screen.getByDisplayValue('second')).toBeInTheDocument();
+  });
+});

--- a/src/editors/MarkdownEditor/index.tsx
+++ b/src/editors/MarkdownEditor/index.tsx
@@ -3,7 +3,7 @@ import { MarkdownEditor } from '@embeddable.com/remarkable-ui';
 
 type MarkdownInputProps = {
   value: string;
-  onChange: (newValue?: string) => void;
+  onChange: (newValue: string) => void;
 };
 
 const MarkdownInput: FC<MarkdownInputProps> = ({ value, onChange }) => {

--- a/src/editors/MarkdownEditor/index.tsx
+++ b/src/editors/MarkdownEditor/index.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { MarkdownEditor } from '@embeddable.com/remarkable-ui';
+
+type MarkdownInputProps = {
+  value: string;
+  onChange: (newValue?: string) => void;
+};
+
+const MarkdownInput: FC<MarkdownInputProps> = ({ value, onChange }) => {
+  return <MarkdownEditor value={value} onChange={onChange} />;
+};
+
+export default MarkdownInput;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,5 +7,9 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
     css: { modules: { classNameStrategy: 'non-scoped' } },
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov'],
+    },
   },
 });


### PR DESCRIPTION
# Why is this pull-request needed?

This PR creates the new Markdown component to be used inside the dashboards.
It also introduces a new custom type 'markdown' and its custom editor. This will collect the value to be displayed inside of the Markdown component.

# Main changes

1. Create MarkdownPro component
1.1. Include the ability to translate keys (partial or complete)
1.2. Create dedicated definition.ts file
1.3. Add tests

2. Create MarkdownEditor component
2.1. Create markdown custom type
2.2. Add tests

3. Cleanup / Refactor
3.1. Remove no longer needed dependency of ReactMarkdown and respective plugin
3.2. Make usage of the new RUI Markdown component on the tables.utils.ts
3.3. Update ColorEditor to use the new GhostButtonIcon instead of the ActionIcon (design decision)

# Test evidence

Create new Markdown component 

https://github.com/user-attachments/assets/f4c9b49d-91b4-4cc3-bcf4-997b09aba002

Create a Markdown variable

https://github.com/user-attachments/assets/3aa1f605-c9e5-40f9-b1a2-89b01f061b23







<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Markdown editor for creating and editing Markdown content
  * Added native Markdown rendering component supporting tables, images, links, and translation placeholders
  * Enhanced table cells with improved Markdown display capabilities

* **Improvements**
  * Updated UI component dependencies for optimized performance and maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->