### PR TITLE
Github workflow added to publish changelog to handbook

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -58,17 +58,12 @@ jobs:
           git add pages/component-libraries/remarkable-pro/changelog.mdx
           git commit -m "chore: add changelog entry for $VERSION"
           git push origin "changelog/$VERSION"
+          PR_BODY="Automated changelog update from remarkable-pro $VERSION ($RELEASE_URL)."
+
           gh pr create \
             --repo embeddable-hq/handbook \
             --head "changelog/$VERSION" \
             --base main \
-            --title "📦 Changelog: Remarkable Pro $VERSION" \
-            --body "Automated changelog update from [remarkable-pro $VERSION]($RELEASE_URL).
-
-**Review checklist before merging:**
-- [ ] Version entry looks correct
-- [ ] Any breaking changes are clearly marked
-- [ ] Links resolve correctly
-
-_This PR was opened automatically by the release automation workflow._" \
+            --title "Changelog: Remarkable Pro $VERSION" \
+            --body "$PR_BODY" \
             --label "changelog,automated"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -58,12 +58,18 @@ jobs:
           git add pages/component-libraries/remarkable-pro/changelog.mdx
           git commit -m "chore: add changelog entry for $VERSION"
           git push origin "changelog/$VERSION"
-s          PR_BODY="Automated changelog update from remarkable-pro $VERSION ($RELEASE_URL)."
-
+          echo "Automated changelog update from remarkable-pro $VERSION ($RELEASE_URL)." > "$RUNNER_TEMP/pr-body.txt"
+          echo "" >> "$RUNNER_TEMP/pr-body.txt"
+          echo "Review checklist before merging:" >> "$RUNNER_TEMP/pr-body.txt"
+          echo "- Version entry looks correct" >> "$RUNNER_TEMP/pr-body.txt"
+          echo "- Any breaking changes are clearly marked" >> "$RUNNER_TEMP/pr-body.txt"
+          echo "- Links resolve correctly" >> "$RUNNER_TEMP/pr-body.txt"
+          echo "" >> "$RUNNER_TEMP/pr-body.txt"
+          echo "This PR was opened automatically by the release automation workflow." >> "$RUNNER_TEMP/pr-body.txt"
           gh pr create \
             --repo embeddable-hq/handbook \
             --head "changelog/$VERSION" \
             --base main \
             --title "Changelog: Remarkable Pro $VERSION" \
-            --body "$PR_BODY" \
+            --body-file "$RUNNER_TEMP/pr-body.txt" \
             --label "changelog,automated"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -58,7 +58,7 @@ jobs:
           git add pages/component-libraries/remarkable-pro/changelog.mdx
           git commit -m "chore: add changelog entry for $VERSION"
           git push origin "changelog/$VERSION"
-          PR_BODY="Automated changelog update from remarkable-pro $VERSION ($RELEASE_URL)."
+s          PR_BODY="Automated changelog update from remarkable-pro $VERSION ($RELEASE_URL)."
 
           gh pr create \
             --repo embeddable-hq/handbook \

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -46,73 +46,29 @@ jobs:
         run: node scripts/update-handbook-changelog.js
 
       - name: Open PR in handbook
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.HANDBOOK_GITHUB_TOKEN }}
-          path: handbook
-          commit-message: "chore: add changelog entry for ${{ github.ref_name }}"
-          title: "📦 Changelog: Remarkable Pro ${{ github.ref_name }}"
-          body: |
-            Automated changelog update from [remarkable-pro ${{ github.ref_name }}](${{ github.event.release.html_url }}).
+        env:
+          GH_TOKEN: ${{ secrets.HANDBOOK_GITHUB_TOKEN }}
+          VERSION: ${{ github.ref_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          cd handbook
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "changelog/$VERSION"
+          git add pages/component-libraries/remarkable-pro/changelog.mdx
+          git commit -m "chore: add changelog entry for $VERSION"
+          git push origin "changelog/$VERSION"
+          gh pr create \
+            --repo embeddable-hq/handbook \
+            --head "changelog/$VERSION" \
+            --base main \
+            --title "📦 Changelog: Remarkable Pro $VERSION" \
+            --body "Automated changelog update from [remarkable-pro $VERSION]($RELEASE_URL).
 
-            **Review checklist before merging:**
-            - [ ] Version entry looks correct
-            - [ ] Any breaking changes are clearly marked
-            - [ ] Links resolve correctly
+**Review checklist before merging:**
+- [ ] Version entry looks correct
+- [ ] Any breaking changes are clearly marked
+- [ ] Links resolve correctly
 
-            _This PR was opened automatically by the release automation workflow._
-          branch: "changelog/${{ github.ref_name }}"
-          base: main
-          labels: changelog,automated
-
-  # # ──────────────────────────────────────────────────────
-  # # JOB 2: Create newsletter draft issue for Loops
-  # # ──────────────────────────────────────────────────────
-  # draft-newsletter:
-  #   name: Draft newsletter → GitHub Issue
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout remarkable-pro
-  #       uses: actions/checkout@v4
-
-  #     - name: Set up Node.js
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 20
-
-  #     - name: Parse CHANGELOG.md
-  #       run: node scripts/parse-changelog.js
-
-  #     - name: Generate newsletter draft
-  #       id: newsletter
-  #       env:
-  #         RELEASE_VERSION: ${{ github.ref_name }}
-  #         RELEASE_DATE: ${{ github.event.release.published_at }}
-  #         RELEASE_URL: ${{ github.event.release.html_url }}
-  #         NPM_URL: https://www.npmjs.com/package/@embeddable.com/remarkable-pro
-  #       run: node scripts/generate-newsletter.js
-
-  #     - name: Create GitHub issue as newsletter staging area
-  #       uses: actions/github-script@v7
-  #       env:
-  #         NEWSLETTER_BODY: ${{ steps.newsletter.outputs.issue_body }}
-  #       with:
-  #         script: |
-  #           const body = process.env.NEWSLETTER_BODY;
-  #           const issue = await github.rest.issues.create({
-  #             owner: context.repo.owner,
-  #             repo: context.repo.repo,
-  #             title: `📧 Newsletter Draft — Remarkable Pro ${{ github.ref_name }}`,
-  #             body,
-  #             labels: ['newsletter', 'draft']
-  #           });
-  #           console.log(`Newsletter draft issue created: ${issue.data.html_url}`);
-
-  #     # Optional: if you add a LOOPS_API_KEY secret, this step will also
-  #     # push the draft as a Loops transactional email to your internal team
-  #     - name: Notify internal team via Loops (optional)
-  #       if: ${{ env.LOOPS_API_KEY != '' }}
-  #       env:
-  #         LOOPS_API_KEY: ${{ secrets.LOOPS_API_KEY }}
-  #         RELEASE_VERSION: ${{ github.ref_name }}
-  #       run: node scripts/notify-loops-team.js
+_This PR was opened automatically by the release automation workflow._" \
+            --label "changelog,automated"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,0 +1,118 @@
+name: Release Automation
+
+# Fires when Changesets publishes a GitHub Release (after NPM publish)
+on:
+  release:
+    types: [published]
+
+jobs:
+  # ─────────────────────────────────────────────
+  # JOB 1: Sync changelog to handbook (docs repo)
+  # ─────────────────────────────────────────────
+  sync-changelog:
+    name: Sync changelog → handbook
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout remarkable-pro
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Parse CHANGELOG.md
+        id: parse
+        run: |
+          node scripts/parse-changelog.js
+          echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          echo "release_url=${{ github.event.release.html_url }}" >> $GITHUB_OUTPUT
+          echo "release_date=$(date -u +%Y-%m-%d)" >> $GITHUB_OUTPUT
+
+      - name: Checkout handbook repo
+        uses: actions/checkout@v4
+        with:
+          repository: embeddable-hq/handbook
+          token: ${{ secrets.HANDBOOK_GITHUB_TOKEN }}
+          path: handbook
+
+      - name: Update handbook changelog page
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+          RELEASE_DATE: ${{ steps.parse.outputs.release_date }}
+          RELEASE_URL: ${{ steps.parse.outputs.release_url }}
+        run: node scripts/update-handbook-changelog.js
+
+      - name: Open PR in handbook
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.HANDBOOK_GITHUB_TOKEN }}
+          path: handbook
+          commit-message: "chore: add changelog entry for ${{ github.ref_name }}"
+          title: "📦 Changelog: Remarkable Pro ${{ github.ref_name }}"
+          body: |
+            Automated changelog update from [remarkable-pro ${{ github.ref_name }}](${{ github.event.release.html_url }}).
+
+            **Review checklist before merging:**
+            - [ ] Version entry looks correct
+            - [ ] Any breaking changes are clearly marked
+            - [ ] Links resolve correctly
+
+            _This PR was opened automatically by the release automation workflow._
+          branch: "changelog/${{ github.ref_name }}"
+          base: main
+          labels: changelog,automated
+
+  # # ──────────────────────────────────────────────────────
+  # # JOB 2: Create newsletter draft issue for Loops
+  # # ──────────────────────────────────────────────────────
+  # draft-newsletter:
+  #   name: Draft newsletter → GitHub Issue
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout remarkable-pro
+  #       uses: actions/checkout@v4
+
+  #     - name: Set up Node.js
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 20
+
+  #     - name: Parse CHANGELOG.md
+  #       run: node scripts/parse-changelog.js
+
+  #     - name: Generate newsletter draft
+  #       id: newsletter
+  #       env:
+  #         RELEASE_VERSION: ${{ github.ref_name }}
+  #         RELEASE_DATE: ${{ github.event.release.published_at }}
+  #         RELEASE_URL: ${{ github.event.release.html_url }}
+  #         NPM_URL: https://www.npmjs.com/package/@embeddable.com/remarkable-pro
+  #       run: node scripts/generate-newsletter.js
+
+  #     - name: Create GitHub issue as newsletter staging area
+  #       uses: actions/github-script@v7
+  #       env:
+  #         NEWSLETTER_BODY: ${{ steps.newsletter.outputs.issue_body }}
+  #       with:
+  #         script: |
+  #           const body = process.env.NEWSLETTER_BODY;
+  #           const issue = await github.rest.issues.create({
+  #             owner: context.repo.owner,
+  #             repo: context.repo.repo,
+  #             title: `📧 Newsletter Draft — Remarkable Pro ${{ github.ref_name }}`,
+  #             body,
+  #             labels: ['newsletter', 'draft']
+  #           });
+  #           console.log(`Newsletter draft issue created: ${issue.data.html_url}`);
+
+  #     # Optional: if you add a LOOPS_API_KEY secret, this step will also
+  #     # push the draft as a Loops transactional email to your internal team
+  #     - name: Notify internal team via Loops (optional)
+  #       if: ${{ env.LOOPS_API_KEY != '' }}
+  #       env:
+  #         LOOPS_API_KEY: ${{ secrets.LOOPS_API_KEY }}
+  #         RELEASE_VERSION: ${{ github.ref_name }}
+  #       run: node scripts/notify-loops-team.js

--- a/scripts/parse-changelog.js
+++ b/scripts/parse-changelog.js
@@ -20,9 +20,9 @@
  *   - def456: Fix tooltip overflow on small screens
  */
 
-import fs from 'fs';
-import path from 'path';
-import process from 'process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
 
 const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
 const raw = fs.readFileSync(changelogPath, 'utf-8');

--- a/scripts/parse-changelog.js
+++ b/scripts/parse-changelog.js
@@ -96,7 +96,11 @@ for (const line of lines) {
   }
 
   // Continuation of previous bullet (indented)
-  if ((line.startsWith('  ') || line.startsWith('\t')) && currentSection && currentItems.length > 0) {
+  if (
+    (line.startsWith('  ') || line.startsWith('\t')) &&
+    currentSection &&
+    currentItems.length > 0
+  ) {
     currentItems[currentItems.length - 1] += ' ' + line.trim();
   }
 }

--- a/scripts/parse-changelog.js
+++ b/scripts/parse-changelog.js
@@ -74,7 +74,7 @@ function buildVersionMarkdown(version, sections) {
 
 for (const line of lines) {
   // Version header: "## 0.1.15" or "## 0.1.15-beta.1"
-  const versionMatch = line.match(/^## (\d+\.\d+\.\d+[\w.-]*)\s*$/);
+  const versionMatch = line.match(/^## (\d+\.\d+\.\d+(?:[-+][a-zA-Z0-9._-]*)?)\s*$/);
   if (versionMatch) {
     flushVersion();
     currentVersion = versionMatch[1];
@@ -108,11 +108,13 @@ if (versions.length === 0) {
   process.exit(1);
 }
 
+const tmpDir = process.env.RUNNER_TEMP ?? '/tmp';
+
 // Write all versions
-fs.writeFileSync('/tmp/changelog-parsed.json', JSON.stringify(versions, null, 2));
+fs.writeFileSync(`${tmpDir}/changelog-parsed.json`, JSON.stringify(versions, null, 2));
 
 // Write latest version only
-fs.writeFileSync('/tmp/changelog-latest.json', JSON.stringify(versions[0], null, 2));
+fs.writeFileSync(`${tmpDir}/changelog-latest.json`, JSON.stringify(versions[0], null, 2));
 
 console.log(`✅ Parsed ${versions.length} versions. Latest: ${versions[0].version}`);
 console.log(`   Sections: ${Object.keys(versions[0].sections).join(', ')}`);

--- a/scripts/parse-changelog.js
+++ b/scripts/parse-changelog.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/**
+ * parse-changelog.js
+ *
+ * Reads CHANGELOG.md (Changesets format) and writes:
+ *   - /tmp/changelog-parsed.json  — all versions as structured JSON
+ *   - /tmp/changelog-latest.json  — just the most recent version entry
+ *
+ * Changesets CHANGELOG.md format:
+ *
+ *   # @embeddable.com/remarkable-pro
+ *
+ *   ## 0.1.15
+ *
+ *   ### Minor Changes
+ *   - abc123: Add new KPI tile variant
+ *
+ *   ### Patch Changes
+ *   - def456: Fix tooltip overflow on small screens
+ */
+
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+
+const changelogPath = path.join(process.cwd(), 'CHANGELOG.md');
+const raw = fs.readFileSync(changelogPath, 'utf-8');
+const lines = raw.split('\n');
+
+const versions = [];
+let currentVersion = null;
+let currentSections = {};
+let currentSection = null;
+let currentItems = [];
+
+function flushSection() {
+  if (currentSection && currentItems.length > 0) {
+    currentSections[currentSection] = [...currentItems];
+  }
+  currentItems = [];
+}
+
+function flushVersion() {
+  if (currentVersion) {
+    flushSection();
+    versions.push({
+      version: currentVersion,
+      sections: { ...currentSections },
+      // Reconstruct raw markdown for this version block
+      markdown: buildVersionMarkdown(currentVersion, currentSections),
+    });
+  }
+  currentSections = {};
+  currentSection = null;
+  currentItems = [];
+}
+
+function buildVersionMarkdown(version, sections) {
+  const sectionOrder = ['Major Changes', 'Minor Changes', 'Patch Changes'];
+  let md = '';
+  for (const heading of sectionOrder) {
+    if (sections[heading] && sections[heading].length > 0) {
+      md += `\n### ${heading}\n\n`;
+      for (const item of sections[heading]) {
+        // Strip the changeset hash prefix (e.g. "abc123: ") if present
+        const cleaned = item.replace(/^-\s+[a-f0-9]+:\s+/, '- ');
+        md += `${cleaned}\n`;
+      }
+    }
+  }
+  return md.trim();
+}
+
+for (const line of lines) {
+  // Version header: "## 0.1.15" or "## 0.1.15-beta.1"
+  const versionMatch = line.match(/^## (\d+\.\d+\.\d+[\w.-]*)\s*$/);
+  if (versionMatch) {
+    flushVersion();
+    currentVersion = versionMatch[1];
+    continue;
+  }
+
+  // Section header: "### Minor Changes"
+  const sectionMatch = line.match(/^### (.+)$/);
+  if (sectionMatch && currentVersion) {
+    flushSection();
+    currentSection = sectionMatch[1];
+    continue;
+  }
+
+  // Bullet item
+  if (line.startsWith('- ') && currentSection) {
+    currentItems.push(line);
+    continue;
+  }
+
+  // Continuation of previous bullet (indented)
+  if ((line.startsWith('  ') || line.startsWith('\t')) && currentSection && currentItems.length > 0) {
+    currentItems[currentItems.length - 1] += ' ' + line.trim();
+  }
+}
+
+flushVersion(); // flush the last version
+
+if (versions.length === 0) {
+  console.error('No versions found in CHANGELOG.md');
+  process.exit(1);
+}
+
+// Write all versions
+fs.writeFileSync('/tmp/changelog-parsed.json', JSON.stringify(versions, null, 2));
+
+// Write latest version only
+fs.writeFileSync('/tmp/changelog-latest.json', JSON.stringify(versions[0], null, 2));
+
+console.log(`✅ Parsed ${versions.length} versions. Latest: ${versions[0].version}`);
+console.log(`   Sections: ${Object.keys(versions[0].sections).join(', ')}`);

--- a/scripts/update-handbook-changelog.js
+++ b/scripts/update-handbook-changelog.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/* eslint-env node */
+/**
+ * update-handbook-changelog.js
+ *
+ * Reads /tmp/changelog-latest.json and prepends a new version block
+ * to handbook/pages/changelog.mdx.
+ *
+ * Env vars (set by the GitHub Actions workflow):
+ *   RELEASE_VERSION  — e.g. "v0.1.15"
+ *   RELEASE_DATE     — e.g. "2026-03-10"
+ *   RELEASE_URL      — GitHub release URL
+ */
+
+import fs from 'fs';
+import path from 'path';
+import process from 'process';
+
+const latest = JSON.parse(fs.readFileSync('/tmp/changelog-latest.json', 'utf-8'));
+const handbookPath = path.join(process.cwd(), 'handbook', 'pages', 'component-libraries', 'remarkable-pro', 'changelog.mdx');
+
+// Strip leading "v" if present for display
+const rawVersion = process.env.RELEASE_VERSION || latest.version;
+const version = rawVersion.replace(/^v/, '');
+const date = process.env.RELEASE_DATE || new Date().toISOString().split('T')[0];
+const releaseUrl = process.env.RELEASE_URL || `https://github.com/embeddable-hq/remarkable-pro/releases/tag/v${version}`;
+const npmUrl = `https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/${version}`;
+
+
+
+// Build the MDX entry for this version
+function buildEntry() {
+  const sections = latest.sections;
+  const sectionOrder = ['Major Changes', 'Minor Changes', 'Patch Changes'];
+
+  let content = '';
+  for (const heading of sectionOrder) {
+    if (sections[heading] && sections[heading].length > 0) {
+      const labels = {
+        'Major Changes': '🚨 Breaking changes',
+        'Minor Changes': '✨ Changes',
+        'Patch Changes': '✨ Changes',
+      };
+      content += `#### ${labels[heading] || heading}\n\n`;
+      for (const item of sections[heading]) {
+        // Clean changeset hash prefix
+        const cleaned = item.replace(/^-\s+[a-f0-9]{7,}:\s+/, '- ');
+        content += `${cleaned}\n`;
+      }
+      content += '\n';
+    }
+  }
+
+  return `### v${version} - ${date}
+
+- View [GitHub release](${releaseUrl})
+- View [npm](${npmUrl})
+
+${content.trim()}
+
+---
+`;
+}
+
+const newEntry = buildEntry();
+const marker = '## Changelog entries';
+
+const existing = fs.readFileSync(handbookPath, 'utf-8');
+const updated = existing.replace(marker, `${marker}\n\n${newEntry}`);
+
+fs.writeFileSync(handbookPath, updated);
+console.log(`✅ Updated handbook/pages/component-libraries/remarkable-pro/changelog.mdx with v${version}`);

--- a/scripts/update-handbook-changelog.js
+++ b/scripts/update-handbook-changelog.js
@@ -16,7 +16,8 @@ import fs from 'node:fs';
 import path from 'node:path';
 import process from 'node:process';
 
-const latest = JSON.parse(fs.readFileSync('/tmp/changelog-latest.json', 'utf-8'));
+const tmpDir = process.env.RUNNER_TEMP ?? '/tmp';
+const latest = JSON.parse(fs.readFileSync(`${tmpDir}/changelog-latest.json`, 'utf-8'));
 const handbookPath = path.join(process.cwd(), 'handbook', 'pages', 'component-libraries', 'remarkable-pro', 'changelog.mdx');
 
 // Strip leading "v" if present for display

--- a/scripts/update-handbook-changelog.js
+++ b/scripts/update-handbook-changelog.js
@@ -67,6 +67,12 @@ const newEntry = buildEntry();
 const marker = '## Changelog entries';
 
 const existing = fs.readFileSync(handbookPath, 'utf-8');
+
+if (!existing.includes(marker)) {
+  console.error(`❌ Marker "${marker}" not found in ${handbookPath}. Aborting.`);
+  process.exit(1);
+}
+
 const updated = existing.replace(marker, `${marker}\n\n${newEntry}`);
 
 fs.writeFileSync(handbookPath, updated);

--- a/scripts/update-handbook-changelog.js
+++ b/scripts/update-handbook-changelog.js
@@ -12,9 +12,9 @@
  *   RELEASE_URL      — GitHub release URL
  */
 
-import fs from 'fs';
-import path from 'path';
-import process from 'process';
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
 
 const latest = JSON.parse(fs.readFileSync('/tmp/changelog-latest.json', 'utf-8'));
 const handbookPath = path.join(process.cwd(), 'handbook', 'pages', 'component-libraries', 'remarkable-pro', 'changelog.mdx');

--- a/scripts/update-handbook-changelog.js
+++ b/scripts/update-handbook-changelog.js
@@ -18,16 +18,23 @@ import process from 'node:process';
 
 const tmpDir = process.env.RUNNER_TEMP ?? '/tmp';
 const latest = JSON.parse(fs.readFileSync(`${tmpDir}/changelog-latest.json`, 'utf-8'));
-const handbookPath = path.join(process.cwd(), 'handbook', 'pages', 'component-libraries', 'remarkable-pro', 'changelog.mdx');
+const handbookPath = path.join(
+  process.cwd(),
+  'handbook',
+  'pages',
+  'component-libraries',
+  'remarkable-pro',
+  'changelog.mdx',
+);
 
 // Strip leading "v" if present for display
 const rawVersion = process.env.RELEASE_VERSION || latest.version;
 const version = rawVersion.replace(/^v/, '');
 const date = process.env.RELEASE_DATE || new Date().toISOString().split('T')[0];
-const releaseUrl = process.env.RELEASE_URL || `https://github.com/embeddable-hq/remarkable-pro/releases/tag/v${version}`;
+const releaseUrl =
+  process.env.RELEASE_URL ||
+  `https://github.com/embeddable-hq/remarkable-pro/releases/tag/v${version}`;
 const npmUrl = `https://www.npmjs.com/package/@embeddable.com/remarkable-pro/v/${version}`;
-
-
 
 // Build the MDX entry for this version
 function buildEntry() {
@@ -76,4 +83,6 @@ if (!existing.includes(marker)) {
 const updated = existing.replace(marker, `${marker}\n\n${newEntry}`);
 
 fs.writeFileSync(handbookPath, updated);
-console.log(`✅ Updated handbook/pages/component-libraries/remarkable-pro/changelog.mdx with v${version}`);
+console.log(
+  `✅ Updated handbook/pages/component-libraries/remarkable-pro/changelog.mdx with v${version}`,
+);

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,5 +3,6 @@ sonar.projectKey=embeddable-hq_remarkable-pro
 sonar.organization=embeddable-com
 sonar.sources=.
 sonar.exclusions= **/*.types.ts, **/*.stories.tsx, **/*.test.ts, **/*.test.tsx, **/**emb.ts, **/**.css, **/**definition.ts
+sonar.coverage.exclusions=scripts/**
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
# Why is this pull-request needed?

Creates an automated workflow using Github actions that will power a changelog in Embeddable's handbook. This means users can easily stay up to date with changes to Remarkable Pro via the documentation and, importantly, our Ask AI functionality. 

# Main changes

New files added:
- A new github release-automation workflow has been added, based on Changesets. 
- The scripts added to generate the changelog within the handbook. 

Outcome: 
- When we release, it will automatically create a PR extending the Remarkable Pro changelog in the handbook. This can then be manually reviewed as per the usual process for that repo. 

# Test evidence

- We will need to test this with the fi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced automated release workflow that synchronizes changelog entries across repositories and streamlines release publication processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->