### PR TITLE
RUI-231: Allow more options to be define in meta

### DIFF
--- a/.changeset/witty-rings-jog.md
+++ b/.changeset/witty-rings-jog.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Support all per-type subinputs in data model meta

--- a/src/theme/formatter/formatter.constants.test.ts
+++ b/src/theme/formatter/formatter.constants.test.ts
@@ -12,9 +12,13 @@ vi.mock('../i18n/i18n', () => ({
   i18nSetup: vi.fn(),
 }));
 
-vi.mock('@embeddable.com/core', () => ({
-  isDimension: vi.fn(() => true),
-}));
+vi.mock('@embeddable.com/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@embeddable.com/core')>();
+  return {
+    ...actual,
+    isDimension: vi.fn(() => true),
+  };
+});
 
 const mockTheme = {
   formatter: {

--- a/src/theme/formatter/formatter.constants.test.ts
+++ b/src/theme/formatter/formatter.constants.test.ts
@@ -197,6 +197,14 @@ describe('dataDateTimeFormatter', () => {
     expect(formatter.format(date)).toContain('2024');
   });
 
+  it('applies granularity from key.meta when inputs.granularity is absent', () => {
+    const formatter = remarkableThemeFormatter.dataDateTimeFormatter(
+      mockTheme,
+      makeKey({}, { granularity: 'year' }),
+    );
+    expect(formatter.format(date)).toContain('2024');
+  });
+
   it('quarter granularity calls i18n.t with quarter number and year', () => {
     const formatter = remarkableThemeFormatter.dataDateTimeFormatter(
       mockTheme,

--- a/src/theme/formatter/formatter.constants.ts
+++ b/src/theme/formatter/formatter.constants.ts
@@ -7,6 +7,7 @@ import {
 import { Theme } from '../theme.types';
 import { DimensionOrMeasure, isDimension } from '@embeddable.com/core';
 import { i18n, i18nSetup } from '../i18n/i18n';
+import { getSubInputValue } from './formatter.utils';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -60,8 +61,8 @@ const numberFormatter = (
 };
 
 const dataNumberFormatter = (theme: Theme, key: DimensionOrMeasure): NumberFormatter => {
-  const currency = key.inputs?.currency ?? (key.meta as any)?.currency;
-  const decimalPlaces = key.inputs?.decimalPlaces ?? (key.meta as any)?.decimalPlaces;
+  const currency = getSubInputValue(key, 'currency');
+  const decimalPlaces = getSubInputValue(key, 'decimalPlaces');
   const hasDecimalPlaces = decimalPlaces != null;
 
   const fixedFractionDigits = hasDecimalPlaces ? decimalPlaces : undefined;
@@ -69,10 +70,7 @@ const dataNumberFormatter = (theme: Theme, key: DimensionOrMeasure): NumberForma
   const options: Intl.NumberFormatOptions = {
     style: currency ? 'currency' : undefined,
     currency: currency ? currency : undefined,
-    notation:
-      (key.inputs?.abbreviateLargeNumber ?? (key.meta as any)?.abbreviateLargeNumber ?? false)
-        ? 'compact'
-        : undefined,
+    notation: (getSubInputValue(key, 'abbreviateLargeNumber') ?? false) ? 'compact' : undefined,
     minimumFractionDigits: fixedFractionDigits,
     maximumFractionDigits: fixedFractionDigits,
   };
@@ -104,7 +102,7 @@ const dataDateTimeFormatter = (theme: Theme, key: DimensionOrMeasure): DateTimeF
 
   const locale = getLocale(theme.formatter.locale);
 
-  const granularity = key.inputs?.granularity ?? (key.meta as any)?.granularity;
+  const granularity = getSubInputValue(key, 'granularity');
 
   const { year, month, day, hour, minute, second } = theme.formatter.defaultDateTimeFormatOptions;
 

--- a/src/theme/formatter/formatter.constants.ts
+++ b/src/theme/formatter/formatter.constants.ts
@@ -104,7 +104,7 @@ const dataDateTimeFormatter = (theme: Theme, key: DimensionOrMeasure): DateTimeF
 
   const locale = getLocale(theme.formatter.locale);
 
-  const granularity = key.inputs?.granularity;
+  const granularity = key.inputs?.granularity ?? (key.meta as any)?.granularity;
 
   const { year, month, day, hour, minute, second } = theme.formatter.defaultDateTimeFormatOptions;
 

--- a/src/theme/formatter/formatter.utils.test.ts
+++ b/src/theme/formatter/formatter.utils.test.ts
@@ -166,6 +166,26 @@ describe('getThemeFormatter', () => {
 
       expect(result).toBe('Renamed Field');
     });
+
+    it('uses displayName from meta when inputs.displayName is absent', () => {
+      const { theme } = createMockTheme();
+      const fmt = getThemeFormatter(theme);
+
+      const result = fmt.dimensionOrMeasureTitle(dim({ meta: { displayName: 'Meta Label' } }));
+
+      expect(result).toBe('Meta Label');
+    });
+
+    it('prefers inputs.displayName over meta.displayName', () => {
+      const { theme } = createMockTheme();
+      const fmt = getThemeFormatter(theme);
+
+      const result = fmt.dimensionOrMeasureTitle(
+        dim({ inputs: { displayName: 'Input Label' }, meta: { displayName: 'Meta Label' } }),
+      );
+
+      expect(result).toBe('Input Label');
+    });
   });
 
   describe('data', () => {
@@ -189,6 +209,22 @@ describe('getThemeFormatter', () => {
         const fmt = getThemeFormatter(theme);
 
         expect(fmt.data(dim({ inputs: { displayNullAs: 'N/A' } }), null)).toBe('N/A');
+      });
+
+      it('returns displayNullAs from meta when inputs.displayNullAs is absent', () => {
+        const { theme } = createMockTheme();
+        const fmt = getThemeFormatter(theme);
+
+        expect(fmt.data(dim({ meta: { displayNullAs: '—' } }), null)).toBe('—');
+      });
+
+      it('prefers inputs.displayNullAs over meta.displayNullAs', () => {
+        const { theme } = createMockTheme();
+        const fmt = getThemeFormatter(theme);
+
+        expect(
+          fmt.data(dim({ inputs: { displayNullAs: 'N/A' }, meta: { displayNullAs: '—' } }), null),
+        ).toBe('N/A');
       });
     });
 
@@ -216,6 +252,34 @@ describe('getThemeFormatter', () => {
         );
 
         expect(result).toBe('**bold**');
+      });
+
+      it('uses displayFormat from meta when inputs.displayFormat is absent', () => {
+        const { theme } = createMockTheme();
+        const fmt = getThemeFormatter(theme);
+        const value = { x: 1 };
+
+        const result = fmt.data(
+          dim({ meta: { displayFormat: DisplayFormatTypeOptions.JSON } }),
+          value,
+        );
+
+        expect(result).toBe(JSON.stringify(value, null, 2));
+      });
+
+      it('prefers inputs.displayFormat over meta.displayFormat', () => {
+        const { theme } = createMockTheme();
+        const fmt = getThemeFormatter(theme);
+
+        const result = fmt.data(
+          dim({
+            inputs: { displayFormat: DisplayFormatTypeOptions.MARKDOWN },
+            meta: { displayFormat: DisplayFormatTypeOptions.JSON },
+          }),
+          '**text**',
+        );
+
+        expect(result).toBe('**text**');
       });
     });
 
@@ -316,6 +380,36 @@ describe('getThemeFormatter', () => {
 
         expect(result).toBe('value <<');
       });
+
+      it('uses meta.pretext and meta.posttext as prefix/suffix when inputs are absent', () => {
+        const { theme, dataOthersFormatFn } = createMockTheme();
+        dataOthersFormatFn.mockReturnValue('value');
+        const fmt = getThemeFormatter(theme);
+
+        const result = fmt.data(
+          dim({ nativeType: 'string', meta: { pretext: '[', posttext: ']' } }),
+          'value',
+        );
+
+        expect(result).toBe('[value]');
+      });
+
+      it('prefers inputs.prefix/suffix over meta.pretext/posttext', () => {
+        const { theme, dataOthersFormatFn } = createMockTheme();
+        dataOthersFormatFn.mockReturnValue('value');
+        const fmt = getThemeFormatter(theme);
+
+        const result = fmt.data(
+          dim({
+            nativeType: 'string',
+            inputs: { prefix: '(', suffix: ')' },
+            meta: { pretext: '[', posttext: ']' },
+          }),
+          'value',
+        );
+
+        expect(result).toBe('(value)');
+      });
     });
 
     describe('maxCharacters', () => {
@@ -357,6 +451,32 @@ describe('getThemeFormatter', () => {
         );
 
         expect(result).toBe('PREFI...');
+      });
+
+      it('uses maxCharacters from meta when inputs.maxCharacters is absent', () => {
+        const { theme, dataOthersFormatFn } = createMockTheme();
+        dataOthersFormatFn.mockReturnValue('Hello World');
+        const fmt = getThemeFormatter(theme);
+
+        const result = fmt.data(
+          dim({ nativeType: 'string', meta: { maxCharacters: 5 } }),
+          'Hello World',
+        );
+
+        expect(result).toBe('Hello...');
+      });
+
+      it('prefers inputs.maxCharacters over meta.maxCharacters', () => {
+        const { theme, dataOthersFormatFn } = createMockTheme();
+        dataOthersFormatFn.mockReturnValue('Hello');
+        const fmt = getThemeFormatter(theme);
+
+        const result = fmt.data(
+          dim({ nativeType: 'string', inputs: { maxCharacters: 10 }, meta: { maxCharacters: 2 } }),
+          'Hello',
+        );
+
+        expect(result).toBe('Hello');
       });
     });
   });

--- a/src/theme/formatter/formatter.utils.ts
+++ b/src/theme/formatter/formatter.utils.ts
@@ -6,12 +6,16 @@ import { isValidISODate } from '../../utils/data.utils';
 import { resolveI18nString } from '../../components/component.utils';
 import { DisplayFormatTypeOptions } from '../../components/types/DisplayFormat.type.emb';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const formatOption = (key: DimensionOrMeasure, inputKey: string, metaKey?: string) =>
+  key.inputs?.[inputKey] ?? (key.meta as any)?.[metaKey ?? inputKey];
+
 export type GetThemeFormatter = {
   string: (key: string) => string;
   number: (value: number | bigint, options?: Intl.NumberFormatOptions) => string;
   dateTime: (value: Date, options?: Intl.DateTimeFormatOptions) => string;
   dimensionOrMeasureTitle: (key: DimensionOrMeasure) => string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: (key: DimensionOrMeasure, value: any) => string;
 };
 
@@ -45,7 +49,7 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
       return cachedDateTimeFormatter(options).format(value);
     },
     dimensionOrMeasureTitle: (key: DimensionOrMeasure): string => {
-      const displayName = key.inputs?.displayName;
+      const displayName = formatOption(key, 'displayName');
       if (displayName) {
         if (displayName.includes('|')) {
           return resolveI18nString(displayName);
@@ -56,19 +60,20 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
       const resolved = cachedDataOthersFormatter(key).format(key.name);
       return resolved === key.name ? (key.title ?? key.name) : resolved;
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data: (key: DimensionOrMeasure, value: any): string => {
       let newValue = value;
 
-      // Nulls
+      // Nulls (inputs override meta)
       if (value == null) {
-        return key.inputs?.displayNullAs ?? '';
+        return formatOption(key, 'displayNullAs') ?? '';
       }
 
-      // JSON and Markdown
-      if (key.inputs?.displayFormat === DisplayFormatTypeOptions.JSON) {
+      // JSON and Markdown (inputs override meta)
+      const displayFormat = formatOption(key, 'displayFormat');
+      if (displayFormat === DisplayFormatTypeOptions.JSON) {
         return JSON.stringify(value, null, 2);
-      } else if (key.inputs?.displayFormat === DisplayFormatTypeOptions.MARKDOWN) {
+      }
+      if (displayFormat === DisplayFormatTypeOptions.MARKDOWN) {
         return value;
       }
       // Objects
@@ -91,15 +96,18 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
         newValue = cachedDataOthersFormatter(key).format(value);
       }
 
-      // Prefix and suffix
-      const appended = `${key.inputs?.prefix || ''}${newValue}${key.inputs?.suffix || ''}`;
+      // Prefix and suffix (inputs override meta; meta uses pretext/posttext)
+      const prefix = formatOption(key, 'prefix', 'pretext') || '';
+      const suffix = formatOption(key, 'suffix', 'posttext') || '';
+      const appended = `${prefix}${newValue}${suffix}`;
 
-      // Max characters
-      if (key.inputs?.maxCharacters) {
-        if (appended.length <= key.inputs.maxCharacters) {
+      // Max characters (inputs override meta)
+      const maxCharacters = formatOption(key, 'maxCharacters');
+      if (maxCharacters != null) {
+        if (appended.length <= maxCharacters) {
           return appended;
         }
-        return appended.substring(0, key.inputs.maxCharacters) + '...';
+        return appended.substring(0, maxCharacters) + '...';
       }
 
       return appended;

--- a/src/theme/formatter/formatter.utils.ts
+++ b/src/theme/formatter/formatter.utils.ts
@@ -8,7 +8,7 @@ import { DisplayFormatTypeOptions } from '../../components/types/DisplayFormat.t
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-const formatOption = (key: DimensionOrMeasure, inputKey: string, metaKey?: string) =>
+export const getSubInputValue = (key: DimensionOrMeasure, inputKey: string, metaKey?: string) =>
   key.inputs?.[inputKey] ?? (key.meta as any)?.[metaKey ?? inputKey];
 
 export type GetThemeFormatter = {
@@ -49,7 +49,7 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
       return cachedDateTimeFormatter(options).format(value);
     },
     dimensionOrMeasureTitle: (key: DimensionOrMeasure): string => {
-      const displayName = formatOption(key, 'displayName');
+      const displayName = getSubInputValue(key, 'displayName');
       if (displayName) {
         if (displayName.includes('|')) {
           return resolveI18nString(displayName);
@@ -65,11 +65,11 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
 
       // Nulls (inputs override meta)
       if (value == null) {
-        return formatOption(key, 'displayNullAs') ?? '';
+        return getSubInputValue(key, 'displayNullAs') ?? '';
       }
 
       // JSON and Markdown (inputs override meta)
-      const displayFormat = formatOption(key, 'displayFormat');
+      const displayFormat = getSubInputValue(key, 'displayFormat');
       if (displayFormat === DisplayFormatTypeOptions.JSON) {
         return JSON.stringify(value, null, 2);
       }
@@ -97,12 +97,12 @@ export const getThemeFormatter = (theme: Theme): GetThemeFormatter => {
       }
 
       // Prefix and suffix (inputs override meta; meta uses pretext/posttext)
-      const prefix = formatOption(key, 'prefix', 'pretext') || '';
-      const suffix = formatOption(key, 'suffix', 'posttext') || '';
+      const prefix = getSubInputValue(key, 'prefix', 'pretext') || '';
+      const suffix = getSubInputValue(key, 'suffix', 'posttext') || '';
       const appended = `${prefix}${newValue}${suffix}`;
 
       // Max characters (inputs override meta)
-      const maxCharacters = formatOption(key, 'maxCharacters');
+      const maxCharacters = getSubInputValue(key, 'maxCharacters');
       if (maxCharacters != null) {
         if (appended.length <= maxCharacters) {
           return appended;


### PR DESCRIPTION
# Why is this pull-request needed?

We need to add support for the remaining format options within the model meta

# Main changes

Updated formatter.utils and formatter.constants to allow for better customisation via meta. 

# Test evidence

Example for such defined measure:

 - name: streaming_royalties
        title: '$ Revenue from royalties'
        type: sum
        sql: total_listens * 0.005
        description: Total USD earned for daily_listens
        meta:
          currency: 'USD'
          decimalPlaces: 2
          displayName: '€ Total revenue'
          posttext: ' total'
          pretext: '€ '



https://github.com/user-attachments/assets/e2282735-da81-4817-95c9-0af60197f0de




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced formatter to support fallback values from metadata when direct input values are not provided, improving flexibility and consistency across formatting options.

* **Tests**
  * Added comprehensive tests verifying formatter behavior with metadata fallbacks and input value precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->