### PR TITLE
RUI-000: rename bar chart stacked horizontal

### DIFF
--- a/.changeset/wide-singers-strive.md
+++ b/.changeset/wide-singers-strive.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Rename BarChartStackedHorizontalPro and type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.1.20",
+  "version": "0.1.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.1.20",
+      "version": "0.1.22",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.6",
@@ -6846,9 +6846,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.2.2.tgz",
-      "integrity": "sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.0.tgz",
+      "integrity": "sha512-04cg8iJFDOxWcYlu0GFFWgs7vtaEPCmr5w1nrj9V3z3axu/48HCMwK6VMp45Zh3ZB+xLP1ifbJfrq86+1ypKKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6867,6 +6867,7 @@
         "has-symbols": "^1.1.0",
         "internal-slot": "^1.1.0",
         "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0",
         "safe-array-concat": "^1.1.3"
       },
       "engines": {
@@ -8331,9 +8332,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.8.17",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.17.tgz",
-      "integrity": "sha512-vWtCttyn5bpOK4hWbRAe1ZXkA+Yzcn2OcACT+WJavtfGMcxzkfvXTLMeOU8MUhRmAySKjU4VVuKlo0sSGeBokA==",
+      "version": "25.8.18",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
+      "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
       "funding": [
         {
           "type": "individual",

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -10,7 +10,7 @@ import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/c
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 
-export type BarChartHorizontalStackedProProps = {
+export type BarChartStackedHorizontalProProps = {
   groupBy: Dimension;
   measure: Measure;
   results: DataResponse;
@@ -32,7 +32,7 @@ export type BarChartHorizontalStackedProProps = {
   }) => void;
 } & ChartCardHeaderProps;
 
-const BarChartHorizontalStackedPro = (props: BarChartHorizontalStackedProProps) => {
+const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
@@ -117,4 +117,4 @@ const BarChartHorizontalStackedPro = (props: BarChartHorizontalStackedProProps) 
   );
 };
 
-export default BarChartHorizontalStackedPro;
+export default BarChartStackedHorizontalPro;

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,7 @@ export type { BarChartGroupedProProps } from './components/charts/bars/BarChartG
 export * as BarChartDefaultHorizontalPro from './components/charts/bars/BarChartDefaultHorizontalPro';
 export type { BarChartDefaultHorizontalProProps } from './components/charts/bars/BarChartDefaultHorizontalPro';
 export * as BarChartStackedHorizontalPro from './components/charts/bars/BarChartStackedHorizontalPro';
-export type { BarChartHorizontalStackedProProps } from './components/charts/bars/BarChartStackedHorizontalPro';
+export type { BarChartStackedHorizontalProProps } from './components/charts/bars/BarChartStackedHorizontalPro';
 export * as BarChartGroupedHorizontalPro from './components/charts/bars/BarChartGroupedHorizontalPro';
 export type { BarChartGroupedHorizontalProProps } from './components/charts/bars/BarChartGroupedHorizontalPro';
 export * from './components/charts/bars/bars.utils';


### PR DESCRIPTION
# Why is this pull-request needed?

Rename BarChartStackedHorizontal and update exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed stacked horizontal bar chart component for improved naming consistency. This is a breaking change for API users importing this component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->