### PR TITLE
[DRAFT] - Add Bar Chart w/ Lines

### DIFF
--- a/src/components/charts/bars/BarChartDefaultWithLinePro/BarChartDefaultWithLinePro.emb.ts
+++ b/src/components/charts/bars/BarChartDefaultWithLinePro/BarChartDefaultWithLinePro.emb.ts
@@ -1,0 +1,12 @@
+import { defineComponent } from '@embeddable.com/react';
+import { barChartDefaultWithLinePro } from './definition';
+
+export const preview = barChartDefaultWithLinePro.preview;
+
+export const meta = barChartDefaultWithLinePro.meta;
+
+export default defineComponent(
+  barChartDefaultWithLinePro.Component,
+  meta,
+  barChartDefaultWithLinePro.config,
+);

--- a/src/components/charts/bars/BarChartDefaultWithLinePro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultWithLinePro/definition.ts
@@ -1,0 +1,158 @@
+import {
+  DataResponse,
+  Dimension,
+  Granularity,
+  LoadDataRequest,
+  Value,
+  loadData,
+} from '@embeddable.com/core';
+import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
+import Component from './index';
+import { inputs } from '../../../component.inputs.constants';
+import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { subInputs } from '../../../component.subinputs.constants';
+
+const meta = {
+  name: 'BarChartDefaultWithLinePro',
+  label: 'Bar Chart - Default with Line',
+  category: 'Bar Charts',
+  inputs: [
+    { ...inputs.dataset, category: 'Chart Data' },
+    {
+      ...inputs.dimensionWithGranularitySelectField,
+      label: 'X-axis',
+      category: 'Chart Data',
+    },
+    {
+      ...inputs.measures,
+      category: 'Chart Data',
+      inputs: [...inputs.measures.inputs, subInputs.color, subInputs.showValueAsPercentage],
+    },
+    {
+      name: 'lineMeasures',
+      type: 'measure',
+      label: 'Line measures',
+      array: true,
+      config: {
+        dataset: 'dataset',
+      },
+      category: 'Chart Data',
+      inputs: [...inputs.measures.inputs, subInputs.color],
+    },
+    {
+      name: 'showSecondYAxis',
+      type: 'boolean',
+      label: 'Show second Y-axis',
+      defaultValue: false,
+      category: 'Axes Settings',
+    },
+    {
+      name: 'yAxisLabelSecondary',
+      type: 'string',
+      label: 'Second Y-axis label',
+      category: 'Axes Settings',
+    },
+    inputs.title,
+    inputs.description,
+    inputs.tooltip,
+    inputs.showLegend,
+    inputs.showTooltips,
+    { ...inputs.showValueLabels, label: 'Show value labels - bar' },
+    {
+      name: 'showValueLabelsLine',
+      type: 'boolean',
+      label: 'Show value labels - line',
+      defaultValue: true,
+      category: 'Component Settings',
+    },
+    inputs.showLogarithmicScale,
+    inputs.xAxisLabel,
+    inputs.yAxisLabel,
+    inputs.reverseXAxis,
+    inputs.yAxisRangeMin,
+    inputs.yAxisRangeMax,
+    inputs.xAxisMaxItems,
+    inputs.maxResults,
+  ],
+  events: [
+    {
+      name: 'onBarClicked',
+      label: 'A bar is clicked',
+      properties: [
+        {
+          name: 'axisDimensionValue',
+          label: 'Clicked axis dimension value',
+          type: 'string',
+        },
+      ],
+    },
+  ],
+} as const satisfies EmbeddedComponentMeta;
+
+export type BarChartDefaultWithLineProState = {
+  granularity?: Granularity;
+};
+
+const previewConfig = {
+  dimension: previewData.dimension,
+  measures: [previewData.measure],
+  lineMeasures: [previewData.measureVariant],
+  results: previewData.results1Measure1Dimension,
+  hideMenu: true,
+};
+
+const preview = definePreview(Component, previewConfig);
+
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  dimension?: Dimension,
+): LoadDataRequest => ({
+  limit: inputs.maxResults,
+  from: inputs.dataset,
+  select: [...inputs.measures, ...(inputs.lineMeasures ?? []), dimension ?? inputs.dimension],
+});
+
+const loadDataResults = (inputs: Inputs<typeof meta>, dimension: Dimension): DataResponse =>
+  loadData(loadDataResultsArgs(inputs, dimension));
+
+const events = {
+  onBarClicked: (value: { axisDimensionValue?: string }) => ({
+    axisDimensionValue: value.axisDimensionValue ?? Value.noFilter(),
+  }),
+};
+
+const props = (
+  inputs: Inputs<typeof meta>,
+  [state, setState]: [
+    BarChartDefaultWithLineProState,
+    (state: BarChartDefaultWithLineProState) => void,
+  ],
+) => {
+  const dimensionWithGranularity = getDimensionWithGranularity(
+    inputs.dimension,
+    state?.granularity,
+  );
+
+  return {
+    ...inputs,
+    dimension: dimensionWithGranularity,
+    setGranularity: (granularity: Granularity) => setState({ granularity }),
+    results: loadDataResults(inputs, dimensionWithGranularity),
+  };
+};
+
+export const barChartDefaultWithLinePro = {
+  Component,
+  meta,
+  preview,
+  previewConfig,
+  config: {
+    props,
+    events,
+  },
+  results: {
+    loadDataArgs: loadDataResultsArgs,
+    loadData: loadDataResults,
+  },
+} as const;

--- a/src/components/charts/bars/BarChartDefaultWithLinePro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultWithLinePro/index.tsx
@@ -1,0 +1,228 @@
+import { Chart as ChartJS, ChartData, ChartOptions, LineElement, PointElement } from 'chart.js';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
+import { useTheme } from '@embeddable.com/react';
+import { BarChart, getChartColors } from '@embeddable.com/remarkable-ui';
+import { mergician } from 'mergician';
+import { Theme } from '../../../../theme/theme.types';
+import { i18nSetup } from '../../../../theme/i18n/i18n';
+import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { resolveI18nProps } from '../../../component.utils';
+import { getBarChartProOptions } from '../bars.utils';
+import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
+import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
+import { groupTailAsOther } from '../../charts.utils';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+
+// Register elements required for mixed bar+line rendering
+ChartJS.register(LineElement, PointElement);
+
+export type BarChartDefaultWithLineProProps = {
+  dimension: Dimension;
+  measures: Measure[];
+  lineMeasures?: Measure[];
+  results: DataResponse;
+  xAxisLabel?: string;
+  xAxisMaxItems?: number;
+  yAxisLabel?: string;
+  yAxisLabelSecondary?: string;
+  yAxisRangeMin?: number;
+  yAxisRangeMax?: number;
+  showLegend?: boolean;
+  showLogarithmicScale?: boolean;
+  showTooltips?: boolean;
+  showValueLabels?: boolean;
+  showValueLabelsLine?: boolean;
+  showSecondYAxis?: boolean;
+  reverseXAxis?: boolean;
+  setGranularity?: (granularity: Granularity) => void;
+  onBarClicked?: (args: { axisDimensionValue: string | null }) => void;
+} & ChartCardHeaderProps;
+
+// Combine the bar and line data into a single ChartData object suitable for Chart.js
+const buildComboChartData = (
+  data: DataResponse['data'],
+  dimension: Dimension,
+  measures: Measure[],
+  lineMeasures: Measure[],
+  maxItems: number | undefined,
+  showSecondYAxis: boolean,
+  theme: Theme,
+): ChartData<'bar'> => {
+  if (!data) {
+    return { labels: [], datasets: [{ data: [] }] };
+  }
+
+  const allMeasures = [...measures, ...lineMeasures];
+  const groupedData = groupTailAsOther(data, dimension, allMeasures, maxItems);
+  const themeFormatter = getThemeFormatter(theme);
+  const chartColors = getChartColors();
+
+  const labels = groupedData.map((item) => item[dimension.name]);
+
+  const barDatasets = measures.map((measure, index) => ({
+    order: 1,
+    label: themeFormatter.dimensionOrMeasureTitle(measure),
+    data: groupedData.map((item) => item[measure.name] ?? 0),
+    backgroundColor: getDimensionMeasureColor({
+      dimensionOrMeasure: measure,
+      theme,
+      color: 'background',
+      value: measure.name,
+      index,
+      chartColors,
+    }),
+    borderColor: getDimensionMeasureColor({
+      dimensionOrMeasure: measure,
+      theme,
+      color: 'border',
+      value: measure.name,
+      index,
+      chartColors,
+    }),
+  }));
+
+  const lineDatasets = lineMeasures.map((measure, index) => {
+    const colorIndex = measures.length + index;
+    const color = getDimensionMeasureColor({
+      dimensionOrMeasure: measure,
+      theme,
+      color: 'background',
+      value: measure.name,
+      index: colorIndex,
+      chartColors,
+    });
+    return {
+      type: 'line' as const,
+      label: themeFormatter.dimensionOrMeasureTitle(measure),
+      data: groupedData.map((item) => item[measure.name] ?? 0),
+      backgroundColor: color,
+      borderColor: color,
+      pointRadius: 2,
+      pointHoverRadius: 3,
+      yAxisID: showSecondYAxis ? 'y1' : 'y',
+    };
+  });
+
+  // Chart.js supports mixed-type datasets but TS's ChartData<'bar'> doesn't, so we cast.
+  return {
+    labels,
+    datasets: [...barDatasets, ...lineDatasets] as ChartData<'bar'>['datasets'],
+  };
+};
+
+const BarChartDefaultWithLinePro = (props: BarChartDefaultWithLineProProps) => {
+  const theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const {
+    measures,
+    lineMeasures = [],
+    yAxisRangeMin,
+    xAxisMaxItems,
+    yAxisRangeMax,
+    showLegend,
+    showTooltips,
+    showLogarithmicScale,
+    showValueLabels,
+    showValueLabelsLine,
+    showSecondYAxis = false,
+    yAxisLabelSecondary,
+    reverseXAxis,
+    hideMenu,
+    dimension,
+    setGranularity,
+    onBarClicked,
+  } = props;
+
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
+  const results = useFillGaps({ results: props.results, dimension });
+
+  const data = buildComboChartData(
+    results.data,
+    dimension,
+    measures,
+    lineMeasures,
+    xAxisMaxItems,
+    showSecondYAxis,
+    theme,
+  );
+
+  const allMeasures = [...measures, ...lineMeasures];
+
+  const secondaryAxisOptions: Partial<ChartOptions<'bar'>> = showSecondYAxis
+    ? {
+        scales: {
+          y1: {
+            type: 'linear',
+            position: 'right',
+            title: {
+              display: Boolean(yAxisLabelSecondary),
+              text: yAxisLabelSecondary ?? '',
+            },
+            grid: { drawOnChartArea: false },
+          },
+        },
+      }
+    : {};
+
+  const valueLabelsOptions: Partial<ChartOptions<'bar'>> = {
+    plugins: {
+      datalabels: {
+        display: (context) => {
+          const isLineSeries = context.datasetIndex >= measures.length;
+          const show = isLineSeries ? showValueLabelsLine : showValueLabels;
+          return show && context.dataset.data[context.dataIndex] !== 0 ? 'auto' : false;
+        },
+      },
+    },
+  };
+
+  const options = mergician(
+    getBarChartProOptions(
+      { measures: allMeasures, horizontal: false, onBarClicked, data, dimension },
+      theme,
+    ),
+    secondaryAxisOptions,
+    valueLabelsOptions,
+    theme.charts?.barChartDefaultWithLinePro?.options ?? {},
+  );
+
+  const granularitySelectorHasMarginTop = !title && !description && !tooltip;
+
+  return (
+    <ChartCard
+      data={results}
+      dimensionsAndMeasures={[dimension, ...allMeasures]}
+      errorMessage={results.error}
+      description={description}
+      title={title}
+      tooltip={tooltip}
+      hideMenu={hideMenu}
+    >
+      {setGranularity && (
+        <ChartGranularitySelectField
+          hasMarginTop={granularitySelectorHasMarginTop}
+          dimension={dimension}
+          onChange={setGranularity}
+        />
+      )}
+      <BarChart
+        data={data}
+        showLegend={showLegend}
+        showTooltips={showTooltips}
+        showValueLabels={showValueLabels}
+        showLogarithmicScale={showLogarithmicScale}
+        xAxisLabel={xAxisLabel}
+        yAxisLabel={yAxisLabel}
+        reverseXAxis={reverseXAxis}
+        yAxisRangeMin={yAxisRangeMin}
+        yAxisRangeMax={yAxisRangeMax}
+        options={options}
+      />
+    </ChartCard>
+  );
+};
+
+export default BarChartDefaultWithLinePro;

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -36,6 +36,7 @@ export type ThemeCharts = {
   donutLabelChartPro?: { options: Partial<ChartOptions<'pie'>> };
   barChartDefaultPro?: { options: Partial<ChartOptions<'bar'>> };
   barChartDefaultHorizontalPro?: { options: Partial<ChartOptions<'bar'>> };
+  barChartDefaultWithLinePro?: { options: Partial<ChartOptions<'bar'>> };
   barChartGroupedPro?: { options: Partial<ChartOptions<'bar'>> };
   barChartGroupedHorizontalPro?: { options: Partial<ChartOptions<'bar'>> };
   barChartStackedPro?: { options: Partial<ChartOptions<'bar'>> };


### PR DESCRIPTION
# Why is this pull-request needed?

We have a POC client, N-Side, who are looking for a few charts that we don't yet support. The Bar Chart w/ Line is a straightforward one, so Ella and I thought I could put it together and make it available to them. However, it was _so_ straightforward that I actually think it's a pretty good candidate to just be added into Remarkable Pro, pending review and discussion. So I'm making this PR.

# Main changes

- Adds necessary `emb.ts`, `definition.ts`, and `index.ts` files
- Updates the theme types

# Test evidence

I've tested locally and it works fine. I'm not sure what the standard is for testing on this repo and would be happy to learn more!

<img width="1438" height="864" alt="image" src="https://github.com/user-attachments/assets/f33efe08-70de-4e15-89d6-189c45e5bbef" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BarChartDefaultWithLinePro: a new mixed bar and line chart component supporting multiple measures, configurable axes, secondary Y-axis, logarithmic scale, granularity selection, and bar-click interactions.

* **Chores**
  * Added theme customization support for the new chart component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->