### PR TITLE
RUI-223: markdown exports

### DIFF
--- a/.changeset/silent-dots-kick.md
+++ b/.changeset/silent-dots-kick.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Update Markdown category and export layout components

--- a/src/components/shared/EmptyContainerPro/EmptyBlockPro.emb.ts
+++ b/src/components/shared/EmptyContainerPro/EmptyBlockPro.emb.ts
@@ -1,14 +1,8 @@
-import { defineComponent, definePreview, EmbeddedComponentMeta } from '@embeddable.com/react';
-import EmptyBlockPro from './index';
+import { defineComponent } from '@embeddable.com/react';
+import { emptyBlockPro } from './definition';
 
-export const meta = {
-  name: 'EmptyBlockPro',
-  label: 'Empty Block',
-  category: 'Layout',
-  defaultWidth: 450,
-  defaultHeight: 120,
-} as const satisfies EmbeddedComponentMeta;
+export const preview = emptyBlockPro.preview;
 
-export const preview = definePreview(EmptyBlockPro, {});
+export const meta = emptyBlockPro.meta;
 
-export default defineComponent(EmptyBlockPro, meta, {});
+export default defineComponent(emptyBlockPro.Component, meta, emptyBlockPro.config);

--- a/src/components/shared/EmptyContainerPro/definition.ts
+++ b/src/components/shared/EmptyContainerPro/definition.ts
@@ -1,0 +1,23 @@
+import { EmbeddedComponentMeta, definePreview } from '@embeddable.com/react';
+import Component from './index';
+
+const meta = {
+  name: 'EmptyBlockPro',
+  label: 'Empty Block',
+  category: 'Layout',
+  defaultWidth: 450,
+  defaultHeight: 120,
+} as const satisfies EmbeddedComponentMeta;
+
+const preview = definePreview(Component, {});
+
+const props = () => ({});
+
+export const emptyBlockPro = {
+  Component,
+  meta,
+  preview,
+  config: {
+    props,
+  },
+} as const;

--- a/src/components/shared/HorizontalDividerPro/HorizontalDividerPro.emb.ts
+++ b/src/components/shared/HorizontalDividerPro/HorizontalDividerPro.emb.ts
@@ -1,35 +1,8 @@
-import {
-  defineComponent,
-  definePreview,
-  EmbeddedComponentMeta,
-  Inputs,
-} from '@embeddable.com/react';
-import HorizontalDividerPro from './index';
-import { inputs } from '../../component.inputs.constants';
-import { getStyle } from '@embeddable.com/remarkable-ui';
+import { defineComponent } from '@embeddable.com/react';
+import { horizontalDividerPro } from './definition';
 
-export const meta = {
-  name: 'HorizontalDividerPro',
-  label: 'Horizontal Divider',
-  category: 'Layout',
-  defaultWidth: 450,
-  defaultHeight: 120,
-  inputs: [
-    {
-      ...inputs.number,
-      name: 'thickness',
-      label: 'Thickness',
-      category: 'Component Settings',
-      description: 'Thickness of the divider in pixels',
-    },
-    { ...inputs.color, defaultValue: getStyle('--em-divider-color', '#e4e4ea') },
-  ],
-} as const satisfies EmbeddedComponentMeta;
+export const preview = horizontalDividerPro.preview;
 
-export const preview = definePreview(HorizontalDividerPro, {});
-export default defineComponent(HorizontalDividerPro, meta, {
-  /* @ts-expect-error - to be fixed in @embeddable.com/react */
-  props: (inputs: Inputs<typeof meta>) => {
-    return { ...inputs };
-  },
-});
+export const meta = horizontalDividerPro.meta;
+
+export default defineComponent(horizontalDividerPro.Component, meta, horizontalDividerPro.config);

--- a/src/components/shared/HorizontalDividerPro/definition.ts
+++ b/src/components/shared/HorizontalDividerPro/definition.ts
@@ -1,0 +1,38 @@
+import { EmbeddedComponentMeta, Inputs, definePreview } from '@embeddable.com/react';
+import Component from './index';
+import { inputs } from '../../component.inputs.constants';
+import { getStyle } from '@embeddable.com/remarkable-ui';
+
+const meta = {
+  name: 'HorizontalDividerPro',
+  label: 'Horizontal Divider',
+  category: 'Layout',
+  defaultWidth: 450,
+  defaultHeight: 120,
+  inputs: [
+    {
+      ...inputs.number,
+      name: 'thickness',
+      label: 'Thickness',
+      category: 'Component Settings',
+      description: 'Thickness of the divider in pixels',
+    },
+    { ...inputs.color, defaultValue: getStyle('--em-divider-color', '#e4e4ea') },
+  ],
+} as const satisfies EmbeddedComponentMeta;
+
+const preview = definePreview(Component, {});
+
+const props = (inputs: Inputs<typeof meta>) => ({
+  ...inputs,
+  color: inputs.color as string | undefined,
+});
+
+export const horizontalDividerPro = {
+  Component,
+  meta,
+  preview,
+  config: {
+    props,
+  },
+} as const;

--- a/src/components/shared/MarkdownPro/definition.ts
+++ b/src/components/shared/MarkdownPro/definition.ts
@@ -5,7 +5,7 @@ import { inputs } from '../../component.inputs.constants';
 const meta = {
   name: 'MarkdownPro',
   label: 'Markdown',
-  category: 'Layout',
+  category: 'Content',
   defaultWidth: 600,
   defaultHeight: 300,
   inputs: [inputs.markdown],

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,11 @@ export * from './components/charts/shared/ChartGranularitySelectField/ChartGranu
 
 // Components - Shared
 export * as EmptyContainerPro from './components/shared/EmptyContainerPro';
+export * from './components/shared/EmptyContainerPro/definition';
+export * as HorizontalDividerPro from './components/shared/HorizontalDividerPro';
+export * from './components/shared/HorizontalDividerPro/definition';
+export * as MarkdownPro from './components/shared/MarkdownPro';
+export * from './components/shared/MarkdownPro/definition';
 
 // Charts - Utils
 export * from './components/charts/charts.utils';
@@ -196,5 +201,6 @@ export * from './components/editors/utils/dimensionsAndMeasures.utils';
 // Custom types
 export { default as ComparisonPeriodType } from './components/types/ComparisonPeriod.type.emb';
 
-// Color Editor
+// Custom Editors
 export * as ColorEditorPro from './editors/ColorEditor';
+export * as MarkdownEditorPro from './editors/MarkdownEditor';


### PR DESCRIPTION
# Why is this pull-request needed?

This PR exports the new Markdown component and the existing 2 layout components.

It also refactors the layout components to use the new definition approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Layout components (EmptyContainer, HorizontalDivider) and editor utilities (ColorEditor, MarkdownEditor) are now exported and available for use.

* **Chores**
  * Updated MarkdownPro category from Layout to Content for improved organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->