### PR TITLE
[RUI-17]: Allow for applying custom font to themes

### DIFF
--- a/.changeset/red-moments-obey.md
+++ b/.changeset/red-moments-obey.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Inject fonts via theme

--- a/embeddable.lifecycle.ts
+++ b/embeddable.lifecycle.ts
@@ -1,6 +1,10 @@
-import { applyRemarkableTheme } from './src/theme/fonts/fonts.utils';
+import { loadThemeFonts } from './src/theme/fonts/fonts.utils';
+import { injectCssVariables } from './src/theme/styles/styles.utils';
 import { Theme } from './src/theme/theme.types';
 
 export default {
-  onThemeUpdated: (theme: Theme) => applyRemarkableTheme(theme),
+  onThemeUpdated: (theme: Theme) => {
+    loadThemeFonts(theme.fonts);
+    return injectCssVariables(theme.styles);
+  },
 };

--- a/embeddable.lifecycle.ts
+++ b/embeddable.lifecycle.ts
@@ -1,35 +1,6 @@
-import { injectCssVariables } from './src/theme/styles/styles.utils';
+import { applyRemarkableTheme } from './src/theme/fonts/fonts.utils';
 import { Theme } from './src/theme/theme.types';
 
-const injectInter = () => {
-  if (typeof document === 'undefined') return;
-  const head = document.head || document.getElementsByTagName('head')[0];
-  if (!head) return;
-  if (!document.querySelector('link[data-remarkable-inter]')) {
-    const pre1 = document.createElement('link');
-    pre1.rel = 'preconnect';
-    pre1.href = 'https://fonts.googleapis.com';
-    head.appendChild(pre1);
-
-    const pre2 = document.createElement('link');
-    pre2.rel = 'preconnect';
-    pre2.href = 'https://fonts.gstatic.com';
-    pre2.crossOrigin = 'anonymous';
-    head.appendChild(pre2);
-
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap';
-    link.setAttribute('data-remarkable-inter', '1');
-    head.appendChild(link);
-  }
-};
-
-injectInter();
-
 export default {
-  onThemeUpdated: (theme: Theme) => {
-    injectInter();
-    return injectCssVariables(theme.styles);
-  },
+  onThemeUpdated: (theme: Theme) => applyRemarkableTheme(theme),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.1.26",
+  "version": "0.1.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.1.26",
+      "version": "0.1.27",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.6",
         "@embeddable.com/react": "^2.13.5",
-        "@embeddable.com/remarkable-ui": "^3.0.1",
+        "@embeddable.com/remarkable-ui": "^3.0.2",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -819,9 +819,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.1.tgz",
-      "integrity": "sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
       "dev": true,
       "funding": [
         {
@@ -905,9 +905,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.0.1.tgz",
-      "integrity": "sha512-KqRYIl+WLOJuijAOiuwliSg5yj00+/6sVtcATpDAYnWj4Drzr+DE5zg6TP5CwtchzdKNmWh5QHb9qaBHqn1BtA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.0.2.tgz",
+      "integrity": "sha512-eR+sAArRhMiVlEdlZ5RG4ok/KVUW5nJCDln0bw5+WLOIq8yStslxjFOmoCMqYHPe0yEdbOeYV90MYfWOq20Xsg==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1779,14 +1779,14 @@
       "license": "MIT"
     },
     "node_modules/@happy-dom/global-registrator": {
-      "version": "20.8.8",
-      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.8.8.tgz",
-      "integrity": "sha512-2NE+gfUX092su6oZYw6yOfgPYAfx9NBLFdMLNdZZtkupCP9oZfz6qFRYf1o8la2Le7Tyb94O5TONzcozENx2xg==",
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.8.9.tgz",
+      "integrity": "sha512-DtZeRRHY9A/bisTJziUBBPrdnPui7+R185G/hzi6/Boymhqh7/wi53AY+IvQHS1+7OPaqfO/1XNpngNwthLz+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
-        "happy-dom": "^20.8.8"
+        "happy-dom": "^20.8.9"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3989,9 +3989,9 @@
       }
     },
     "node_modules/@tabler/icons": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.40.0.tgz",
-      "integrity": "sha512-V/Q4VgNPKubRTiLdmWjV/zscYcj5IIk+euicUtaVVqF6luSC9rDngYWgST5/yh3Mrg/mYUwRv1YVTk71Jp0twQ==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.41.0.tgz",
+      "integrity": "sha512-arlig0nkaC9UGqTZuT1MMZepX29t3Ysx5HSy2UvmR+CZrhlNxZrCM6Z4qYBoaIO+2ICZykttjBCSpf+p/t0H3w==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3999,12 +3999,12 @@
       }
     },
     "node_modules/@tabler/icons-react": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.40.0.tgz",
-      "integrity": "sha512-oO5+6QCnna4a//mYubx4euZfECtzQZFDGsDMIdzZUhbdyBCT+3bRVFBPueGIcemWld4Vb/0UQ39C/cmGfGylAg==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.41.0.tgz",
+      "integrity": "sha512-8XKc3wZKf1icxqwIPSOO61M+dtf8yJPwAE/rtFAVzc5Ros+OjCqowfcoI5IpKK09RSo8s0hHrWvydGgnXqYILg==",
       "license": "MIT",
       "dependencies": {
-        "@tabler/icons": "3.40.0"
+        "@tabler/icons": "3.41.0"
       },
       "funding": {
         "type": "github",
@@ -5535,9 +5535,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6685,9 +6685,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.325",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.325.tgz",
-      "integrity": "sha512-PwfIw7WQSt3xX7yOf5OE/unLzsK9CaN2f/FvV3WjPR1Knoc1T9vePRVV4W1EM301JzzysK51K7FNKcusCr0zYA==",
+      "version": "1.5.328",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
+      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
       "dev": true,
       "license": "ISC"
     },
@@ -8099,9 +8099,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.8.8",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.8.tgz",
-      "integrity": "sha512-5/F8wxkNxYtsN0bXfMwIyNLZ9WYsoOYPbmoluqVJqv8KBUbcyKZawJ7uYK4WTX8IHBLYv+VXIwfeNDPy1oKMwQ==",
+      "version": "20.8.9",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.8.9.tgz",
+      "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.6",
     "@embeddable.com/react": "^2.13.5",
-    "@embeddable.com/remarkable-ui": "^3.0.1",
+    "@embeddable.com/remarkable-ui": "^3.0.2",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,14 +19,7 @@ export * from './theme/styles/styles.utils';
 
 // Theme - Fonts
 export * from './theme/fonts/fonts.types';
-export {
-  applyRemarkableTheme,
-  getFontFamilyStyles,
-  injectInter,
-  loadThemeFonts,
-  removeThemeFonts,
-  themeHasFonts,
-} from './theme/fonts/fonts.utils';
+export { applyRemarkableTheme, loadThemeFonts, removeThemeFonts } from './theme/fonts/fonts.utils';
 
 // Theme - Formatter
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,17 @@ export * from './theme/styles/styles.types';
 export * from './theme/styles/styles.constants';
 export * from './theme/styles/styles.utils';
 
+// Theme - Fonts
+export * from './theme/fonts/fonts.types';
+export {
+  applyRemarkableTheme,
+  getFontFamilyStyles,
+  injectInter,
+  loadThemeFonts,
+  removeThemeFonts,
+  themeHasFonts,
+} from './theme/fonts/fonts.utils';
+
 // Theme - Formatter
 export type {
   NumberFormatter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export * from './theme/styles/styles.utils';
 
 // Theme - Fonts
 export * from './theme/fonts/fonts.types';
-export { applyRemarkableTheme, loadThemeFonts, removeThemeFonts } from './theme/fonts/fonts.utils';
+export { loadThemeFonts } from './theme/fonts/fonts.utils';
 
 // Theme - Formatter
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export * from './theme/styles/styles.utils';
 
 // Theme - Fonts
 export * from './theme/fonts/fonts.types';
-export { loadThemeFonts } from './theme/fonts/fonts.utils';
+export * from './theme/fonts/fonts.utils';
 
 // Theme - Formatter
 export type {

--- a/src/theme/fonts/fonts.types.ts
+++ b/src/theme/fonts/fonts.types.ts
@@ -1,16 +1,6 @@
-export type ThemeGoogleFontFamily = {
+export type ThemeFontGoogle = {
   name: string;
   weights?: string;
-};
-
-export type ThemeFontGoogleConfig = {
-  families: ThemeGoogleFontFamily[];
-  display?: string;
-};
-
-export type ThemeFontCustomSrc = {
-  url: string;
-  format?: string;
 };
 
 export type ThemeFontCustomDescriptors = {
@@ -22,11 +12,11 @@ export type ThemeFontCustomDescriptors = {
 
 export type ThemeFontCustom = {
   family: string;
-  src: string | ThemeFontCustomSrc[];
+  src: string;
   descriptors?: ThemeFontCustomDescriptors;
 };
 
 export type ThemeFonts = {
-  google?: ThemeFontGoogleConfig;
+  google?: ThemeFontGoogle[];
   custom?: ThemeFontCustom[];
 };

--- a/src/theme/fonts/fonts.types.ts
+++ b/src/theme/fonts/fonts.types.ts
@@ -1,5 +1,10 @@
+export type ThemeGoogleFontFamily = {
+  name: string;
+  weights?: string;
+};
+
 export type ThemeFontGoogleConfig = {
-  families: string[];
+  families: ThemeGoogleFontFamily[];
   display?: string;
 };
 
@@ -24,6 +29,4 @@ export type ThemeFontCustom = {
 export type ThemeFonts = {
   google?: ThemeFontGoogleConfig;
   custom?: ThemeFontCustom[];
-  familyBase?: string;
-  familyCode?: string;
 };

--- a/src/theme/fonts/fonts.types.ts
+++ b/src/theme/fonts/fonts.types.ts
@@ -1,0 +1,29 @@
+export type ThemeFontGoogleConfig = {
+  families: string[];
+  display?: string;
+};
+
+export type ThemeFontCustomSrc = {
+  url: string;
+  format?: string;
+};
+
+export type ThemeFontCustomDescriptors = {
+  style?: string;
+  weight?: string;
+  stretch?: string;
+  unicodeRange?: string;
+};
+
+export type ThemeFontCustom = {
+  family: string;
+  src: string | ThemeFontCustomSrc[];
+  descriptors?: ThemeFontCustomDescriptors;
+};
+
+export type ThemeFonts = {
+  google?: ThemeFontGoogleConfig;
+  custom?: ThemeFontCustom[];
+  familyBase?: string;
+  familyCode?: string;
+};

--- a/src/theme/fonts/fonts.utils.test.ts
+++ b/src/theme/fonts/fonts.utils.test.ts
@@ -1,10 +1,4 @@
-import { applyRemarkableTheme, loadThemeFonts, removeThemeFonts } from './fonts.utils';
-import type { Theme } from '../theme.types';
-
-type ThemeOverrides = Omit<Partial<Theme>, 'styles'> & { styles?: Record<string, string> };
-
-const makeTheme = (overrides: ThemeOverrides = {}): Theme =>
-  ({ styles: {}, ...overrides }) as unknown as Theme;
+import { loadThemeFonts } from './fonts.utils';
 
 const getGoogleFontLinks = () => document.querySelectorAll('link[data-remarkable-google-fonts]');
 
@@ -12,21 +6,23 @@ const getPreconnectLinks = () => document.querySelectorAll('link[data-remarkable
 
 const getCustomFontStyle = () => document.getElementById('remarkable-theme-fonts');
 
-describe('loadThemeFonts', () => {
-  afterEach(() => removeThemeFonts());
+const cleanup = () => {
+  document.querySelectorAll('link[data-remarkable-preconnect]').forEach((el) => el.remove());
+  document.querySelectorAll('link[data-remarkable-google-fonts]').forEach((el) => el.remove());
+  document.getElementById('remarkable-theme-fonts')?.remove();
+};
 
-  it('is a no-op when theme.fonts is undefined', () => {
-    loadThemeFonts(makeTheme());
+describe('loadThemeFonts', () => {
+  afterEach(() => cleanup());
+
+  it('is a no-op when fonts is undefined', () => {
+    loadThemeFonts(undefined);
     expect(getGoogleFontLinks()).toHaveLength(0);
     expect(getCustomFontStyle()).toBeNull();
   });
 
-  it('loads Google Fonts when google.families is provided', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: { google: { families: [{ name: 'Roboto' }, { name: 'Open Sans' }] } },
-      }),
-    );
+  it('loads Google Fonts when google fonts are provided', () => {
+    loadThemeFonts({ google: [{ name: 'Roboto' }, { name: 'Open Sans' }] });
 
     const links = getGoogleFontLinks();
     expect(links).toHaveLength(1);
@@ -37,40 +33,34 @@ describe('loadThemeFonts', () => {
   });
 
   it('respects custom weights per family', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: { google: { families: [{ name: 'Roboto', weights: '400;700' }] } },
-      }),
-    );
+    loadThemeFonts({ google: [{ name: 'Roboto', weights: '400;700' }] });
 
     const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
     expect(href).toContain('wght@400;700');
   });
 
   it('defaults to full weight range when weights not specified', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: [{ name: 'Lato' }] } } }));
+    loadThemeFonts({ google: [{ name: 'Lato' }] });
 
     const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
     expect(href).toContain('wght@100..900');
   });
 
-  it('respects custom display parameter for Google Fonts', () => {
-    loadThemeFonts(
-      makeTheme({ fonts: { google: { families: [{ name: 'Lato' }], display: 'block' } } }),
-    );
+  it('injects preconnect links for Google Fonts', () => {
+    loadThemeFonts({ google: [{ name: 'Roboto' }] });
+    expect(getPreconnectLinks()).toHaveLength(2);
+  });
 
-    const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
-    expect(href).toContain('display=block');
+  it('does not duplicate Google Font links on repeated calls', () => {
+    loadThemeFonts({ google: [{ name: 'Roboto' }] });
+    loadThemeFonts({ google: [{ name: 'Roboto' }] });
+    expect(getGoogleFontLinks()).toHaveLength(1);
   });
 
   it('injects @font-face rules for custom fonts', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: {
-          custom: [{ family: 'BrandFont', src: 'https://example.com/brand.woff2' }],
-        },
-      }),
-    );
+    loadThemeFonts({
+      custom: [{ family: 'BrandFont', src: 'https://example.com/brand.woff2' }],
+    });
 
     const styleEl = getCustomFontStyle();
     expect(styleEl).not.toBeNull();
@@ -78,42 +68,16 @@ describe('loadThemeFonts', () => {
     expect(styleEl!.textContent).toContain('url(https://example.com/brand.woff2)');
   });
 
-  it('supports multiple custom font sources with format', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: {
-          custom: [
-            {
-              family: 'MyFont',
-              src: [
-                { url: 'https://example.com/font.woff2', format: 'woff2' },
-                { url: 'https://example.com/font.woff', format: 'woff' },
-              ],
-            },
-          ],
-        },
-      }),
-    );
-
-    const css = getCustomFontStyle()!.textContent!;
-    expect(css).toContain("format('woff2')");
-    expect(css).toContain("format('woff')");
-  });
-
   it('includes font descriptors in @font-face rules', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: {
-          custom: [
-            {
-              family: 'MyFont',
-              src: 'https://example.com/bold.woff2',
-              descriptors: { weight: '700', style: 'italic' },
-            },
-          ],
+    loadThemeFonts({
+      custom: [
+        {
+          family: 'MyFont',
+          src: 'https://example.com/bold.woff2',
+          descriptors: { weight: '700', style: 'italic' },
         },
-      }),
-    );
+      ],
+    });
 
     const css = getCustomFontStyle()!.textContent!;
     expect(css).toContain('font-weight: 700');
@@ -121,97 +85,12 @@ describe('loadThemeFonts', () => {
   });
 
   it('loads both Google and custom fonts together', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: {
-          google: { families: [{ name: 'Roboto' }] },
-          custom: [{ family: 'BrandFont', src: 'https://example.com/brand.woff2' }],
-        },
-      }),
-    );
+    loadThemeFonts({
+      google: [{ name: 'Roboto' }],
+      custom: [{ family: 'BrandFont', src: 'https://example.com/brand.woff2' }],
+    });
 
     expect(getGoogleFontLinks()).toHaveLength(1);
     expect(getCustomFontStyle()).not.toBeNull();
-  });
-});
-
-describe('removeThemeFonts', () => {
-  it('removes preconnect links', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: [{ name: 'Roboto' }] } } }));
-    expect(getPreconnectLinks()).toHaveLength(2);
-
-    removeThemeFonts();
-    expect(getPreconnectLinks()).toHaveLength(0);
-  });
-
-  it('removes Google Font links', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: [{ name: 'Roboto' }] } } }));
-    expect(getGoogleFontLinks()).toHaveLength(1);
-
-    removeThemeFonts();
-    expect(getGoogleFontLinks()).toHaveLength(0);
-  });
-
-  it('removes custom font style element', () => {
-    loadThemeFonts(
-      makeTheme({
-        fonts: { custom: [{ family: 'X', src: 'https://example.com/x.woff2' }] },
-      }),
-    );
-    expect(getCustomFontStyle()).not.toBeNull();
-
-    removeThemeFonts();
-    expect(getCustomFontStyle()).toBeNull();
-  });
-});
-
-describe('applyRemarkableTheme', () => {
-  afterEach(() => removeThemeFonts());
-
-  it('loads fonts and injects CSS variables', () => {
-    const cleanup = applyRemarkableTheme(
-      makeTheme({
-        fonts: { google: { families: [{ name: 'Roboto' }] } },
-        styles: { '--em-core-font-family--base': "'Roboto'", '--em-sem-text': '#000' },
-      }),
-    );
-
-    expect(getGoogleFontLinks()).toHaveLength(1);
-
-    const styleEl = document.getElementById('remarkable-ui-embeddable-style');
-    expect(styleEl?.textContent).toContain("--em-core-font-family--base: 'Roboto'");
-    expect(styleEl?.textContent).toContain('--em-sem-text: #000');
-
-    if (typeof cleanup === 'function') cleanup();
-  });
-
-  it('cleans up previous fonts before loading new ones', () => {
-    applyRemarkableTheme(makeTheme({ fonts: { google: { families: [{ name: 'Roboto' }] } } }));
-    expect(getGoogleFontLinks()).toHaveLength(1);
-
-    applyRemarkableTheme(makeTheme({ fonts: { google: { families: [{ name: 'Open Sans' }] } } }));
-
-    expect(getGoogleFontLinks()).toHaveLength(1);
-    expect((getGoogleFontLinks()[0] as HTMLLinkElement).href).toContain('family=Open%20Sans');
-  });
-
-  it('loads Inter by default when using remarkableTheme fonts', () => {
-    applyRemarkableTheme(
-      makeTheme({
-        fonts: { google: { families: [{ name: 'Inter', weights: '100..900' }] } },
-      }),
-    );
-
-    const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
-    expect(href).toContain('family=Inter');
-    expect(href).toContain('wght@100..900');
-  });
-
-  it('injects only styles when no fonts are configured', () => {
-    applyRemarkableTheme(makeTheme({ styles: { '--em-sem-text': 'red' } }));
-
-    expect(getGoogleFontLinks()).toHaveLength(0);
-    const styleEl = document.getElementById('remarkable-ui-embeddable-style');
-    expect(styleEl?.textContent).toContain('--em-sem-text: red');
   });
 });

--- a/src/theme/fonts/fonts.utils.test.ts
+++ b/src/theme/fonts/fonts.utils.test.ts
@@ -1,0 +1,299 @@
+import {
+  applyRemarkableTheme,
+  loadThemeFonts,
+  getFontFamilyStyles,
+  removeThemeFonts,
+  injectInter,
+  themeHasFonts,
+} from './fonts.utils';
+import type { Theme } from '../theme.types';
+
+type ThemeOverrides = Omit<Partial<Theme>, 'styles'> & { styles?: Record<string, string> };
+
+const makeTheme = (overrides: ThemeOverrides = {}): Theme =>
+  ({ styles: {}, ...overrides }) as unknown as Theme;
+
+const getGoogleFontLinks = () => document.querySelectorAll('link[data-remarkable-google-fonts]');
+
+const getInterLinks = () => document.querySelectorAll('link[data-remarkable-inter]');
+
+const getCustomFontStyle = () => document.getElementById('remarkable-theme-fonts');
+
+describe('loadThemeFonts', () => {
+  afterEach(() => removeThemeFonts());
+
+  it('is a no-op when theme.fonts is undefined', () => {
+    loadThemeFonts(makeTheme());
+    expect(getGoogleFontLinks()).toHaveLength(0);
+    expect(getCustomFontStyle()).toBeNull();
+  });
+
+  it('loads Google Fonts when google.families is provided', () => {
+    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto', 'Open Sans'] } } }));
+
+    const links = getGoogleFontLinks();
+    expect(links).toHaveLength(1);
+    const href = (links[0] as HTMLLinkElement).href;
+    expect(href).toContain('family=Roboto');
+    expect(href).toContain('family=Open%20Sans');
+    expect(href).toContain('display=swap');
+  });
+
+  it('respects custom display parameter for Google Fonts', () => {
+    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Lato'], display: 'block' } } }));
+
+    const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
+    expect(href).toContain('display=block');
+  });
+
+  it('injects @font-face rules for custom fonts', () => {
+    loadThemeFonts(
+      makeTheme({
+        fonts: {
+          custom: [{ family: 'BrandFont', src: 'https://example.com/brand.woff2' }],
+        },
+      }),
+    );
+
+    const styleEl = getCustomFontStyle();
+    expect(styleEl).not.toBeNull();
+    expect(styleEl!.textContent).toContain("font-family: 'BrandFont'");
+    expect(styleEl!.textContent).toContain('url(https://example.com/brand.woff2)');
+  });
+
+  it('supports multiple custom font sources with format', () => {
+    loadThemeFonts(
+      makeTheme({
+        fonts: {
+          custom: [
+            {
+              family: 'MyFont',
+              src: [
+                { url: 'https://example.com/font.woff2', format: 'woff2' },
+                { url: 'https://example.com/font.woff', format: 'woff' },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    const css = getCustomFontStyle()!.textContent!;
+    expect(css).toContain("format('woff2')");
+    expect(css).toContain("format('woff')");
+  });
+
+  it('includes font descriptors in @font-face rules', () => {
+    loadThemeFonts(
+      makeTheme({
+        fonts: {
+          custom: [
+            {
+              family: 'MyFont',
+              src: 'https://example.com/bold.woff2',
+              descriptors: { weight: '700', style: 'italic' },
+            },
+          ],
+        },
+      }),
+    );
+
+    const css = getCustomFontStyle()!.textContent!;
+    expect(css).toContain('font-weight: 700');
+    expect(css).toContain('font-style: italic');
+  });
+});
+
+describe('getFontFamilyStyles', () => {
+  it('returns empty object when no fonts config', () => {
+    expect(getFontFamilyStyles(makeTheme())).toEqual({});
+  });
+
+  it('uses familyBase for --em-core-font-family--base', () => {
+    const result = getFontFamilyStyles(makeTheme({ fonts: { familyBase: 'Roboto' } }));
+    expect(result['--em-core-font-family--base']).toBe("'Roboto'");
+  });
+
+  it('uses familyCode for --em-core-font-family--code', () => {
+    const result = getFontFamilyStyles(makeTheme({ fonts: { familyCode: 'Fira Code' } }));
+    expect(result['--em-core-font-family--code']).toBe("'Fira Code'");
+  });
+
+  it('falls back to first Google family when familyBase is not set', () => {
+    const result = getFontFamilyStyles(
+      makeTheme({ fonts: { google: { families: ['Lato', 'Open Sans'] } } }),
+    );
+    expect(result['--em-core-font-family--base']).toBe("'Lato'");
+  });
+
+  it('falls back to first custom font family when no Google families', () => {
+    const result = getFontFamilyStyles(
+      makeTheme({
+        fonts: { custom: [{ family: 'BrandFont', src: 'https://example.com/f.woff2' }] },
+      }),
+    );
+    expect(result['--em-core-font-family--base']).toBe("'BrandFont'");
+  });
+
+  it('familyBase takes precedence over google/custom families', () => {
+    const result = getFontFamilyStyles(
+      makeTheme({
+        fonts: {
+          google: { families: ['Roboto'] },
+          familyBase: 'CustomName',
+        },
+      }),
+    );
+    expect(result['--em-core-font-family--base']).toBe("'CustomName'");
+  });
+});
+
+describe('themeHasFonts', () => {
+  it('returns false when no fonts and default styles', () => {
+    expect(themeHasFonts(makeTheme())).toBe(false);
+  });
+
+  it('returns true when Google families are set', () => {
+    expect(themeHasFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }))).toBe(true);
+  });
+
+  it('returns true when custom fonts are set', () => {
+    expect(
+      themeHasFonts(
+        makeTheme({
+          fonts: { custom: [{ family: 'X', src: 'https://example.com/x.woff2' }] },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true when styles override --em-core-font-family--base with non-default', () => {
+    expect(
+      themeHasFonts(
+        makeTheme({
+          styles: { '--em-core-font-family--base': "'Roboto'" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when styles set --em-core-font-family--base to inter', () => {
+    expect(
+      themeHasFonts(
+        makeTheme({
+          styles: { '--em-core-font-family--base': 'inter' },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for generic font families in styles', () => {
+    expect(
+      themeHasFonts(
+        makeTheme({
+          styles: { '--em-core-font-family--base': 'sans-serif' },
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('injectInter', () => {
+  afterEach(() => removeThemeFonts());
+
+  it('injects Inter stylesheet with preconnect links', () => {
+    injectInter();
+
+    const links = getInterLinks();
+    expect(links).toHaveLength(1);
+    expect((links[0] as HTMLLinkElement).href).toContain('family=Inter');
+  });
+
+  it('does not duplicate Inter links on repeated calls', () => {
+    injectInter();
+    injectInter();
+
+    expect(getInterLinks()).toHaveLength(1);
+  });
+});
+
+describe('removeThemeFonts', () => {
+  it('removes Google Font links', () => {
+    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
+    expect(getGoogleFontLinks()).toHaveLength(1);
+
+    removeThemeFonts();
+    expect(getGoogleFontLinks()).toHaveLength(0);
+  });
+
+  it('removes custom font style element', () => {
+    loadThemeFonts(
+      makeTheme({
+        fonts: { custom: [{ family: 'X', src: 'https://example.com/x.woff2' }] },
+      }),
+    );
+    expect(getCustomFontStyle()).not.toBeNull();
+
+    removeThemeFonts();
+    expect(getCustomFontStyle()).toBeNull();
+  });
+
+  it('removes Inter links', () => {
+    injectInter();
+    expect(getInterLinks()).toHaveLength(1);
+
+    removeThemeFonts();
+    expect(getInterLinks()).toHaveLength(0);
+  });
+});
+
+describe('applyRemarkableTheme', () => {
+  afterEach(() => removeThemeFonts());
+
+  it('loads custom fonts and injects CSS variables with font overrides', () => {
+    const cleanup = applyRemarkableTheme(
+      makeTheme({
+        fonts: {
+          google: { families: ['Roboto'] },
+          familyBase: 'Roboto',
+        },
+        styles: { '--em-sem-text': '#000' },
+      }),
+    );
+
+    expect(getGoogleFontLinks()).toHaveLength(1);
+
+    const styleEl = document.getElementById('remarkable-ui-embeddable-style');
+    expect(styleEl?.textContent).toContain("--em-core-font-family--base: 'Roboto'");
+    expect(styleEl?.textContent).toContain('--em-sem-text: #000');
+
+    if (typeof cleanup === 'function') cleanup();
+  });
+
+  it('defers Inter loading when no custom fonts are configured', () => {
+    vi.useFakeTimers();
+
+    applyRemarkableTheme(makeTheme());
+
+    expect(getInterLinks()).toHaveLength(0);
+
+    vi.runAllTimers();
+    expect(getInterLinks()).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+
+  it('cancels deferred Inter when a themed font arrives', () => {
+    vi.useFakeTimers();
+
+    applyRemarkableTheme(makeTheme());
+
+    applyRemarkableTheme(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
+
+    vi.runAllTimers();
+    expect(getInterLinks()).toHaveLength(0);
+    expect(getGoogleFontLinks()).toHaveLength(1);
+
+    vi.useRealTimers();
+  });
+});

--- a/src/theme/fonts/fonts.utils.test.ts
+++ b/src/theme/fonts/fonts.utils.test.ts
@@ -218,6 +218,14 @@ describe('injectInter', () => {
 });
 
 describe('removeThemeFonts', () => {
+  it('removes preconnect links', () => {
+    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
+    expect(document.querySelectorAll('link[data-remarkable-preconnect]')).toHaveLength(2);
+
+    removeThemeFonts();
+    expect(document.querySelectorAll('link[data-remarkable-preconnect]')).toHaveLength(0);
+  });
+
   it('removes Google Font links', () => {
     loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
     expect(getGoogleFontLinks()).toHaveLength(1);

--- a/src/theme/fonts/fonts.utils.test.ts
+++ b/src/theme/fonts/fonts.utils.test.ts
@@ -1,11 +1,4 @@
-import {
-  applyRemarkableTheme,
-  loadThemeFonts,
-  getFontFamilyStyles,
-  removeThemeFonts,
-  injectInter,
-  themeHasFonts,
-} from './fonts.utils';
+import { applyRemarkableTheme, loadThemeFonts, removeThemeFonts } from './fonts.utils';
 import type { Theme } from '../theme.types';
 
 type ThemeOverrides = Omit<Partial<Theme>, 'styles'> & { styles?: Record<string, string> };
@@ -15,7 +8,7 @@ const makeTheme = (overrides: ThemeOverrides = {}): Theme =>
 
 const getGoogleFontLinks = () => document.querySelectorAll('link[data-remarkable-google-fonts]');
 
-const getInterLinks = () => document.querySelectorAll('link[data-remarkable-inter]');
+const getPreconnectLinks = () => document.querySelectorAll('link[data-remarkable-preconnect]');
 
 const getCustomFontStyle = () => document.getElementById('remarkable-theme-fonts');
 
@@ -29,7 +22,11 @@ describe('loadThemeFonts', () => {
   });
 
   it('loads Google Fonts when google.families is provided', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto', 'Open Sans'] } } }));
+    loadThemeFonts(
+      makeTheme({
+        fonts: { google: { families: [{ name: 'Roboto' }, { name: 'Open Sans' }] } },
+      }),
+    );
 
     const links = getGoogleFontLinks();
     expect(links).toHaveLength(1);
@@ -39,8 +36,28 @@ describe('loadThemeFonts', () => {
     expect(href).toContain('display=swap');
   });
 
+  it('respects custom weights per family', () => {
+    loadThemeFonts(
+      makeTheme({
+        fonts: { google: { families: [{ name: 'Roboto', weights: '400;700' }] } },
+      }),
+    );
+
+    const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
+    expect(href).toContain('wght@400;700');
+  });
+
+  it('defaults to full weight range when weights not specified', () => {
+    loadThemeFonts(makeTheme({ fonts: { google: { families: [{ name: 'Lato' }] } } }));
+
+    const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
+    expect(href).toContain('wght@100..900');
+  });
+
   it('respects custom display parameter for Google Fonts', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Lato'], display: 'block' } } }));
+    loadThemeFonts(
+      makeTheme({ fonts: { google: { families: [{ name: 'Lato' }], display: 'block' } } }),
+    );
 
     const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
     expect(href).toContain('display=block');
@@ -102,132 +119,33 @@ describe('loadThemeFonts', () => {
     expect(css).toContain('font-weight: 700');
     expect(css).toContain('font-style: italic');
   });
-});
 
-describe('getFontFamilyStyles', () => {
-  it('returns empty object when no fonts config', () => {
-    expect(getFontFamilyStyles(makeTheme())).toEqual({});
-  });
-
-  it('uses familyBase for --em-core-font-family--base', () => {
-    const result = getFontFamilyStyles(makeTheme({ fonts: { familyBase: 'Roboto' } }));
-    expect(result['--em-core-font-family--base']).toBe("'Roboto'");
-  });
-
-  it('uses familyCode for --em-core-font-family--code', () => {
-    const result = getFontFamilyStyles(makeTheme({ fonts: { familyCode: 'Fira Code' } }));
-    expect(result['--em-core-font-family--code']).toBe("'Fira Code'");
-  });
-
-  it('falls back to first Google family when familyBase is not set', () => {
-    const result = getFontFamilyStyles(
-      makeTheme({ fonts: { google: { families: ['Lato', 'Open Sans'] } } }),
-    );
-    expect(result['--em-core-font-family--base']).toBe("'Lato'");
-  });
-
-  it('falls back to first custom font family when no Google families', () => {
-    const result = getFontFamilyStyles(
-      makeTheme({
-        fonts: { custom: [{ family: 'BrandFont', src: 'https://example.com/f.woff2' }] },
-      }),
-    );
-    expect(result['--em-core-font-family--base']).toBe("'BrandFont'");
-  });
-
-  it('familyBase takes precedence over google/custom families', () => {
-    const result = getFontFamilyStyles(
+  it('loads both Google and custom fonts together', () => {
+    loadThemeFonts(
       makeTheme({
         fonts: {
-          google: { families: ['Roboto'] },
-          familyBase: 'CustomName',
+          google: { families: [{ name: 'Roboto' }] },
+          custom: [{ family: 'BrandFont', src: 'https://example.com/brand.woff2' }],
         },
       }),
     );
-    expect(result['--em-core-font-family--base']).toBe("'CustomName'");
-  });
-});
 
-describe('themeHasFonts', () => {
-  it('returns false when no fonts and default styles', () => {
-    expect(themeHasFonts(makeTheme())).toBe(false);
-  });
-
-  it('returns true when Google families are set', () => {
-    expect(themeHasFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }))).toBe(true);
-  });
-
-  it('returns true when custom fonts are set', () => {
-    expect(
-      themeHasFonts(
-        makeTheme({
-          fonts: { custom: [{ family: 'X', src: 'https://example.com/x.woff2' }] },
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it('returns true when styles override --em-core-font-family--base with non-default', () => {
-    expect(
-      themeHasFonts(
-        makeTheme({
-          styles: { '--em-core-font-family--base': "'Roboto'" },
-        }),
-      ),
-    ).toBe(true);
-  });
-
-  it('returns false when styles set --em-core-font-family--base to inter', () => {
-    expect(
-      themeHasFonts(
-        makeTheme({
-          styles: { '--em-core-font-family--base': 'inter' },
-        }),
-      ),
-    ).toBe(false);
-  });
-
-  it('returns false for generic font families in styles', () => {
-    expect(
-      themeHasFonts(
-        makeTheme({
-          styles: { '--em-core-font-family--base': 'sans-serif' },
-        }),
-      ),
-    ).toBe(false);
-  });
-});
-
-describe('injectInter', () => {
-  afterEach(() => removeThemeFonts());
-
-  it('injects Inter stylesheet with preconnect links', () => {
-    injectInter();
-
-    const links = getInterLinks();
-    expect(links).toHaveLength(1);
-    expect((links[0] as HTMLLinkElement).href).toContain('family=Inter');
-  });
-
-  it('does not duplicate Inter links on repeated calls', () => {
-    injectInter();
-    injectInter();
-
-    expect(getInterLinks()).toHaveLength(1);
+    expect(getGoogleFontLinks()).toHaveLength(1);
+    expect(getCustomFontStyle()).not.toBeNull();
   });
 });
 
 describe('removeThemeFonts', () => {
   it('removes preconnect links', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
-    expect(document.querySelectorAll('link[data-remarkable-preconnect]')).toHaveLength(2);
+    loadThemeFonts(makeTheme({ fonts: { google: { families: [{ name: 'Roboto' }] } } }));
+    expect(getPreconnectLinks()).toHaveLength(2);
 
     removeThemeFonts();
-    expect(document.querySelectorAll('link[data-remarkable-preconnect]')).toHaveLength(0);
+    expect(getPreconnectLinks()).toHaveLength(0);
   });
 
   it('removes Google Font links', () => {
-    loadThemeFonts(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
+    loadThemeFonts(makeTheme({ fonts: { google: { families: [{ name: 'Roboto' }] } } }));
     expect(getGoogleFontLinks()).toHaveLength(1);
 
     removeThemeFonts();
@@ -245,27 +163,16 @@ describe('removeThemeFonts', () => {
     removeThemeFonts();
     expect(getCustomFontStyle()).toBeNull();
   });
-
-  it('removes Inter links', () => {
-    injectInter();
-    expect(getInterLinks()).toHaveLength(1);
-
-    removeThemeFonts();
-    expect(getInterLinks()).toHaveLength(0);
-  });
 });
 
 describe('applyRemarkableTheme', () => {
   afterEach(() => removeThemeFonts());
 
-  it('loads custom fonts and injects CSS variables with font overrides', () => {
+  it('loads fonts and injects CSS variables', () => {
     const cleanup = applyRemarkableTheme(
       makeTheme({
-        fonts: {
-          google: { families: ['Roboto'] },
-          familyBase: 'Roboto',
-        },
-        styles: { '--em-sem-text': '#000' },
+        fonts: { google: { families: [{ name: 'Roboto' }] } },
+        styles: { '--em-core-font-family--base': "'Roboto'", '--em-sem-text': '#000' },
       }),
     );
 
@@ -278,30 +185,33 @@ describe('applyRemarkableTheme', () => {
     if (typeof cleanup === 'function') cleanup();
   });
 
-  it('defers Inter loading when no custom fonts are configured', () => {
-    vi.useFakeTimers();
-
-    applyRemarkableTheme(makeTheme());
-
-    expect(getInterLinks()).toHaveLength(0);
-
-    vi.runAllTimers();
-    expect(getInterLinks()).toHaveLength(1);
-
-    vi.useRealTimers();
-  });
-
-  it('cancels deferred Inter when a themed font arrives', () => {
-    vi.useFakeTimers();
-
-    applyRemarkableTheme(makeTheme());
-
-    applyRemarkableTheme(makeTheme({ fonts: { google: { families: ['Roboto'] } } }));
-
-    vi.runAllTimers();
-    expect(getInterLinks()).toHaveLength(0);
+  it('cleans up previous fonts before loading new ones', () => {
+    applyRemarkableTheme(makeTheme({ fonts: { google: { families: [{ name: 'Roboto' }] } } }));
     expect(getGoogleFontLinks()).toHaveLength(1);
 
-    vi.useRealTimers();
+    applyRemarkableTheme(makeTheme({ fonts: { google: { families: [{ name: 'Open Sans' }] } } }));
+
+    expect(getGoogleFontLinks()).toHaveLength(1);
+    expect((getGoogleFontLinks()[0] as HTMLLinkElement).href).toContain('family=Open%20Sans');
+  });
+
+  it('loads Inter by default when using remarkableTheme fonts', () => {
+    applyRemarkableTheme(
+      makeTheme({
+        fonts: { google: { families: [{ name: 'Inter', weights: '100..900' }] } },
+      }),
+    );
+
+    const href = (getGoogleFontLinks()[0] as HTMLLinkElement).href;
+    expect(href).toContain('family=Inter');
+    expect(href).toContain('wght@100..900');
+  });
+
+  it('injects only styles when no fonts are configured', () => {
+    applyRemarkableTheme(makeTheme({ styles: { '--em-sem-text': 'red' } }));
+
+    expect(getGoogleFontLinks()).toHaveLength(0);
+    const styleEl = document.getElementById('remarkable-ui-embeddable-style');
+    expect(styleEl?.textContent).toContain('--em-sem-text: red');
   });
 });

--- a/src/theme/fonts/fonts.utils.ts
+++ b/src/theme/fonts/fonts.utils.ts
@@ -1,6 +1,4 @@
-import { injectCssVariables } from '../styles/styles.utils';
-import { Theme } from '../theme.types';
-import { ThemeFontCustom, ThemeGoogleFontFamily } from './fonts.types';
+import { ThemeFonts, ThemeFontCustom, ThemeFontGoogle } from './fonts.types';
 
 const REMARKABLE_FONTS_STYLE_ID = 'remarkable-theme-fonts';
 const REMARKABLE_PRECONNECT_ATTR = 'data-remarkable-preconnect';
@@ -23,14 +21,14 @@ const injectGooglePreconnect = (head: HTMLHeadElement): void => {
   head.appendChild(pre2);
 };
 
-const injectGoogleFonts = (families: ThemeGoogleFontFamily[], display = 'swap'): void => {
+const injectGoogleFonts = (fonts: ThemeFontGoogle[]): void => {
   if (typeof document === 'undefined' || !document.head) return;
   if (document.querySelector(`link[${REMARKABLE_GOOGLE_FONTS_ATTR}]`)) return;
 
   const head = document.head;
   injectGooglePreconnect(head);
 
-  const query = families
+  const query = fonts
     .map((f) => {
       const encoded = encodeURIComponent(f.name.replace(/\s+/g, ' '));
       const weights = f.weights ?? '100..900';
@@ -40,22 +38,13 @@ const injectGoogleFonts = (families: ThemeGoogleFontFamily[], display = 'swap'):
 
   const link = document.createElement('link');
   link.rel = 'stylesheet';
-  link.href = `https://fonts.googleapis.com/css2?${query}&display=${display}`;
+  link.href = `https://fonts.googleapis.com/css2?${query}&display=swap`;
   link.setAttribute(REMARKABLE_GOOGLE_FONTS_ATTR, '1');
   head.appendChild(link);
 };
 
 const fontFaceCss = (font: ThemeFontCustom): string => {
   const family = font.family.replace(/'/g, "\\'");
-  let src: string;
-
-  if (typeof font.src === 'string') {
-    src = `url(${font.src})`;
-  } else {
-    src = font.src
-      .map((s) => (s.format ? `url(${s.url}) format('${s.format}')` : `url(${s.url})`))
-      .join(', ');
-  }
 
   const descriptorParts: string[] = [];
   if (font.descriptors) {
@@ -69,7 +58,7 @@ const fontFaceCss = (font: ThemeFontCustom): string => {
   const descriptors = descriptorParts.join('; ');
   const decl = descriptors ? `; ${descriptors}` : '';
 
-  return `@font-face { font-family: '${family}'; src: ${src}${decl}; }`;
+  return `@font-face { font-family: '${family}'; src: url(${font.src})${decl}; }`;
 };
 
 const injectCustomFonts = (custom: ThemeFontCustom[]): void => {
@@ -88,34 +77,13 @@ const injectCustomFonts = (custom: ThemeFontCustom[]): void => {
   }
 };
 
-export const loadThemeFonts = (theme: Theme): void => {
-  const fonts = theme.fonts;
+export const loadThemeFonts = (fonts?: ThemeFonts): void => {
   if (!fonts) return;
 
-  if (fonts.google?.families?.length) {
-    injectGoogleFonts(fonts.google.families, fonts.google.display ?? 'swap');
+  if (fonts.google?.length) {
+    injectGoogleFonts(fonts.google);
   }
   if (fonts.custom?.length) {
     injectCustomFonts(fonts.custom);
   }
-};
-
-export const removeThemeFonts = (): void => {
-  if (typeof document === 'undefined') return;
-
-  document.querySelectorAll(`link[${REMARKABLE_PRECONNECT_ATTR}]`).forEach((el) => el.remove());
-  document.querySelectorAll(`link[${REMARKABLE_GOOGLE_FONTS_ATTR}]`).forEach((el) => el.remove());
-  document.getElementById(REMARKABLE_FONTS_STYLE_ID)?.remove();
-};
-
-/**
- * Applies Remarkable theme to the DOM: loads fonts and injects CSS variables.
- *
- * Fonts are loaded based on theme.fonts (Inter by default via remarkableTheme).
- * Font assignment (which font is used where) is controlled via theme.styles CSS variables.
- */
-export const applyRemarkableTheme = (theme: Theme): (() => void) | void => {
-  removeThemeFonts();
-  loadThemeFonts(theme);
-  return injectCssVariables(theme.styles);
 };

--- a/src/theme/fonts/fonts.utils.ts
+++ b/src/theme/fonts/fonts.utils.ts
@@ -21,7 +21,8 @@ const injectGooglePreconnect = (head: HTMLHeadElement): void => {
   head.appendChild(pre2);
 };
 
-const injectGoogleFonts = (fonts: ThemeFontGoogle[]): void => {
+const injectGoogleFonts = (fonts: ThemeFontGoogle[] | undefined): void => {
+  if (!fonts || fonts.length === 0) return;
   if (typeof document === 'undefined' || !document.head) return;
   if (document.querySelector(`link[${REMARKABLE_GOOGLE_FONTS_ATTR}]`)) return;
 
@@ -61,7 +62,8 @@ const fontFaceCss = (font: ThemeFontCustom): string => {
   return `@font-face { font-family: '${family}'; src: url(${font.src})${decl}; }`;
 };
 
-const injectCustomFonts = (custom: ThemeFontCustom[]): void => {
+const injectCustomFonts = (custom: ThemeFontCustom[] | undefined): void => {
+  if (!custom || custom.length === 0) return;
   if (typeof document === 'undefined' || !document.head || custom.length === 0) return;
 
   let styleEl = document.getElementById(REMARKABLE_FONTS_STYLE_ID) as HTMLStyleElement | null;
@@ -80,10 +82,6 @@ const injectCustomFonts = (custom: ThemeFontCustom[]): void => {
 export const loadThemeFonts = (fonts?: ThemeFonts): void => {
   if (!fonts) return;
 
-  if (fonts.google?.length) {
-    injectGoogleFonts(fonts.google);
-  }
-  if (fonts.custom?.length) {
-    injectCustomFonts(fonts.custom);
-  }
+  injectGoogleFonts(fonts.google);
+  injectCustomFonts(fonts.custom);
 };

--- a/src/theme/fonts/fonts.utils.ts
+++ b/src/theme/fonts/fonts.utils.ts
@@ -1,4 +1,4 @@
-import { ThemeFonts, ThemeFontCustom, ThemeFontGoogle } from './fonts.types';
+import { ThemeFonts, ThemeFontCustom } from './fonts.types';
 
 const REMARKABLE_FONTS_STYLE_ID = 'remarkable-theme-fonts';
 const REMARKABLE_PRECONNECT_ATTR = 'data-remarkable-preconnect';
@@ -21,7 +21,7 @@ const injectGooglePreconnect = (head: HTMLHeadElement): void => {
   head.appendChild(pre2);
 };
 
-const injectGoogleFonts = (fonts: ThemeFontGoogle[] | undefined): void => {
+const injectGoogleFonts = (fonts: ThemeFonts['google']): void => {
   if (!fonts || fonts.length === 0) return;
   if (typeof document === 'undefined' || !document.head) return;
   if (document.querySelector(`link[${REMARKABLE_GOOGLE_FONTS_ATTR}]`)) return;
@@ -62,7 +62,7 @@ const fontFaceCss = (font: ThemeFontCustom): string => {
   return `@font-face { font-family: '${family}'; src: url(${font.src})${decl}; }`;
 };
 
-const injectCustomFonts = (custom: ThemeFontCustom[] | undefined): void => {
+const injectCustomFonts = (custom: ThemeFonts['custom']): void => {
   if (!custom || custom.length === 0) return;
   if (typeof document === 'undefined' || !document.head || custom.length === 0) return;
 

--- a/src/theme/fonts/fonts.utils.ts
+++ b/src/theme/fonts/fonts.utils.ts
@@ -1,0 +1,235 @@
+import { injectCssVariables } from '../styles/styles.utils';
+import { Theme } from '../theme.types';
+import { ThemeFontCustom } from './fonts.types';
+
+const REMARKABLE_FONTS_STYLE_ID = 'remarkable-theme-fonts';
+const REMARKABLE_INTER_LINK_SELECTOR = 'link[data-remarkable-inter]';
+const DEFAULT_FONT_BASE = 'inter';
+const GENERIC_FONT_FAMILIES = new Set([
+  'serif',
+  'sans-serif',
+  'monospace',
+  'cursive',
+  'fantasy',
+  'system-ui',
+]);
+
+let pendingInterTimeout: ReturnType<typeof setTimeout> | null = null;
+
+const injectGoogleFonts = (families: string[], display = 'swap'): void => {
+  if (typeof document === 'undefined' || !document.head) return;
+  if (document.querySelector('link[data-remarkable-google-fonts]')) return;
+
+  const head = document.head;
+
+  const pre1 = document.createElement('link');
+  pre1.rel = 'preconnect';
+  pre1.href = 'https://fonts.googleapis.com';
+  head.appendChild(pre1);
+
+  const pre2 = document.createElement('link');
+  pre2.rel = 'preconnect';
+  pre2.href = 'https://fonts.gstatic.com';
+  pre2.crossOrigin = 'anonymous';
+  head.appendChild(pre2);
+
+  const query = families
+    .map((f) => `family=${encodeURIComponent(f.replace(/\s+/g, ' '))}:wght@100..900`)
+    .join('&');
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = `https://fonts.googleapis.com/css2?${query}&display=${display}`;
+  link.setAttribute('data-remarkable-google-fonts', '1');
+  head.appendChild(link);
+};
+
+const fontFaceCss = (font: ThemeFontCustom): string => {
+  const family = font.family.replace(/'/g, "\\'");
+  let src: string;
+
+  if (typeof font.src === 'string') {
+    src = `url(${font.src})`;
+  } else {
+    src = font.src
+      .map((s) => (s.format ? `url(${s.url}) format('${s.format}')` : `url(${s.url})`))
+      .join(', ');
+  }
+
+  const descriptorParts: string[] = [];
+  if (font.descriptors) {
+    const d = font.descriptors;
+    if (d.style != null) descriptorParts.push(`font-style: ${d.style}`);
+    if (d.weight != null) descriptorParts.push(`font-weight: ${d.weight}`);
+    if (d.stretch != null) descriptorParts.push(`font-stretch: ${d.stretch}`);
+    if (d.unicodeRange != null) descriptorParts.push(`unicode-range: ${d.unicodeRange}`);
+  }
+
+  const descriptors = descriptorParts.join('; ');
+  const decl = descriptors ? `; ${descriptors}` : '';
+
+  return `@font-face { font-family: '${family}'; src: ${src}${decl}; }`;
+};
+
+const injectCustomFonts = (custom: ThemeFontCustom[]): void => {
+  if (typeof document === 'undefined' || !document.head || custom.length === 0) return;
+
+  let styleEl = document.getElementById(REMARKABLE_FONTS_STYLE_ID) as HTMLStyleElement | null;
+  const css = custom.map(fontFaceCss).join('\n');
+
+  if (styleEl) {
+    styleEl.textContent = css;
+  } else {
+    styleEl = document.createElement('style');
+    styleEl.id = REMARKABLE_FONTS_STYLE_ID;
+    styleEl.setAttribute('data-remarkable-custom-fonts', '1');
+    styleEl.textContent = css;
+    document.head.appendChild(styleEl);
+  }
+};
+
+export const loadThemeFonts = (theme: Theme): void => {
+  const fonts = theme.fonts;
+  if (!fonts) return;
+
+  if (fonts.google?.families?.length) {
+    injectGoogleFonts(fonts.google.families, fonts.google.display ?? 'swap');
+  }
+  if (fonts.custom?.length) {
+    injectCustomFonts(fonts.custom);
+  }
+};
+
+export const getFontFamilyStyles = (theme: Theme): Record<string, string> => {
+  const fonts = theme.fonts;
+  if (!fonts) return {};
+
+  const base = fonts.familyBase ?? fonts.google?.families?.[0] ?? fonts.custom?.[0]?.family;
+  const code = fonts.familyCode;
+  const result: Record<string, string> = {};
+
+  if (base) {
+    result['--em-core-font-family--base'] = `'${base.replace(/'/g, "\\'")}'`;
+  }
+  if (code) {
+    result['--em-core-font-family--code'] = `'${code.replace(/'/g, "\\'")}'`;
+  }
+
+  return result;
+};
+
+export const removeThemeFonts = (): void => {
+  if (typeof document === 'undefined') return;
+
+  if (pendingInterTimeout) {
+    clearTimeout(pendingInterTimeout);
+    pendingInterTimeout = null;
+  }
+
+  document.querySelectorAll('link[data-remarkable-google-fonts]').forEach((el) => el.remove());
+  document.querySelectorAll(REMARKABLE_INTER_LINK_SELECTOR).forEach((el) => el.remove());
+  document.getElementById(REMARKABLE_FONTS_STYLE_ID)?.remove();
+};
+
+export const injectInter = (): void => {
+  if (typeof document === 'undefined') return;
+
+  const head = document.head || document.getElementsByTagName('head')[0];
+  if (!head) return;
+
+  if (document.querySelector(REMARKABLE_INTER_LINK_SELECTOR)) return;
+
+  const pre1 = document.createElement('link');
+  pre1.rel = 'preconnect';
+  pre1.href = 'https://fonts.googleapis.com';
+  head.appendChild(pre1);
+
+  const pre2 = document.createElement('link');
+  pre2.rel = 'preconnect';
+  pre2.href = 'https://fonts.gstatic.com';
+  pre2.crossOrigin = 'anonymous';
+  head.appendChild(pre2);
+
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap';
+  link.setAttribute('data-remarkable-inter', '1');
+  head.appendChild(link);
+};
+
+const parseFontFamilyFromStyle = (value: unknown): string | null => {
+  if (!value || typeof value !== 'string') return null;
+
+  const trimmed = value
+    .trim()
+    .replace(/^['"]|['"]$/g, '')
+    .trim();
+
+  if (!trimmed || trimmed.toLowerCase() === DEFAULT_FONT_BASE) return null;
+  if (GENERIC_FONT_FAMILIES.has(trimmed.toLowerCase())) return null;
+
+  return trimmed;
+};
+
+export const themeHasFonts = (theme: Theme): boolean => {
+  const f = theme.fonts;
+
+  if ((f?.google?.families?.length ?? 0) > 0 || (f?.custom?.length ?? 0) > 0) return true;
+
+  return (
+    parseFontFamilyFromStyle(theme.styles?.['--em-core-font-family--base']) != null ||
+    parseFontFamilyFromStyle(theme.styles?.['--em-core-font-family--code']) != null
+  );
+};
+
+const loadFontFromStylesIfSet = (theme: Theme): boolean => {
+  const families: string[] = [];
+
+  for (const key of ['--em-core-font-family--base', '--em-core-font-family--code'] as const) {
+    const f = parseFontFamilyFromStyle(theme.styles?.[key]);
+    if (f && !families.includes(f)) families.push(f);
+  }
+
+  if (families.length === 0) return false;
+
+  injectGoogleFonts(families);
+  return true;
+};
+
+/**
+ * Applies Remarkable theme to the DOM: loads fonts (or fallback Inter), injects CSS variables.
+ *
+ * Supports fonts via theme.fonts (if merged by defineTheme) or via theme.styles font tokens
+ * (covers cases where `fonts` is omitted in transit). Inter is injected on a 0ms timeout so a
+ * follow-up onThemeUpdated with full theme can cancel it.
+ */
+export const applyRemarkableTheme = (theme: Theme): (() => void) | void => {
+  if (pendingInterTimeout) {
+    clearTimeout(pendingInterTimeout);
+    pendingInterTimeout = null;
+  }
+
+  removeThemeFonts();
+
+  if (themeHasFonts(theme)) {
+    loadThemeFonts(theme);
+
+    const hasFontConfig =
+      (theme.fonts?.google?.families?.length ?? 0) > 0 || (theme.fonts?.custom?.length ?? 0) > 0;
+
+    if (!hasFontConfig) {
+      loadFontFromStylesIfSet(theme);
+    }
+
+    const fontVars = getFontFamilyStyles(theme);
+    const mergedStyles = { ...theme.styles, ...fontVars };
+    return injectCssVariables(mergedStyles);
+  }
+
+  pendingInterTimeout = setTimeout(() => {
+    pendingInterTimeout = null;
+    injectInter();
+  }, 0);
+
+  return injectCssVariables(theme.styles);
+};

--- a/src/theme/fonts/fonts.utils.ts
+++ b/src/theme/fonts/fonts.utils.ts
@@ -4,6 +4,7 @@ import { ThemeFontCustom } from './fonts.types';
 
 const REMARKABLE_FONTS_STYLE_ID = 'remarkable-theme-fonts';
 const REMARKABLE_INTER_LINK_SELECTOR = 'link[data-remarkable-inter]';
+const REMARKABLE_PRECONNECT_ATTR = 'data-remarkable-preconnect';
 const DEFAULT_FONT_BASE = 'inter';
 const GENERIC_FONT_FAMILIES = new Set([
   'serif',
@@ -16,22 +17,29 @@ const GENERIC_FONT_FAMILIES = new Set([
 
 let pendingInterTimeout: ReturnType<typeof setTimeout> | null = null;
 
-const injectGoogleFonts = (families: string[], display = 'swap'): void => {
-  if (typeof document === 'undefined' || !document.head) return;
-  if (document.querySelector('link[data-remarkable-google-fonts]')) return;
-
-  const head = document.head;
+const injectGooglePreconnect = (head: HTMLHeadElement): void => {
+  if (document.querySelector(`link[${REMARKABLE_PRECONNECT_ATTR}]`)) return;
 
   const pre1 = document.createElement('link');
   pre1.rel = 'preconnect';
   pre1.href = 'https://fonts.googleapis.com';
+  pre1.setAttribute(REMARKABLE_PRECONNECT_ATTR, '1');
   head.appendChild(pre1);
 
   const pre2 = document.createElement('link');
   pre2.rel = 'preconnect';
   pre2.href = 'https://fonts.gstatic.com';
   pre2.crossOrigin = 'anonymous';
+  pre2.setAttribute(REMARKABLE_PRECONNECT_ATTR, '1');
   head.appendChild(pre2);
+};
+
+const injectGoogleFonts = (families: string[], display = 'swap'): void => {
+  if (typeof document === 'undefined' || !document.head) return;
+  if (document.querySelector('link[data-remarkable-google-fonts]')) return;
+
+  const head = document.head;
+  injectGooglePreconnect(head);
 
   const query = families
     .map((f) => `family=${encodeURIComponent(f.replace(/\s+/g, ' '))}:wght@100..900`)
@@ -126,6 +134,7 @@ export const removeThemeFonts = (): void => {
     pendingInterTimeout = null;
   }
 
+  document.querySelectorAll(`link[${REMARKABLE_PRECONNECT_ATTR}]`).forEach((el) => el.remove());
   document.querySelectorAll('link[data-remarkable-google-fonts]').forEach((el) => el.remove());
   document.querySelectorAll(REMARKABLE_INTER_LINK_SELECTOR).forEach((el) => el.remove());
   document.getElementById(REMARKABLE_FONTS_STYLE_ID)?.remove();
@@ -139,16 +148,7 @@ export const injectInter = (): void => {
 
   if (document.querySelector(REMARKABLE_INTER_LINK_SELECTOR)) return;
 
-  const pre1 = document.createElement('link');
-  pre1.rel = 'preconnect';
-  pre1.href = 'https://fonts.googleapis.com';
-  head.appendChild(pre1);
-
-  const pre2 = document.createElement('link');
-  pre2.rel = 'preconnect';
-  pre2.href = 'https://fonts.gstatic.com';
-  pre2.crossOrigin = 'anonymous';
-  head.appendChild(pre2);
+  injectGooglePreconnect(head);
 
   const link = document.createElement('link');
   link.rel = 'stylesheet';

--- a/src/theme/fonts/fonts.utils.ts
+++ b/src/theme/fonts/fonts.utils.ts
@@ -1,21 +1,10 @@
 import { injectCssVariables } from '../styles/styles.utils';
 import { Theme } from '../theme.types';
-import { ThemeFontCustom } from './fonts.types';
+import { ThemeFontCustom, ThemeGoogleFontFamily } from './fonts.types';
 
 const REMARKABLE_FONTS_STYLE_ID = 'remarkable-theme-fonts';
-const REMARKABLE_INTER_LINK_SELECTOR = 'link[data-remarkable-inter]';
 const REMARKABLE_PRECONNECT_ATTR = 'data-remarkable-preconnect';
-const DEFAULT_FONT_BASE = 'inter';
-const GENERIC_FONT_FAMILIES = new Set([
-  'serif',
-  'sans-serif',
-  'monospace',
-  'cursive',
-  'fantasy',
-  'system-ui',
-]);
-
-let pendingInterTimeout: ReturnType<typeof setTimeout> | null = null;
+const REMARKABLE_GOOGLE_FONTS_ATTR = 'data-remarkable-google-fonts';
 
 const injectGooglePreconnect = (head: HTMLHeadElement): void => {
   if (document.querySelector(`link[${REMARKABLE_PRECONNECT_ATTR}]`)) return;
@@ -34,21 +23,25 @@ const injectGooglePreconnect = (head: HTMLHeadElement): void => {
   head.appendChild(pre2);
 };
 
-const injectGoogleFonts = (families: string[], display = 'swap'): void => {
+const injectGoogleFonts = (families: ThemeGoogleFontFamily[], display = 'swap'): void => {
   if (typeof document === 'undefined' || !document.head) return;
-  if (document.querySelector('link[data-remarkable-google-fonts]')) return;
+  if (document.querySelector(`link[${REMARKABLE_GOOGLE_FONTS_ATTR}]`)) return;
 
   const head = document.head;
   injectGooglePreconnect(head);
 
   const query = families
-    .map((f) => `family=${encodeURIComponent(f.replace(/\s+/g, ' '))}:wght@100..900`)
+    .map((f) => {
+      const encoded = encodeURIComponent(f.name.replace(/\s+/g, ' '));
+      const weights = f.weights ?? '100..900';
+      return `family=${encoded}:wght@${weights}`;
+    })
     .join('&');
 
   const link = document.createElement('link');
   link.rel = 'stylesheet';
   link.href = `https://fonts.googleapis.com/css2?${query}&display=${display}`;
-  link.setAttribute('data-remarkable-google-fonts', '1');
+  link.setAttribute(REMARKABLE_GOOGLE_FONTS_ATTR, '1');
   head.appendChild(link);
 };
 
@@ -90,7 +83,6 @@ const injectCustomFonts = (custom: ThemeFontCustom[]): void => {
   } else {
     styleEl = document.createElement('style');
     styleEl.id = REMARKABLE_FONTS_STYLE_ID;
-    styleEl.setAttribute('data-remarkable-custom-fonts', '1');
     styleEl.textContent = css;
     document.head.appendChild(styleEl);
   }
@@ -108,128 +100,22 @@ export const loadThemeFonts = (theme: Theme): void => {
   }
 };
 
-export const getFontFamilyStyles = (theme: Theme): Record<string, string> => {
-  const fonts = theme.fonts;
-  if (!fonts) return {};
-
-  const base = fonts.familyBase ?? fonts.google?.families?.[0] ?? fonts.custom?.[0]?.family;
-  const code = fonts.familyCode;
-  const result: Record<string, string> = {};
-
-  if (base) {
-    result['--em-core-font-family--base'] = `'${base.replace(/'/g, "\\'")}'`;
-  }
-  if (code) {
-    result['--em-core-font-family--code'] = `'${code.replace(/'/g, "\\'")}'`;
-  }
-
-  return result;
-};
-
 export const removeThemeFonts = (): void => {
   if (typeof document === 'undefined') return;
 
-  if (pendingInterTimeout) {
-    clearTimeout(pendingInterTimeout);
-    pendingInterTimeout = null;
-  }
-
   document.querySelectorAll(`link[${REMARKABLE_PRECONNECT_ATTR}]`).forEach((el) => el.remove());
-  document.querySelectorAll('link[data-remarkable-google-fonts]').forEach((el) => el.remove());
-  document.querySelectorAll(REMARKABLE_INTER_LINK_SELECTOR).forEach((el) => el.remove());
+  document.querySelectorAll(`link[${REMARKABLE_GOOGLE_FONTS_ATTR}]`).forEach((el) => el.remove());
   document.getElementById(REMARKABLE_FONTS_STYLE_ID)?.remove();
 };
 
-export const injectInter = (): void => {
-  if (typeof document === 'undefined') return;
-
-  const head = document.head || document.getElementsByTagName('head')[0];
-  if (!head) return;
-
-  if (document.querySelector(REMARKABLE_INTER_LINK_SELECTOR)) return;
-
-  injectGooglePreconnect(head);
-
-  const link = document.createElement('link');
-  link.rel = 'stylesheet';
-  link.href = 'https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap';
-  link.setAttribute('data-remarkable-inter', '1');
-  head.appendChild(link);
-};
-
-const parseFontFamilyFromStyle = (value: unknown): string | null => {
-  if (!value || typeof value !== 'string') return null;
-
-  const trimmed = value
-    .trim()
-    .replace(/^['"]|['"]$/g, '')
-    .trim();
-
-  if (!trimmed || trimmed.toLowerCase() === DEFAULT_FONT_BASE) return null;
-  if (GENERIC_FONT_FAMILIES.has(trimmed.toLowerCase())) return null;
-
-  return trimmed;
-};
-
-export const themeHasFonts = (theme: Theme): boolean => {
-  const f = theme.fonts;
-
-  if ((f?.google?.families?.length ?? 0) > 0 || (f?.custom?.length ?? 0) > 0) return true;
-
-  return (
-    parseFontFamilyFromStyle(theme.styles?.['--em-core-font-family--base']) != null ||
-    parseFontFamilyFromStyle(theme.styles?.['--em-core-font-family--code']) != null
-  );
-};
-
-const loadFontFromStylesIfSet = (theme: Theme): boolean => {
-  const families: string[] = [];
-
-  for (const key of ['--em-core-font-family--base', '--em-core-font-family--code'] as const) {
-    const f = parseFontFamilyFromStyle(theme.styles?.[key]);
-    if (f && !families.includes(f)) families.push(f);
-  }
-
-  if (families.length === 0) return false;
-
-  injectGoogleFonts(families);
-  return true;
-};
-
 /**
- * Applies Remarkable theme to the DOM: loads fonts (or fallback Inter), injects CSS variables.
+ * Applies Remarkable theme to the DOM: loads fonts and injects CSS variables.
  *
- * Supports fonts via theme.fonts (if merged by defineTheme) or via theme.styles font tokens
- * (covers cases where `fonts` is omitted in transit). Inter is injected on a 0ms timeout so a
- * follow-up onThemeUpdated with full theme can cancel it.
+ * Fonts are loaded based on theme.fonts (Inter by default via remarkableTheme).
+ * Font assignment (which font is used where) is controlled via theme.styles CSS variables.
  */
 export const applyRemarkableTheme = (theme: Theme): (() => void) | void => {
-  if (pendingInterTimeout) {
-    clearTimeout(pendingInterTimeout);
-    pendingInterTimeout = null;
-  }
-
   removeThemeFonts();
-
-  if (themeHasFonts(theme)) {
-    loadThemeFonts(theme);
-
-    const hasFontConfig =
-      (theme.fonts?.google?.families?.length ?? 0) > 0 || (theme.fonts?.custom?.length ?? 0) > 0;
-
-    if (!hasFontConfig) {
-      loadFontFromStylesIfSet(theme);
-    }
-
-    const fontVars = getFontFamilyStyles(theme);
-    const mergedStyles = { ...theme.styles, ...fontVars };
-    return injectCssVariables(mergedStyles);
-  }
-
-  pendingInterTimeout = setTimeout(() => {
-    pendingInterTimeout = null;
-    injectInter();
-  }, 0);
-
+  loadThemeFonts(theme);
   return injectCssVariables(theme.styles);
 };

--- a/src/theme/theme.constants.ts
+++ b/src/theme/theme.constants.ts
@@ -29,9 +29,7 @@ const remarkableThemeDefaults: ThemeDefaults = {
 };
 
 const remarkableThemeFonts: ThemeFonts = {
-  google: {
-    families: [{ name: 'Inter', weights: '100..900' }],
-  },
+  google: [{ name: 'Inter', weights: '100..900' }],
 };
 
 export const remarkableTheme: Theme = {

--- a/src/theme/theme.constants.ts
+++ b/src/theme/theme.constants.ts
@@ -2,6 +2,7 @@ import { en } from './i18n/translations/en';
 import { de } from './i18n/translations/de';
 import { remarkableThemeFormatter } from './formatter/formatter.constants';
 import { remarkableThemeStyles } from './styles/styles.constants';
+import { ThemeFonts } from './fonts/fonts.types';
 import { Theme, ThemeCharts, ThemeDefaults } from './theme.types';
 import { defaultComparisonPeriodOptions } from './defaults/defaults.ComparisonPeriods.constants';
 import { defaultDateRangeOptions } from './defaults/defaults.DateRanges.constants';
@@ -27,10 +28,17 @@ const remarkableThemeDefaults: ThemeDefaults = {
   tableCellStyleOptions: defaultTableCellStyleOptions,
 };
 
+const remarkableThemeFonts: ThemeFonts = {
+  google: {
+    families: [{ name: 'Inter', weights: '100..900' }],
+  },
+};
+
 export const remarkableTheme: Theme = {
   i18n: remarkableThemeI18n,
   charts: remarkableThemeCharts,
   formatter: remarkableThemeFormatter,
   styles: remarkableThemeStyles,
   defaults: remarkableThemeDefaults,
+  fonts: remarkableThemeFonts,
 } as const;

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -1,6 +1,7 @@
 import { Resource } from 'i18next';
 import { ThemeFormatter } from './formatter/formatter.types';
 import { ThemeStyles } from './styles/styles.types';
+import { ThemeFonts } from './fonts/fonts.types';
 import { ChartOptions } from 'chart.js';
 import { ComparisonPeriodOption } from './defaults/defaults.ComparisonPeriods.constants';
 import { DateRangeOption } from './defaults/defaults.DateRanges.constants';
@@ -58,4 +59,5 @@ export type Theme = {
   styles: ThemeStyles;
   formatter: ThemeFormatter;
   defaults: ThemeDefaults;
+  fonts?: ThemeFonts;
 };


### PR DESCRIPTION
# Why is this pull-request needed?

We want to support custom fonts in Remarkable UI, configurable via the theme. This includes both Google Fonts and fully custom fonts.

# Main changes

Added possibility to dynamically load different google font or custom font

# Test evidence

https://github.com/user-attachments/assets/8d6728e4-0c2b-4f7b-949c-39f762e8c6c5




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive font configuration support to theme system, including Google Fonts and custom font families.
  * Introduced new public APIs for font management: loading, applying, and removing theme fonts.
  * Extended theme type to support optional font configuration with Google and custom font settings.
  * Added font family CSS variable injection for base and code typography.

* **Tests**
  * Added extensive test coverage for font loading, font family style generation, and theme font application workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->