### PR TITLE
[RUI-245]: Add support for sort and limit for Bar charts

### DIFF
--- a/.changeset/free-cats-bake.md
+++ b/.changeset/free-cats-bake.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Added support for sorting and limit for grouped bar charts

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -11,7 +11,12 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
+import {
+  hasSortOrLimit,
+  buildTotalsRequest,
+  buildAxisTotalFilter,
+  getTotalsRequestKey,
+} from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartGroupedHorizontalPro',
@@ -61,6 +66,7 @@ const meta = {
 export type BarChartGroupedHorizontalProState = {
   granularity?: Granularity;
   axisTotalValues?: string[];
+  axisTotalsKey?: string;
 };
 
 const previewConfig = {
@@ -108,7 +114,18 @@ const props = (
   const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
   const limitAxisItems = inputs.limitAxisItems as number | undefined;
   const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
-  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsKey = needsSortOrLimit
+    ? getTotalsRequestKey({
+        sortByAxisTotal,
+        limitAxisItems,
+        axisDimensionName: yAxisWithGranularity.name,
+        measureName: inputs.measure.name,
+      })
+    : undefined;
+
+  const axisTotalValues =
+    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
 
   const totalsRequest = needsSortOrLimit
     ? buildTotalsRequest({
@@ -125,11 +142,13 @@ const props = (
     yAxis: yAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
     totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    totalsKey,
     results:
       needsSortOrLimit && !axisTotalValues
         ? undefined
         : loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
+    setAxisTotalValues: (values: string[], key?: string) =>
+      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -11,6 +11,7 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartGroupedHorizontalPro',
@@ -34,6 +35,8 @@ const meta = {
     inputs.reverseYAxis,
     inputs.xAxisRangeMin,
     inputs.xAxisRangeMax,
+    { ...inputs.sortByAxisTotal, label: 'Sort by y-axis total' },
+    { ...inputs.limitAxisItems, label: 'Limit y-axis items' },
   ],
   events: [
     {
@@ -57,6 +60,7 @@ const meta = {
 
 export type BarChartGroupedHorizontalProState = {
   granularity?: Granularity;
+  axisTotalValues?: string[];
 };
 
 const previewConfig = {
@@ -69,14 +73,22 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, yAxis?: Dimension): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  yAxis?: Dimension,
+  axisTotalValues?: string[],
+): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [yAxis ?? inputs.yAxis, inputs.groupBy, inputs.measure],
+  filters: buildAxisTotalFilter(yAxis ?? inputs.yAxis, axisTotalValues),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, yAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, yAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  yAxis: Dimension,
+  axisTotalValues?: string[],
+): DataResponse => loadData(loadDataResultsArgs(inputs, yAxis, axisTotalValues));
 
 const events = {
   onBarClicked: (value: { axisDimensionValue?: string; groupingDimensionValue?: string }) => ({
@@ -93,12 +105,31 @@ const props = (
   ],
 ) => {
   const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
+  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
+  const limitAxisItems = inputs.limitAxisItems as number | undefined;
+  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
+  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsRequest = needsSortOrLimit
+    ? buildTotalsRequest({
+        dataset: inputs.dataset,
+        axisDimension: yAxisWithGranularity,
+        measure: inputs.measure,
+        sortByAxisTotal,
+        limitAxisItems,
+      })
+    : undefined;
 
   return {
     ...inputs,
     yAxis: yAxisWithGranularity,
-    setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, yAxisWithGranularity),
+    setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
+    totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    results:
+      needsSortOrLimit && !axisTotalValues
+        ? undefined
+        : loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
+    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -11,12 +11,8 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import {
-  hasSortOrLimit,
-  buildTotalsRequest,
-  buildAxisTotalFilter,
-  getTotalsRequestKey,
-} from '../bars.sort.utils';
+import { buildAxisTotalFilter, buildSortLimitProps } from '../bars.sort.utils';
+import type { BarChartSortState } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartGroupedHorizontalPro',
@@ -65,9 +61,7 @@ const meta = {
 
 export type BarChartGroupedHorizontalProState = {
   granularity?: Granularity;
-  axisTotalValues?: string[];
-  axisTotalsKey?: string;
-};
+} & BarChartSortState;
 
 const previewConfig = {
   yAxis: previewData.dimension,
@@ -111,44 +105,25 @@ const props = (
   ],
 ) => {
   const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
-  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
-  const limitAxisItems = inputs.limitAxisItems as number | undefined;
-  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
 
-  const totalsKey = needsSortOrLimit
-    ? getTotalsRequestKey({
-        sortByAxisTotal,
-        limitAxisItems,
-        axisDimensionName: yAxisWithGranularity.name,
-        measureName: inputs.measure.name,
-      })
-    : undefined;
-
-  const axisTotalValues =
-    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
-
-  const totalsRequest = needsSortOrLimit
-    ? buildTotalsRequest({
-        dataset: inputs.dataset,
-        axisDimension: yAxisWithGranularity,
-        measure: inputs.measure,
-        sortByAxisTotal,
-        limitAxisItems,
-      })
-    : undefined;
+  const sortLimitProps = buildSortLimitProps({
+    dataset: inputs.dataset,
+    axisDimension: yAxisWithGranularity,
+    measure: inputs.measure,
+    sortByAxisTotal: inputs.sortByAxisTotal as string | undefined,
+    limitAxisItems: inputs.limitAxisItems as number | undefined,
+    cachedState: state,
+    updateSortState: (patch) => setState({ ...state, ...patch }),
+    loadData,
+    loadResults: (axisTotalValues) =>
+      loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
+  });
 
   return {
     ...inputs,
     yAxis: yAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
-    totals: totalsRequest ? loadData(totalsRequest) : undefined,
-    totalsKey,
-    results:
-      needsSortOrLimit && !axisTotalValues
-        ? undefined
-        : loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[], key?: string) =>
-      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
+    ...sortLimitProps,
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -32,6 +32,7 @@ export type BarChartGroupedHorizontalProProps = {
   }) => void;
   totals?: DataResponse;
   totalsKey?: string;
+  axisTotalValues?: string[];
   setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
@@ -61,6 +62,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
   const { results, axisOrder } = useAxisTotals({
     totals: props.totals,
     totalsKey: props.totalsKey,
+    axisTotalValues: props.axisTotalValues,
     setAxisTotalValues: props.setAxisTotalValues,
     results: props.results,
     axisDimension: yAxis,

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -9,11 +9,12 @@ import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+import { useEffect } from 'react';
 
 export type BarChartGroupedHorizontalProProps = {
   groupBy: Dimension;
   measure: Measure;
-  results: DataResponse;
+  results?: DataResponse;
   reverseYAxis?: boolean;
   showLegend?: boolean;
   showLogarithmicScale?: boolean;
@@ -30,6 +31,8 @@ export type BarChartGroupedHorizontalProProps = {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
   }) => void;
+  totals?: DataResponse;
+  setAxisTotalValues?: (values: string[]) => void;
 } & ChartCardHeaderProps;
 
 const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) => {
@@ -53,12 +56,23 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
     xAxisRangeMin,
     setGranularity,
     onBarClicked,
+    totals,
+    setAxisTotalValues,
   } = props;
 
-  const results = useFillGaps({
-    results: props.results,
-    dimension: yAxis,
-  });
+  useEffect(() => {
+    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
+    const values = totals.data.map((d) => d[yAxis.name] as string);
+    setAxisTotalValues(values);
+  }, [totals, yAxis.name, setAxisTotalValues]);
+
+  const results =
+    useFillGaps({
+      results: props.results,
+      dimension: yAxis,
+    }) ?? ({ isLoading: true, data: [] } as DataResponse);
+
+  const axisOrder = totals?.data?.map((d) => d[yAxis.name] as string);
 
   const data = getBarStackedChartProData(
     {
@@ -66,6 +80,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       dimension: yAxis,
       groupDimension: groupBy,
       measure,
+      axisOrder,
     },
     theme,
   );

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -32,7 +32,8 @@ export type BarChartGroupedHorizontalProProps = {
     groupingDimensionValue: string | null;
   }) => void;
   totals?: DataResponse;
-  setAxisTotalValues?: (values: string[]) => void;
+  totalsKey?: string;
+  setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
 const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) => {
@@ -57,14 +58,15 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
     setGranularity,
     onBarClicked,
     totals,
+    totalsKey,
     setAxisTotalValues,
   } = props;
 
   useEffect(() => {
     if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
     const values = totals.data.map((d) => d[yAxis.name] as string);
-    setAxisTotalValues(values);
-  }, [totals, yAxis.name, setAxisTotalValues]);
+    setAxisTotalValues(values, totalsKey);
+  }, [totals, yAxis.name, setAxisTotalValues, totalsKey]);
 
   const results =
     useFillGaps({

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -7,9 +7,8 @@ import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
-import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { useEffect } from 'react';
+import { useAxisTotals } from '../bars.sort.hooks';
 
 export type BarChartGroupedHorizontalProProps = {
   groupBy: Dimension;
@@ -57,24 +56,15 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
     xAxisRangeMin,
     setGranularity,
     onBarClicked,
-    totals,
-    totalsKey,
-    setAxisTotalValues,
   } = props;
 
-  useEffect(() => {
-    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
-    const values = totals.data.map((d) => d[yAxis.name] as string);
-    setAxisTotalValues(values, totalsKey);
-  }, [totals, yAxis.name, setAxisTotalValues, totalsKey]);
-
-  const results =
-    useFillGaps({
-      results: props.results,
-      dimension: yAxis,
-    }) ?? ({ isLoading: true, data: [] } as DataResponse);
-
-  const axisOrder = totals?.data?.map((d) => d[yAxis.name] as string);
+  const { results, axisOrder } = useAxisTotals({
+    totals: props.totals,
+    totalsKey: props.totalsKey,
+    setAxisTotalValues: props.setAxisTotalValues,
+    results: props.results,
+    axisDimension: yAxis,
+  });
 
   const data = getBarStackedChartProData(
     {

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -11,12 +11,8 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import {
-  hasSortOrLimit,
-  buildTotalsRequest,
-  buildAxisTotalFilter,
-  getTotalsRequestKey,
-} from '../bars.sort.utils';
+import { buildAxisTotalFilter, buildSortLimitProps } from '../bars.sort.utils';
+import type { BarChartSortState } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartGroupedPro',
@@ -65,9 +61,7 @@ const meta = {
 
 export type BarChartGroupedProState = {
   granularity?: Granularity;
-  axisTotalValues?: string[];
-  axisTotalsKey?: string;
-};
+} & BarChartSortState;
 
 const previewConfig = {
   xAxis: previewData.dimension,
@@ -108,44 +102,25 @@ const props = (
   [state, setState]: [BarChartGroupedProState, (state: BarChartGroupedProState) => void],
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
-  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
-  const limitAxisItems = inputs.limitAxisItems as number | undefined;
-  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
 
-  const totalsKey = needsSortOrLimit
-    ? getTotalsRequestKey({
-        sortByAxisTotal,
-        limitAxisItems,
-        axisDimensionName: xAxisWithGranularity.name,
-        measureName: inputs.measure.name,
-      })
-    : undefined;
-
-  const axisTotalValues =
-    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
-
-  const totalsRequest = needsSortOrLimit
-    ? buildTotalsRequest({
-        dataset: inputs.dataset,
-        axisDimension: xAxisWithGranularity,
-        measure: inputs.measure,
-        sortByAxisTotal,
-        limitAxisItems,
-      })
-    : undefined;
+  const sortLimitProps = buildSortLimitProps({
+    dataset: inputs.dataset,
+    axisDimension: xAxisWithGranularity,
+    measure: inputs.measure,
+    sortByAxisTotal: inputs.sortByAxisTotal as string | undefined,
+    limitAxisItems: inputs.limitAxisItems as number | undefined,
+    cachedState: state,
+    updateSortState: (patch) => setState({ ...state, ...patch }),
+    loadData,
+    loadResults: (axisTotalValues) =>
+      loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
+  });
 
   return {
     ...inputs,
     xAxis: xAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
-    totals: totalsRequest ? loadData(totalsRequest) : undefined,
-    totalsKey,
-    results:
-      needsSortOrLimit && !axisTotalValues
-        ? undefined
-        : loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[], key?: string) =>
-      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
+    ...sortLimitProps,
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -11,6 +11,7 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartGroupedPro',
@@ -34,6 +35,8 @@ const meta = {
     inputs.reverseXAxis,
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
+    inputs.sortByAxisTotal,
+    inputs.limitAxisItems,
   ],
   events: [
     {
@@ -57,6 +60,7 @@ const meta = {
 
 export type BarChartGroupedProState = {
   granularity?: Granularity;
+  axisTotalValues?: string[];
 };
 
 const previewConfig = {
@@ -69,14 +73,22 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, xAxis?: Dimension): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  xAxis?: Dimension,
+  axisTotalValues?: string[],
+): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [xAxis ?? inputs.xAxis, inputs.groupBy, inputs.measure],
+  filters: buildAxisTotalFilter(xAxis ?? inputs.xAxis, axisTotalValues),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, xAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, xAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  xAxis: Dimension,
+  axisTotalValues?: string[],
+): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, axisTotalValues));
 
 const events = {
   onBarClicked: (value: { axisDimensionValue?: string; groupingDimensionValue?: string }) => ({
@@ -90,12 +102,31 @@ const props = (
   [state, setState]: [BarChartGroupedProState, (state: BarChartGroupedProState) => void],
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
+  const limitAxisItems = inputs.limitAxisItems as number | undefined;
+  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
+  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsRequest = needsSortOrLimit
+    ? buildTotalsRequest({
+        dataset: inputs.dataset,
+        axisDimension: xAxisWithGranularity,
+        measure: inputs.measure,
+        sortByAxisTotal,
+        limitAxisItems,
+      })
+    : undefined;
 
   return {
     ...inputs,
     xAxis: xAxisWithGranularity,
-    setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, xAxisWithGranularity),
+    setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
+    totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    results:
+      needsSortOrLimit && !axisTotalValues
+        ? undefined
+        : loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
+    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -11,7 +11,12 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
+import {
+  hasSortOrLimit,
+  buildTotalsRequest,
+  buildAxisTotalFilter,
+  getTotalsRequestKey,
+} from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartGroupedPro',
@@ -61,6 +66,7 @@ const meta = {
 export type BarChartGroupedProState = {
   granularity?: Granularity;
   axisTotalValues?: string[];
+  axisTotalsKey?: string;
 };
 
 const previewConfig = {
@@ -105,7 +111,18 @@ const props = (
   const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
   const limitAxisItems = inputs.limitAxisItems as number | undefined;
   const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
-  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsKey = needsSortOrLimit
+    ? getTotalsRequestKey({
+        sortByAxisTotal,
+        limitAxisItems,
+        axisDimensionName: xAxisWithGranularity.name,
+        measureName: inputs.measure.name,
+      })
+    : undefined;
+
+  const axisTotalValues =
+    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
 
   const totalsRequest = needsSortOrLimit
     ? buildTotalsRequest({
@@ -122,11 +139,13 @@ const props = (
     xAxis: xAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
     totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    totalsKey,
     results:
       needsSortOrLimit && !axisTotalValues
         ? undefined
         : loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
+    setAxisTotalValues: (values: string[], key?: string) =>
+      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -9,11 +9,12 @@ import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+import { useEffect } from 'react';
 
 export type BarChartGroupedProProps = {
   groupBy: Dimension;
   measure: Measure;
-  results: DataResponse;
+  results?: DataResponse;
   reverseXAxis?: boolean;
   showLegend?: boolean;
   showLogarithmicScale?: boolean;
@@ -30,6 +31,8 @@ export type BarChartGroupedProProps = {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
   }) => void;
+  totals?: DataResponse;
+  setAxisTotalValues?: (values: string[]) => void;
 } & ChartCardHeaderProps;
 
 const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
@@ -50,16 +53,27 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
     yAxisRangeMin,
     setGranularity,
     onBarClicked,
+    totals,
+    setAxisTotalValues,
   } = props;
 
   const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
 
   const { hideMenu } = props;
 
-  const results = useFillGaps({
-    results: props.results,
-    dimension: props.xAxis,
-  });
+  useEffect(() => {
+    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
+    const values = totals.data.map((d) => d[xAxis.name] as string);
+    setAxisTotalValues(values);
+  }, [totals, xAxis.name, setAxisTotalValues]);
+
+  const results =
+    useFillGaps({
+      results: props.results,
+      dimension: props.xAxis,
+    }) ?? ({ isLoading: true, data: [] } as DataResponse);
+
+  const axisOrder = totals?.data?.map((d) => d[xAxis.name] as string);
 
   const data = getBarStackedChartProData(
     {
@@ -67,6 +81,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       dimension: xAxis,
       groupDimension: groupBy,
       measure,
+      axisOrder,
     },
     theme,
   );

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -32,6 +32,7 @@ export type BarChartGroupedProProps = {
   }) => void;
   totals?: DataResponse;
   totalsKey?: string;
+  axisTotalValues?: string[];
   setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
@@ -62,6 +63,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
   const { results, axisOrder } = useAxisTotals({
     totals: props.totals,
     totalsKey: props.totalsKey,
+    axisTotalValues: props.axisTotalValues,
     setAxisTotalValues: props.setAxisTotalValues,
     results: props.results,
     axisDimension: xAxis,

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -32,7 +32,8 @@ export type BarChartGroupedProProps = {
     groupingDimensionValue: string | null;
   }) => void;
   totals?: DataResponse;
-  setAxisTotalValues?: (values: string[]) => void;
+  totalsKey?: string;
+  setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
 const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
@@ -54,6 +55,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
     setGranularity,
     onBarClicked,
     totals,
+    totalsKey,
     setAxisTotalValues,
   } = props;
 
@@ -64,8 +66,8 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
   useEffect(() => {
     if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
     const values = totals.data.map((d) => d[xAxis.name] as string);
-    setAxisTotalValues(values);
-  }, [totals, xAxis.name, setAxisTotalValues]);
+    setAxisTotalValues(values, totalsKey);
+  }, [totals, xAxis.name, setAxisTotalValues, totalsKey]);
 
   const results =
     useFillGaps({

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -7,9 +7,8 @@ import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
-import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { useEffect } from 'react';
+import { useAxisTotals } from '../bars.sort.hooks';
 
 export type BarChartGroupedProProps = {
   groupBy: Dimension;
@@ -54,28 +53,19 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
     yAxisRangeMin,
     setGranularity,
     onBarClicked,
-    totals,
-    totalsKey,
-    setAxisTotalValues,
   } = props;
 
   const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
 
   const { hideMenu } = props;
 
-  useEffect(() => {
-    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
-    const values = totals.data.map((d) => d[xAxis.name] as string);
-    setAxisTotalValues(values, totalsKey);
-  }, [totals, xAxis.name, setAxisTotalValues, totalsKey]);
-
-  const results =
-    useFillGaps({
-      results: props.results,
-      dimension: props.xAxis,
-    }) ?? ({ isLoading: true, data: [] } as DataResponse);
-
-  const axisOrder = totals?.data?.map((d) => d[xAxis.name] as string);
+  const { results, axisOrder } = useAxisTotals({
+    totals: props.totals,
+    totalsKey: props.totalsKey,
+    setAxisTotalValues: props.setAxisTotalValues,
+    results: props.results,
+    axisDimension: xAxis,
+  });
 
   const data = getBarStackedChartProData(
     {

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -11,7 +11,12 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
+import {
+  hasSortOrLimit,
+  buildTotalsRequest,
+  buildAxisTotalFilter,
+  getTotalsRequestKey,
+} from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartStackedHorizontalPro',
@@ -62,6 +67,7 @@ const meta = {
 export type BarChartStackedHorizontalProState = {
   granularity?: Granularity;
   axisTotalValues?: string[];
+  axisTotalsKey?: string;
 };
 
 const previewConfig = {
@@ -109,7 +115,18 @@ const props = (
   const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
   const limitAxisItems = inputs.limitAxisItems as number | undefined;
   const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
-  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsKey = needsSortOrLimit
+    ? getTotalsRequestKey({
+        sortByAxisTotal,
+        limitAxisItems,
+        axisDimensionName: yAxisWithGranularity.name,
+        measureName: inputs.measure.name,
+      })
+    : undefined;
+
+  const axisTotalValues =
+    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
 
   const totalsRequest = needsSortOrLimit
     ? buildTotalsRequest({
@@ -126,11 +143,13 @@ const props = (
     yAxis: yAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
     totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    totalsKey,
     results:
       needsSortOrLimit && !axisTotalValues
         ? undefined
         : loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
+    setAxisTotalValues: (values: string[], key?: string) =>
+      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
   };
 };
 

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -11,6 +11,7 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartStackedHorizontalPro',
@@ -35,6 +36,8 @@ const meta = {
     inputs.xAxisRangeMin,
     inputs.xAxisRangeMax,
     inputs.showTotalLabels,
+    { ...inputs.sortByAxisTotal, label: 'Sort by y-axis total' },
+    { ...inputs.limitAxisItems, label: 'Limit y-axis items' },
   ],
   events: [
     {
@@ -58,6 +61,7 @@ const meta = {
 
 export type BarChartStackedHorizontalProState = {
   granularity?: Granularity;
+  axisTotalValues?: string[];
 };
 
 const previewConfig = {
@@ -70,14 +74,22 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, yAxis?: Dimension): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  yAxis?: Dimension,
+  axisTotalValues?: string[],
+): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [yAxis ?? inputs.yAxis, inputs.groupBy, inputs.measure],
+  filters: buildAxisTotalFilter(yAxis ?? inputs.yAxis, axisTotalValues),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, yAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, yAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  yAxis: Dimension,
+  axisTotalValues?: string[],
+): DataResponse => loadData(loadDataResultsArgs(inputs, yAxis, axisTotalValues));
 
 const events = {
   onBarClicked: (value: { axisDimensionValue?: string; groupingDimensionValue?: string }) => ({
@@ -94,12 +106,31 @@ const props = (
   ],
 ) => {
   const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
+  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
+  const limitAxisItems = inputs.limitAxisItems as number | undefined;
+  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
+  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsRequest = needsSortOrLimit
+    ? buildTotalsRequest({
+        dataset: inputs.dataset,
+        axisDimension: yAxisWithGranularity,
+        measure: inputs.measure,
+        sortByAxisTotal,
+        limitAxisItems,
+      })
+    : undefined;
 
   return {
     ...inputs,
     yAxis: yAxisWithGranularity,
-    setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, yAxisWithGranularity),
+    setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
+    totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    results:
+      needsSortOrLimit && !axisTotalValues
+        ? undefined
+        : loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
+    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
   };
 };
 

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -11,12 +11,8 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import {
-  hasSortOrLimit,
-  buildTotalsRequest,
-  buildAxisTotalFilter,
-  getTotalsRequestKey,
-} from '../bars.sort.utils';
+import { buildAxisTotalFilter, buildSortLimitProps } from '../bars.sort.utils';
+import type { BarChartSortState } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartStackedHorizontalPro',
@@ -66,9 +62,7 @@ const meta = {
 
 export type BarChartStackedHorizontalProState = {
   granularity?: Granularity;
-  axisTotalValues?: string[];
-  axisTotalsKey?: string;
-};
+} & BarChartSortState;
 
 const previewConfig = {
   yAxis: previewData.dimension,
@@ -112,44 +106,25 @@ const props = (
   ],
 ) => {
   const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
-  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
-  const limitAxisItems = inputs.limitAxisItems as number | undefined;
-  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
 
-  const totalsKey = needsSortOrLimit
-    ? getTotalsRequestKey({
-        sortByAxisTotal,
-        limitAxisItems,
-        axisDimensionName: yAxisWithGranularity.name,
-        measureName: inputs.measure.name,
-      })
-    : undefined;
-
-  const axisTotalValues =
-    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
-
-  const totalsRequest = needsSortOrLimit
-    ? buildTotalsRequest({
-        dataset: inputs.dataset,
-        axisDimension: yAxisWithGranularity,
-        measure: inputs.measure,
-        sortByAxisTotal,
-        limitAxisItems,
-      })
-    : undefined;
+  const sortLimitProps = buildSortLimitProps({
+    dataset: inputs.dataset,
+    axisDimension: yAxisWithGranularity,
+    measure: inputs.measure,
+    sortByAxisTotal: inputs.sortByAxisTotal as string | undefined,
+    limitAxisItems: inputs.limitAxisItems as number | undefined,
+    cachedState: state,
+    updateSortState: (patch) => setState({ ...state, ...patch }),
+    loadData,
+    loadResults: (axisTotalValues) =>
+      loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
+  });
 
   return {
     ...inputs,
     yAxis: yAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
-    totals: totalsRequest ? loadData(totalsRequest) : undefined,
-    totalsKey,
-    results:
-      needsSortOrLimit && !axisTotalValues
-        ? undefined
-        : loadDataResults(inputs, yAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[], key?: string) =>
-      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
+    ...sortLimitProps,
   };
 };
 

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -32,6 +32,7 @@ export type BarChartStackedHorizontalProProps = {
   }) => void;
   totals?: DataResponse;
   totalsKey?: string;
+  axisTotalValues?: string[];
   setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
@@ -61,6 +62,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
   const { results, axisOrder } = useAxisTotals({
     totals: props.totals,
     totalsKey: props.totalsKey,
+    axisTotalValues: props.axisTotalValues,
     setAxisTotalValues: props.setAxisTotalValues,
     results: props.results,
     axisDimension: yAxis,

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -9,11 +9,12 @@ import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+import { useEffect } from 'react';
 
 export type BarChartStackedHorizontalProProps = {
   groupBy: Dimension;
   measure: Measure;
-  results: DataResponse;
+  results?: DataResponse;
   reverseYAxis?: boolean;
   showLegend?: boolean;
   showLogarithmicScale?: boolean;
@@ -30,6 +31,8 @@ export type BarChartStackedHorizontalProProps = {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
   }) => void;
+  totals?: DataResponse;
+  setAxisTotalValues?: (values: string[]) => void;
 } & ChartCardHeaderProps;
 
 const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) => {
@@ -53,12 +56,23 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
     xAxisRangeMin,
     setGranularity,
     onBarClicked,
+    totals,
+    setAxisTotalValues,
   } = props;
 
-  const results = useFillGaps({
-    results: props.results,
-    dimension: props.yAxis,
-  });
+  useEffect(() => {
+    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
+    const values = totals.data.map((d) => d[yAxis.name] as string);
+    setAxisTotalValues(values);
+  }, [totals, yAxis.name, setAxisTotalValues]);
+
+  const results =
+    useFillGaps({
+      results: props.results,
+      dimension: props.yAxis,
+    }) ?? ({ isLoading: true, data: [] } as DataResponse);
+
+  const axisOrder = totals?.data?.map((d) => d[yAxis.name] as string);
 
   const data = getBarStackedChartProData(
     {
@@ -66,6 +80,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
       dimension: yAxis,
       groupDimension: groupBy,
       measure,
+      axisOrder,
     },
     theme,
   );

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -7,9 +7,8 @@ import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
-import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { useEffect } from 'react';
+import { useAxisTotals } from '../bars.sort.hooks';
 
 export type BarChartStackedHorizontalProProps = {
   groupBy: Dimension;
@@ -57,24 +56,15 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
     xAxisRangeMin,
     setGranularity,
     onBarClicked,
-    totals,
-    totalsKey,
-    setAxisTotalValues,
   } = props;
 
-  useEffect(() => {
-    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
-    const values = totals.data.map((d) => d[yAxis.name] as string);
-    setAxisTotalValues(values, totalsKey);
-  }, [totals, yAxis.name, setAxisTotalValues, totalsKey]);
-
-  const results =
-    useFillGaps({
-      results: props.results,
-      dimension: props.yAxis,
-    }) ?? ({ isLoading: true, data: [] } as DataResponse);
-
-  const axisOrder = totals?.data?.map((d) => d[yAxis.name] as string);
+  const { results, axisOrder } = useAxisTotals({
+    totals: props.totals,
+    totalsKey: props.totalsKey,
+    setAxisTotalValues: props.setAxisTotalValues,
+    results: props.results,
+    axisDimension: yAxis,
+  });
 
   const data = getBarStackedChartProData(
     {

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -32,7 +32,8 @@ export type BarChartStackedHorizontalProProps = {
     groupingDimensionValue: string | null;
   }) => void;
   totals?: DataResponse;
-  setAxisTotalValues?: (values: string[]) => void;
+  totalsKey?: string;
+  setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
 const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) => {
@@ -57,14 +58,15 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
     setGranularity,
     onBarClicked,
     totals,
+    totalsKey,
     setAxisTotalValues,
   } = props;
 
   useEffect(() => {
     if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
     const values = totals.data.map((d) => d[yAxis.name] as string);
-    setAxisTotalValues(values);
-  }, [totals, yAxis.name, setAxisTotalValues]);
+    setAxisTotalValues(values, totalsKey);
+  }, [totals, yAxis.name, setAxisTotalValues, totalsKey]);
 
   const results =
     useFillGaps({

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -11,7 +11,12 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
+import {
+  hasSortOrLimit,
+  buildTotalsRequest,
+  buildAxisTotalFilter,
+  getTotalsRequestKey,
+} from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartStackedPro',
@@ -62,6 +67,7 @@ const meta = {
 export type BarChartStackedProState = {
   granularity?: Granularity;
   axisTotalValues?: string[];
+  axisTotalsKey?: string;
 };
 
 const previewConfig = {
@@ -106,7 +112,18 @@ const props = (
   const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
   const limitAxisItems = inputs.limitAxisItems as number | undefined;
   const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
-  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsKey = needsSortOrLimit
+    ? getTotalsRequestKey({
+        sortByAxisTotal,
+        limitAxisItems,
+        axisDimensionName: xAxisWithGranularity.name,
+        measureName: inputs.measure.name,
+      })
+    : undefined;
+
+  const axisTotalValues =
+    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
 
   const totalsRequest = needsSortOrLimit
     ? buildTotalsRequest({
@@ -123,11 +140,13 @@ const props = (
     xAxis: xAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
     totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    totalsKey,
     results:
       needsSortOrLimit && !axisTotalValues
         ? undefined
         : loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
+    setAxisTotalValues: (values: string[], key?: string) =>
+      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
   };
 };
 

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -11,6 +11,7 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { hasSortOrLimit, buildTotalsRequest, buildAxisTotalFilter } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartStackedPro',
@@ -35,6 +36,8 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.showTotalLabels,
+    inputs.sortByAxisTotal,
+    inputs.limitAxisItems,
   ],
   events: [
     {
@@ -58,6 +61,7 @@ const meta = {
 
 export type BarChartStackedProState = {
   granularity?: Granularity;
+  axisTotalValues?: string[];
 };
 
 const previewConfig = {
@@ -70,14 +74,22 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, xAxis?: Dimension): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  xAxis?: Dimension,
+  axisTotalValues?: string[],
+): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [xAxis ?? inputs.xAxis, inputs.groupBy, inputs.measure],
+  filters: buildAxisTotalFilter(xAxis ?? inputs.xAxis, axisTotalValues),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, xAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, xAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  xAxis: Dimension,
+  axisTotalValues?: string[],
+): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, axisTotalValues));
 
 const events = {
   onBarClicked: (value: { axisDimensionValue?: string; groupingDimensionValue?: string }) => ({
@@ -91,12 +103,31 @@ const props = (
   [state, setState]: [BarChartStackedProState, (state: BarChartStackedProState) => void],
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
+  const limitAxisItems = inputs.limitAxisItems as number | undefined;
+  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
+  const axisTotalValues = needsSortOrLimit ? state?.axisTotalValues : undefined;
+
+  const totalsRequest = needsSortOrLimit
+    ? buildTotalsRequest({
+        dataset: inputs.dataset,
+        axisDimension: xAxisWithGranularity,
+        measure: inputs.measure,
+        sortByAxisTotal,
+        limitAxisItems,
+      })
+    : undefined;
 
   return {
     ...inputs,
     xAxis: xAxisWithGranularity,
-    setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, xAxisWithGranularity),
+    setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
+    totals: totalsRequest ? loadData(totalsRequest) : undefined,
+    results:
+      needsSortOrLimit && !axisTotalValues
+        ? undefined
+        : loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
+    setAxisTotalValues: (values: string[]) => setState({ ...state, axisTotalValues: values }),
   };
 };
 

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -11,12 +11,8 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
-import {
-  hasSortOrLimit,
-  buildTotalsRequest,
-  buildAxisTotalFilter,
-  getTotalsRequestKey,
-} from '../bars.sort.utils';
+import { buildAxisTotalFilter, buildSortLimitProps } from '../bars.sort.utils';
+import type { BarChartSortState } from '../bars.sort.utils';
 
 const meta = {
   name: 'BarChartStackedPro',
@@ -66,9 +62,7 @@ const meta = {
 
 export type BarChartStackedProState = {
   granularity?: Granularity;
-  axisTotalValues?: string[];
-  axisTotalsKey?: string;
-};
+} & BarChartSortState;
 
 const previewConfig = {
   xAxis: previewData.dimension,
@@ -109,44 +103,25 @@ const props = (
   [state, setState]: [BarChartStackedProState, (state: BarChartStackedProState) => void],
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
-  const sortByAxisTotal = inputs.sortByAxisTotal as string | undefined;
-  const limitAxisItems = inputs.limitAxisItems as number | undefined;
-  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
 
-  const totalsKey = needsSortOrLimit
-    ? getTotalsRequestKey({
-        sortByAxisTotal,
-        limitAxisItems,
-        axisDimensionName: xAxisWithGranularity.name,
-        measureName: inputs.measure.name,
-      })
-    : undefined;
-
-  const axisTotalValues =
-    needsSortOrLimit && state?.axisTotalsKey === totalsKey ? state?.axisTotalValues : undefined;
-
-  const totalsRequest = needsSortOrLimit
-    ? buildTotalsRequest({
-        dataset: inputs.dataset,
-        axisDimension: xAxisWithGranularity,
-        measure: inputs.measure,
-        sortByAxisTotal,
-        limitAxisItems,
-      })
-    : undefined;
+  const sortLimitProps = buildSortLimitProps({
+    dataset: inputs.dataset,
+    axisDimension: xAxisWithGranularity,
+    measure: inputs.measure,
+    sortByAxisTotal: inputs.sortByAxisTotal as string | undefined,
+    limitAxisItems: inputs.limitAxisItems as number | undefined,
+    cachedState: state,
+    updateSortState: (patch) => setState({ ...state, ...patch }),
+    loadData,
+    loadResults: (axisTotalValues) =>
+      loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
+  });
 
   return {
     ...inputs,
     xAxis: xAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ ...state, granularity }),
-    totals: totalsRequest ? loadData(totalsRequest) : undefined,
-    totalsKey,
-    results:
-      needsSortOrLimit && !axisTotalValues
-        ? undefined
-        : loadDataResults(inputs, xAxisWithGranularity, axisTotalValues),
-    setAxisTotalValues: (values: string[], key?: string) =>
-      setState({ ...state, axisTotalValues: values, axisTotalsKey: key }),
+    ...sortLimitProps,
   };
 };
 

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -33,6 +33,7 @@ export type BarChartStackedProProps = {
   }) => void;
   totals?: DataResponse;
   totalsKey?: string;
+  axisTotalValues?: string[];
   setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
@@ -62,6 +63,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
   const { results, axisOrder } = useAxisTotals({
     totals: props.totals,
     totalsKey: props.totalsKey,
+    axisTotalValues: props.axisTotalValues,
     setAxisTotalValues: props.setAxisTotalValues,
     results: props.results,
     axisDimension: xAxis,

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -9,12 +9,13 @@ import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+import { useEffect } from 'react';
 
 export type BarChartStackedProProps = {
   groupBy: Dimension;
   maxLegendItems?: number;
   measure: Measure;
-  results: DataResponse;
+  results?: DataResponse;
   reverseXAxis?: boolean;
   showLegend?: boolean;
   showLogarithmicScale?: boolean;
@@ -31,6 +32,8 @@ export type BarChartStackedProProps = {
     axisDimensionValue: string | null;
     groupingDimensionValue: string | null;
   }) => void;
+  totals?: DataResponse;
+  setAxisTotalValues?: (values: string[]) => void;
 } & ChartCardHeaderProps;
 
 const BarChartStackedPro = (props: BarChartStackedProProps) => {
@@ -52,14 +55,25 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
     yAxisRangeMin,
     setGranularity,
     onBarClicked,
+    totals,
+    setAxisTotalValues,
   } = props;
 
   const { hideMenu } = props;
 
-  const results = useFillGaps({
-    results: props.results,
-    dimension: props.xAxis,
-  });
+  useEffect(() => {
+    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
+    const values = totals.data.map((d) => d[xAxis.name] as string);
+    setAxisTotalValues(values);
+  }, [totals, xAxis.name, setAxisTotalValues]);
+
+  const results =
+    useFillGaps({
+      results: props.results,
+      dimension: props.xAxis,
+    }) ?? ({ isLoading: true, data: [] } as DataResponse);
+
+  const axisOrder = totals?.data?.map((d) => d[xAxis.name] as string);
 
   const data = getBarStackedChartProData(
     {
@@ -67,6 +81,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       dimension: xAxis,
       groupDimension: groupBy,
       measure,
+      axisOrder,
     },
     theme,
   );

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -33,7 +33,8 @@ export type BarChartStackedProProps = {
     groupingDimensionValue: string | null;
   }) => void;
   totals?: DataResponse;
-  setAxisTotalValues?: (values: string[]) => void;
+  totalsKey?: string;
+  setAxisTotalValues?: (values: string[], key?: string) => void;
 } & ChartCardHeaderProps;
 
 const BarChartStackedPro = (props: BarChartStackedProProps) => {
@@ -56,6 +57,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
     setGranularity,
     onBarClicked,
     totals,
+    totalsKey,
     setAxisTotalValues,
   } = props;
 
@@ -64,8 +66,8 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
   useEffect(() => {
     if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
     const values = totals.data.map((d) => d[xAxis.name] as string);
-    setAxisTotalValues(values);
-  }, [totals, xAxis.name, setAxisTotalValues]);
+    setAxisTotalValues(values, totalsKey);
+  }, [totals, xAxis.name, setAxisTotalValues, totalsKey]);
 
   const results =
     useFillGaps({

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -7,9 +7,8 @@ import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
-import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { useEffect } from 'react';
+import { useAxisTotals } from '../bars.sort.hooks';
 
 export type BarChartStackedProProps = {
   groupBy: Dimension;
@@ -56,26 +55,17 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
     yAxisRangeMin,
     setGranularity,
     onBarClicked,
-    totals,
-    totalsKey,
-    setAxisTotalValues,
   } = props;
 
   const { hideMenu } = props;
 
-  useEffect(() => {
-    if (!totals?.data || totals.isLoading || !setAxisTotalValues) return;
-    const values = totals.data.map((d) => d[xAxis.name] as string);
-    setAxisTotalValues(values, totalsKey);
-  }, [totals, xAxis.name, setAxisTotalValues, totalsKey]);
-
-  const results =
-    useFillGaps({
-      results: props.results,
-      dimension: props.xAxis,
-    }) ?? ({ isLoading: true, data: [] } as DataResponse);
-
-  const axisOrder = totals?.data?.map((d) => d[xAxis.name] as string);
+  const { results, axisOrder } = useAxisTotals({
+    totals: props.totals,
+    totalsKey: props.totalsKey,
+    setAxisTotalValues: props.setAxisTotalValues,
+    results: props.results,
+    axisDimension: xAxis,
+  });
 
   const data = getBarStackedChartProData(
     {

--- a/src/components/charts/bars/bars.sort.hooks.test.ts
+++ b/src/components/charts/bars/bars.sort.hooks.test.ts
@@ -75,7 +75,7 @@ describe('useAxisTotals', () => {
     ).not.toThrow();
   });
 
-  it('derives axisOrder from totals data', () => {
+  it('derives axisOrder from totals data when axisTotalValues is not cached', () => {
     const totals = makeResponse([{ country: 'US' }, { country: 'DE' }, { country: 'UK' }]);
     const results = makeResponse([]);
 
@@ -88,6 +88,20 @@ describe('useAxisTotals', () => {
     );
 
     expect(result.current.axisOrder).toEqual(['US', 'DE', 'UK']);
+  });
+
+  it('uses axisTotalValues as axisOrder when provided (cached path)', () => {
+    const results = makeResponse([]);
+
+    const { result } = renderHook(() =>
+      useAxisTotals({
+        axisTotalValues: ['DE', 'US', 'UK'],
+        results,
+        axisDimension,
+      }),
+    );
+
+    expect(result.current.axisOrder).toEqual(['DE', 'US', 'UK']);
   });
 
   it('re-invokes callback when totalsKey changes', () => {

--- a/src/components/charts/bars/bars.sort.hooks.test.ts
+++ b/src/components/charts/bars/bars.sort.hooks.test.ts
@@ -1,0 +1,118 @@
+import { renderHook } from '@testing-library/react';
+import type { DataResponse, Dimension } from '@embeddable.com/core';
+import { useAxisTotals } from './bars.sort.hooks';
+
+vi.mock('../charts.fillGaps.hooks', () => ({
+  useFillGaps: (props: { results?: DataResponse }) => props.results,
+}));
+
+const makeDimension = (name = 'country'): Dimension =>
+  ({ name, title: name, nativeType: 'string', inputs: {} }) as unknown as Dimension;
+
+const makeResponse = (data: Record<string, unknown>[], isLoading = false): DataResponse =>
+  ({ data, isLoading }) as DataResponse;
+
+describe('useAxisTotals', () => {
+  const axisDimension = makeDimension('country');
+
+  it('returns results from useFillGaps when no totals are provided', () => {
+    const results = makeResponse([{ country: 'US', revenue: 100 }]);
+
+    const { result } = renderHook(() => useAxisTotals({ results, axisDimension }));
+
+    expect(result.current.results).toBe(results);
+    expect(result.current.axisOrder).toBeUndefined();
+  });
+
+  it('returns a loading fallback when results is undefined', () => {
+    const { result } = renderHook(() => useAxisTotals({ results: undefined, axisDimension }));
+
+    expect(result.current.results).toEqual({ isLoading: true, data: [] });
+  });
+
+  it('calls setAxisTotalValues with extracted axis values when totals resolve', () => {
+    const setAxisTotalValues = vi.fn();
+    const totals = makeResponse([{ country: 'US' }, { country: 'UK' }]);
+    const results = makeResponse([]);
+
+    renderHook(() =>
+      useAxisTotals({
+        totals,
+        totalsKey: 'key-1',
+        setAxisTotalValues,
+        results,
+        axisDimension,
+      }),
+    );
+
+    expect(setAxisTotalValues).toHaveBeenCalledWith(['US', 'UK'], 'key-1');
+  });
+
+  it('does not call setAxisTotalValues when totals is loading', () => {
+    const setAxisTotalValues = vi.fn();
+    const totals = makeResponse([], true);
+    const results = makeResponse([]);
+
+    renderHook(() =>
+      useAxisTotals({
+        totals,
+        totalsKey: 'key-1',
+        setAxisTotalValues,
+        results,
+        axisDimension,
+      }),
+    );
+
+    expect(setAxisTotalValues).not.toHaveBeenCalled();
+  });
+
+  it('does not call setAxisTotalValues when callback is not provided', () => {
+    const totals = makeResponse([{ country: 'US' }]);
+    const results = makeResponse([]);
+
+    expect(() =>
+      renderHook(() => useAxisTotals({ totals, totalsKey: 'key-1', results, axisDimension })),
+    ).not.toThrow();
+  });
+
+  it('derives axisOrder from totals data', () => {
+    const totals = makeResponse([{ country: 'US' }, { country: 'DE' }, { country: 'UK' }]);
+    const results = makeResponse([]);
+
+    const { result } = renderHook(() =>
+      useAxisTotals({
+        totals,
+        results,
+        axisDimension,
+      }),
+    );
+
+    expect(result.current.axisOrder).toEqual(['US', 'DE', 'UK']);
+  });
+
+  it('re-invokes callback when totalsKey changes', () => {
+    const setAxisTotalValues = vi.fn();
+    const totals = makeResponse([{ country: 'US' }]);
+    const results = makeResponse([]);
+
+    const { rerender } = renderHook(
+      (props: { totalsKey: string }) =>
+        useAxisTotals({
+          totals,
+          totalsKey: props.totalsKey,
+          setAxisTotalValues,
+          results,
+          axisDimension,
+        }),
+      { initialProps: { totalsKey: 'key-1' } },
+    );
+
+    expect(setAxisTotalValues).toHaveBeenCalledTimes(1);
+    expect(setAxisTotalValues).toHaveBeenCalledWith(['US'], 'key-1');
+
+    rerender({ totalsKey: 'key-2' });
+
+    expect(setAxisTotalValues).toHaveBeenCalledTimes(2);
+    expect(setAxisTotalValues).toHaveBeenLastCalledWith(['US'], 'key-2');
+  });
+});

--- a/src/components/charts/bars/bars.sort.hooks.ts
+++ b/src/components/charts/bars/bars.sort.hooks.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from 'react';
+import { DataResponse, Dimension } from '@embeddable.com/core';
+import { useFillGaps } from '../charts.fillGaps.hooks';
+
+export const useAxisTotals = (params: {
+  totals?: DataResponse;
+  totalsKey?: string;
+  setAxisTotalValues?: (values: string[], key?: string) => void;
+  results?: DataResponse;
+  axisDimension: Dimension;
+}): { results: DataResponse; axisOrder?: string[] } => {
+  const { totals, totalsKey, setAxisTotalValues, results: rawResults, axisDimension } = params;
+
+  const callbackRef = useRef(setAxisTotalValues);
+  callbackRef.current = setAxisTotalValues;
+
+  useEffect(() => {
+    if (!totals?.data || totals.isLoading || !callbackRef.current) return;
+    const values = totals.data.map((d) => d[axisDimension.name] as string);
+    callbackRef.current(values, totalsKey);
+  }, [totals, axisDimension.name, totalsKey]);
+
+  const results =
+    useFillGaps({
+      results: rawResults,
+      dimension: axisDimension,
+    }) ?? ({ isLoading: true, data: [] } as DataResponse);
+
+  const axisOrder = totals?.data?.map((d) => d[axisDimension.name] as string);
+
+  return { results, axisOrder };
+};

--- a/src/components/charts/bars/bars.sort.hooks.ts
+++ b/src/components/charts/bars/bars.sort.hooks.ts
@@ -5,11 +5,19 @@ import { useFillGaps } from '../charts.fillGaps.hooks';
 export const useAxisTotals = (params: {
   totals?: DataResponse;
   totalsKey?: string;
+  axisTotalValues?: string[];
   setAxisTotalValues?: (values: string[], key?: string) => void;
   results?: DataResponse;
   axisDimension: Dimension;
 }): { results: DataResponse; axisOrder?: string[] } => {
-  const { totals, totalsKey, setAxisTotalValues, results: rawResults, axisDimension } = params;
+  const {
+    totals,
+    totalsKey,
+    axisTotalValues,
+    setAxisTotalValues,
+    results: rawResults,
+    axisDimension,
+  } = params;
 
   const callbackRef = useRef(setAxisTotalValues);
   callbackRef.current = setAxisTotalValues;
@@ -26,7 +34,7 @@ export const useAxisTotals = (params: {
       dimension: axisDimension,
     }) ?? ({ isLoading: true, data: [] } as DataResponse);
 
-  const axisOrder = totals?.data?.map((d) => d[axisDimension.name] as string);
+  const axisOrder = axisTotalValues ?? totals?.data?.map((d) => d[axisDimension.name] as string);
 
   return { results, axisOrder };
 };

--- a/src/components/charts/bars/bars.sort.utils.test.ts
+++ b/src/components/charts/bars/bars.sort.utils.test.ts
@@ -308,7 +308,7 @@ describe('buildSortLimitProps', () => {
     expect(mockLoadResults).not.toHaveBeenCalled();
   });
 
-  it('uses cached axisTotalValues when the key matches', () => {
+  it('uses cached axisTotalValues when the key matches and skips totals query', () => {
     const key = getTotalsRequestKey({
       sortByAxisTotal: 'Descending',
       axisDimensionName: 'country',
@@ -322,7 +322,10 @@ describe('buildSortLimitProps', () => {
     });
 
     expect(result.results).toBe(mockResponse);
+    expect(result.axisTotalValues).toEqual(['US', 'UK']);
     expect(mockLoadResults).toHaveBeenCalledWith(['US', 'UK']);
+    expect(result.totals).toBeUndefined();
+    expect(mockLoadData).not.toHaveBeenCalled();
   });
 
   it('invalidates cache when the key changes', () => {

--- a/src/components/charts/bars/bars.sort.utils.test.ts
+++ b/src/components/charts/bars/bars.sort.utils.test.ts
@@ -5,6 +5,7 @@ import {
   getSortDirection,
   buildTotalsRequest,
   buildAxisTotalFilter,
+  getTotalsRequestKey,
 } from './bars.sort.utils';
 
 const makeDimension = (name = 'category'): Dimension =>
@@ -183,5 +184,79 @@ describe('buildAxisTotalFilter', () => {
     const result = buildAxisTotalFilter(dimension, values);
 
     expect(result).toEqual([{ property: dimension, operator: 'equals', value: values }]);
+  });
+});
+
+describe('getTotalsRequestKey', () => {
+  it('produces a stable key for the same parameters', () => {
+    const params = {
+      sortByAxisTotal: 'Descending',
+      limitAxisItems: 5,
+      axisDimensionName: 'country',
+      measureName: 'revenue',
+    };
+
+    expect(getTotalsRequestKey(params)).toBe(getTotalsRequestKey(params));
+  });
+
+  it('produces different keys when sort changes', () => {
+    const base = { limitAxisItems: 5, axisDimensionName: 'country', measureName: 'revenue' };
+
+    expect(getTotalsRequestKey({ ...base, sortByAxisTotal: 'Ascending' })).not.toBe(
+      getTotalsRequestKey({ ...base, sortByAxisTotal: 'Descending' }),
+    );
+  });
+
+  it('produces different keys when limit changes', () => {
+    const base = {
+      sortByAxisTotal: 'Descending',
+      axisDimensionName: 'country',
+      measureName: 'revenue',
+    };
+
+    expect(getTotalsRequestKey({ ...base, limitAxisItems: 3 })).not.toBe(
+      getTotalsRequestKey({ ...base, limitAxisItems: 10 }),
+    );
+  });
+
+  it('produces different keys when dimension changes', () => {
+    const base = { sortByAxisTotal: 'Descending', limitAxisItems: 5, measureName: 'revenue' };
+
+    expect(getTotalsRequestKey({ ...base, axisDimensionName: 'country' })).not.toBe(
+      getTotalsRequestKey({ ...base, axisDimensionName: 'city' }),
+    );
+  });
+
+  it('produces different keys when measure changes', () => {
+    const base = {
+      sortByAxisTotal: 'Descending',
+      limitAxisItems: 5,
+      axisDimensionName: 'country',
+    };
+
+    expect(getTotalsRequestKey({ ...base, measureName: 'revenue' })).not.toBe(
+      getTotalsRequestKey({ ...base, measureName: 'cost' }),
+    );
+  });
+
+  it('handles undefined sort and limit', () => {
+    const key = getTotalsRequestKey({
+      axisDimensionName: 'country',
+      measureName: 'revenue',
+    });
+
+    expect(key).toBe('::country:revenue');
+  });
+
+  it('floors decimal limits in the key', () => {
+    const base = {
+      sortByAxisTotal: 'Descending',
+      axisDimensionName: 'country',
+      measureName: 'revenue',
+    };
+
+    expect(getTotalsRequestKey({ ...base, limitAxisItems: 3.7 })).toBe(
+      getTotalsRequestKey({ ...base, limitAxisItems: 3 }),
+    );
   });
 });

--- a/src/components/charts/bars/bars.sort.utils.test.ts
+++ b/src/components/charts/bars/bars.sort.utils.test.ts
@@ -1,4 +1,4 @@
-import type { Dimension, Measure } from '@embeddable.com/core';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import {
   getValidLimit,
   hasSortOrLimit,
@@ -6,6 +6,7 @@ import {
   buildTotalsRequest,
   buildAxisTotalFilter,
   getTotalsRequestKey,
+  buildSortLimitProps,
 } from './bars.sort.utils';
 
 const makeDimension = (name = 'category'): Dimension =>
@@ -258,5 +259,112 @@ describe('getTotalsRequestKey', () => {
     expect(getTotalsRequestKey({ ...base, limitAxisItems: 3.7 })).toBe(
       getTotalsRequestKey({ ...base, limitAxisItems: 3 }),
     );
+  });
+});
+
+describe('buildSortLimitProps', () => {
+  const dataset = 'test-dataset' as never;
+  const axisDimension = makeDimension('country');
+  const measure = makeMeasure('revenue');
+  const mockResponse = { isLoading: false, data: [{ country: 'US' }] } as DataResponse;
+  const mockLoadData = vi.fn().mockReturnValue(mockResponse);
+  const mockLoadResults = vi.fn().mockReturnValue(mockResponse);
+  const mockUpdateState = vi.fn();
+
+  const baseParams = {
+    dataset,
+    axisDimension,
+    measure,
+    cachedState: undefined,
+    updateSortState: mockUpdateState,
+    loadData: mockLoadData,
+    loadResults: mockLoadResults,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns no totals and calls loadResults when sort/limit are not set', () => {
+    const result = buildSortLimitProps(baseParams);
+
+    expect(result.totals).toBeUndefined();
+    expect(result.totalsKey).toBeUndefined();
+    expect(result.results).toBe(mockResponse);
+    expect(mockLoadData).not.toHaveBeenCalled();
+    expect(mockLoadResults).toHaveBeenCalledWith(undefined);
+  });
+
+  it('loads totals and withholds results when sort is set but cache is empty', () => {
+    const result = buildSortLimitProps({
+      ...baseParams,
+      sortByAxisTotal: 'Descending',
+    });
+
+    expect(result.totals).toBe(mockResponse);
+    expect(result.totalsKey).toBeDefined();
+    expect(result.results).toBeUndefined();
+    expect(mockLoadData).toHaveBeenCalledTimes(1);
+    expect(mockLoadResults).not.toHaveBeenCalled();
+  });
+
+  it('uses cached axisTotalValues when the key matches', () => {
+    const key = getTotalsRequestKey({
+      sortByAxisTotal: 'Descending',
+      axisDimensionName: 'country',
+      measureName: 'revenue',
+    });
+
+    const result = buildSortLimitProps({
+      ...baseParams,
+      sortByAxisTotal: 'Descending',
+      cachedState: { axisTotalValues: ['US', 'UK'], axisTotalsKey: key },
+    });
+
+    expect(result.results).toBe(mockResponse);
+    expect(mockLoadResults).toHaveBeenCalledWith(['US', 'UK']);
+  });
+
+  it('invalidates cache when the key changes', () => {
+    const staleKey = getTotalsRequestKey({
+      sortByAxisTotal: 'Ascending',
+      axisDimensionName: 'country',
+      measureName: 'revenue',
+    });
+
+    const result = buildSortLimitProps({
+      ...baseParams,
+      sortByAxisTotal: 'Descending',
+      cachedState: { axisTotalValues: ['US', 'UK'], axisTotalsKey: staleKey },
+    });
+
+    expect(result.results).toBeUndefined();
+    expect(mockLoadResults).not.toHaveBeenCalled();
+  });
+
+  it('loads totals and withholds results when limit is set but cache is empty', () => {
+    const result = buildSortLimitProps({
+      ...baseParams,
+      limitAxisItems: 5,
+    });
+
+    expect(result.totals).toBe(mockResponse);
+    expect(result.totalsKey).toBeDefined();
+    expect(result.results).toBeUndefined();
+    expect(mockLoadData).toHaveBeenCalledTimes(1);
+  });
+
+  it('setAxisTotalValues calls updateSortState with correct patch', () => {
+    const result = buildSortLimitProps({
+      ...baseParams,
+      sortByAxisTotal: 'Descending',
+    });
+
+    result.setAxisTotalValues(['A', 'B'], 'some-key');
+
+    expect(mockUpdateState).toHaveBeenCalledWith({
+      axisTotalValues: ['A', 'B'],
+      axisTotalsKey: 'some-key',
+    });
   });
 });

--- a/src/components/charts/bars/bars.sort.utils.test.ts
+++ b/src/components/charts/bars/bars.sort.utils.test.ts
@@ -1,0 +1,187 @@
+import type { Dimension, Measure } from '@embeddable.com/core';
+import {
+  getValidLimit,
+  hasSortOrLimit,
+  getSortDirection,
+  buildTotalsRequest,
+  buildAxisTotalFilter,
+} from './bars.sort.utils';
+
+const makeDimension = (name = 'category'): Dimension =>
+  ({ name, title: name, nativeType: 'string', inputs: {} }) as unknown as Dimension;
+
+const makeMeasure = (name = 'revenue'): Measure =>
+  ({ name, title: name, nativeType: 'number', inputs: {} }) as unknown as Measure;
+
+describe('getValidLimit', () => {
+  it('returns undefined for undefined input', () => {
+    expect(getValidLimit(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for zero', () => {
+    expect(getValidLimit(0)).toBeUndefined();
+  });
+
+  it('returns undefined for negative numbers', () => {
+    expect(getValidLimit(-5)).toBeUndefined();
+  });
+
+  it('returns the integer value for positive integers', () => {
+    expect(getValidLimit(10)).toBe(10);
+  });
+
+  it('floors positive decimals to an integer', () => {
+    expect(getValidLimit(3.7)).toBe(3);
+  });
+
+  it('returns undefined when a decimal floors to zero', () => {
+    expect(getValidLimit(0.5)).toBeUndefined();
+  });
+
+  it('returns undefined for NaN', () => {
+    expect(getValidLimit(NaN)).toBeUndefined();
+  });
+});
+
+describe('hasSortOrLimit', () => {
+  it('returns false when neither sort nor limit is set', () => {
+    expect(hasSortOrLimit(undefined, undefined)).toBe(false);
+  });
+
+  it('returns true when sort is set', () => {
+    expect(hasSortOrLimit('Ascending', undefined)).toBe(true);
+  });
+
+  it('returns true when a valid limit is set', () => {
+    expect(hasSortOrLimit(undefined, 5)).toBe(true);
+  });
+
+  it('returns false when limit is invalid', () => {
+    expect(hasSortOrLimit(undefined, -1)).toBe(false);
+    expect(hasSortOrLimit(undefined, 0)).toBe(false);
+  });
+
+  it('returns true when both sort and limit are set', () => {
+    expect(hasSortOrLimit('Descending', 10)).toBe(true);
+  });
+});
+
+describe('getSortDirection', () => {
+  it('returns "asc" for "Ascending"', () => {
+    expect(getSortDirection('Ascending')).toBe('asc');
+  });
+
+  it('returns "desc" for "Descending"', () => {
+    expect(getSortDirection('Descending')).toBe('desc');
+  });
+
+  it('defaults to "desc" when undefined', () => {
+    expect(getSortDirection(undefined)).toBe('desc');
+  });
+
+  it('defaults to "desc" for unrecognized values', () => {
+    expect(getSortDirection('something-else')).toBe('desc');
+  });
+});
+
+describe('buildTotalsRequest', () => {
+  const dataset = 'test-dataset' as never;
+  const axisDimension = makeDimension('xAxis');
+  const measure = makeMeasure('revenue');
+
+  it('returns undefined when neither sort nor limit is set', () => {
+    expect(buildTotalsRequest({ dataset, axisDimension, measure })).toBeUndefined();
+  });
+
+  it('builds a request with sort only', () => {
+    const result = buildTotalsRequest({
+      dataset,
+      axisDimension,
+      measure,
+      sortByAxisTotal: 'Ascending',
+    });
+
+    expect(result).toEqual({
+      from: dataset,
+      select: [axisDimension, measure],
+      orderBy: [{ property: measure, direction: 'asc' }],
+      limit: undefined,
+    });
+  });
+
+  it('builds a request with limit only, defaulting sort to desc', () => {
+    const result = buildTotalsRequest({
+      dataset,
+      axisDimension,
+      measure,
+      limitAxisItems: 5,
+    });
+
+    expect(result).toEqual({
+      from: dataset,
+      select: [axisDimension, measure],
+      orderBy: [{ property: measure, direction: 'desc' }],
+      limit: 5,
+    });
+  });
+
+  it('builds a request with both sort and limit', () => {
+    const result = buildTotalsRequest({
+      dataset,
+      axisDimension,
+      measure,
+      sortByAxisTotal: 'Ascending',
+      limitAxisItems: 3,
+    });
+
+    expect(result).toEqual({
+      from: dataset,
+      select: [axisDimension, measure],
+      orderBy: [{ property: measure, direction: 'asc' }],
+      limit: 3,
+    });
+  });
+
+  it('floors decimal limit values', () => {
+    const result = buildTotalsRequest({
+      dataset,
+      axisDimension,
+      measure,
+      sortByAxisTotal: 'Descending',
+      limitAxisItems: 7.9,
+    });
+
+    expect(result?.limit).toBe(7);
+  });
+
+  it('ignores invalid limit values', () => {
+    const result = buildTotalsRequest({
+      dataset,
+      axisDimension,
+      measure,
+      sortByAxisTotal: 'Descending',
+      limitAxisItems: -3,
+    });
+
+    expect(result?.limit).toBeUndefined();
+  });
+});
+
+describe('buildAxisTotalFilter', () => {
+  const dimension = makeDimension('category');
+
+  it('returns undefined when axisTotalValues is undefined', () => {
+    expect(buildAxisTotalFilter(dimension, undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when axisTotalValues is empty', () => {
+    expect(buildAxisTotalFilter(dimension, [])).toBeUndefined();
+  });
+
+  it('returns an equals filter for non-empty values', () => {
+    const values = ['A', 'B', 'C'];
+    const result = buildAxisTotalFilter(dimension, values);
+
+    expect(result).toEqual([{ property: dimension, operator: 'equals', value: values }]);
+  });
+});

--- a/src/components/charts/bars/bars.sort.utils.ts
+++ b/src/components/charts/bars/bars.sort.utils.ts
@@ -1,0 +1,47 @@
+import { Dimension, LoadDataRequest, Measure, OrderBy } from '@embeddable.com/core';
+
+export const getValidLimit = (limitValue?: number): number | undefined => {
+  if (typeof limitValue !== 'number' || !Number.isFinite(limitValue) || limitValue <= 0)
+    return undefined;
+  const floored = Math.floor(limitValue);
+  return floored > 0 ? floored : undefined;
+};
+
+export const hasSortOrLimit = (sortByAxisTotal?: string, limitAxisItems?: number): boolean => {
+  return !!sortByAxisTotal || getValidLimit(limitAxisItems) !== undefined;
+};
+
+export const getSortDirection = (sortByAxisTotal?: string): 'asc' | 'desc' => {
+  if (sortByAxisTotal === 'Ascending') return 'asc';
+  if (sortByAxisTotal === 'Descending') return 'desc';
+  return 'desc';
+};
+
+export const buildTotalsRequest = (params: {
+  dataset: LoadDataRequest['from'];
+  axisDimension: Dimension;
+  measure: Measure;
+  sortByAxisTotal?: string;
+  limitAxisItems?: number;
+}): LoadDataRequest | undefined => {
+  if (!hasSortOrLimit(params.sortByAxisTotal, params.limitAxisItems)) return undefined;
+
+  const orderBy: OrderBy[] = [
+    { property: params.measure, direction: getSortDirection(params.sortByAxisTotal) },
+  ];
+
+  return {
+    from: params.dataset,
+    select: [params.axisDimension, params.measure],
+    orderBy,
+    limit: getValidLimit(params.limitAxisItems),
+  };
+};
+
+export const buildAxisTotalFilter = (
+  axisDimension: Dimension,
+  axisTotalValues?: string[],
+): LoadDataRequest['filters'] => {
+  if (!axisTotalValues?.length) return undefined;
+  return [{ property: axisDimension, operator: 'equals' as const, value: axisTotalValues }];
+};

--- a/src/components/charts/bars/bars.sort.utils.ts
+++ b/src/components/charts/bars/bars.sort.utils.ts
@@ -74,6 +74,7 @@ export const buildSortLimitProps = (params: {
 }): {
   totals: DataResponse | undefined;
   totalsKey: string | undefined;
+  axisTotalValues: string[] | undefined;
   results: DataResponse | undefined;
   setAxisTotalValues: (values: string[], key?: string) => void;
 } => {
@@ -94,19 +95,21 @@ export const buildSortLimitProps = (params: {
       ? cachedState?.axisTotalValues
       : undefined;
 
-  const totalsRequest = needsSortOrLimit
-    ? buildTotalsRequest({
-        dataset: params.dataset,
-        axisDimension: params.axisDimension,
-        measure: params.measure,
-        sortByAxisTotal,
-        limitAxisItems,
-      })
-    : undefined;
+  const totalsRequest =
+    needsSortOrLimit && !axisTotalValues
+      ? buildTotalsRequest({
+          dataset: params.dataset,
+          axisDimension: params.axisDimension,
+          measure: params.measure,
+          sortByAxisTotal,
+          limitAxisItems,
+        })
+      : undefined;
 
   return {
     totals: totalsRequest ? params.loadData(totalsRequest) : undefined,
     totalsKey,
+    axisTotalValues,
     results: needsSortOrLimit && !axisTotalValues ? undefined : params.loadResults(axisTotalValues),
     setAxisTotalValues: (values: string[], key?: string) =>
       params.updateSortState({ axisTotalValues: values, axisTotalsKey: key }),

--- a/src/components/charts/bars/bars.sort.utils.ts
+++ b/src/components/charts/bars/bars.sort.utils.ts
@@ -38,6 +38,16 @@ export const buildTotalsRequest = (params: {
   };
 };
 
+export const getTotalsRequestKey = (params: {
+  sortByAxisTotal?: string;
+  limitAxisItems?: number;
+  axisDimensionName: string;
+  measureName: string;
+}): string => {
+  const limit = getValidLimit(params.limitAxisItems);
+  return `${params.sortByAxisTotal ?? ''}:${limit ?? ''}:${params.axisDimensionName}:${params.measureName}`;
+};
+
 export const buildAxisTotalFilter = (
   axisDimension: Dimension,
   axisTotalValues?: string[],

--- a/src/components/charts/bars/bars.sort.utils.ts
+++ b/src/components/charts/bars/bars.sort.utils.ts
@@ -1,4 +1,9 @@
-import { Dimension, LoadDataRequest, Measure, OrderBy } from '@embeddable.com/core';
+import { DataResponse, Dimension, LoadDataRequest, Measure, OrderBy } from '@embeddable.com/core';
+
+export type BarChartSortState = {
+  axisTotalValues?: string[];
+  axisTotalsKey?: string;
+};
 
 export const getValidLimit = (limitValue?: number): number | undefined => {
   if (typeof limitValue !== 'number' || !Number.isFinite(limitValue) || limitValue <= 0)
@@ -54,4 +59,56 @@ export const buildAxisTotalFilter = (
 ): LoadDataRequest['filters'] => {
   if (!axisTotalValues?.length) return undefined;
   return [{ property: axisDimension, operator: 'equals' as const, value: axisTotalValues }];
+};
+
+export const buildSortLimitProps = (params: {
+  dataset: LoadDataRequest['from'];
+  axisDimension: Dimension;
+  measure: Measure;
+  sortByAxisTotal?: string;
+  limitAxisItems?: number;
+  cachedState?: BarChartSortState;
+  updateSortState: (patch: BarChartSortState) => void;
+  loadData: (request: LoadDataRequest) => DataResponse;
+  loadResults: (axisTotalValues?: string[]) => DataResponse;
+}): {
+  totals: DataResponse | undefined;
+  totalsKey: string | undefined;
+  results: DataResponse | undefined;
+  setAxisTotalValues: (values: string[], key?: string) => void;
+} => {
+  const { sortByAxisTotal, limitAxisItems, cachedState } = params;
+  const needsSortOrLimit = hasSortOrLimit(sortByAxisTotal, limitAxisItems);
+
+  const totalsKey = needsSortOrLimit
+    ? getTotalsRequestKey({
+        sortByAxisTotal,
+        limitAxisItems,
+        axisDimensionName: params.axisDimension.name,
+        measureName: params.measure.name,
+      })
+    : undefined;
+
+  const axisTotalValues =
+    needsSortOrLimit && cachedState?.axisTotalsKey === totalsKey
+      ? cachedState?.axisTotalValues
+      : undefined;
+
+  const totalsRequest = needsSortOrLimit
+    ? buildTotalsRequest({
+        dataset: params.dataset,
+        axisDimension: params.axisDimension,
+        measure: params.measure,
+        sortByAxisTotal,
+        limitAxisItems,
+      })
+    : undefined;
+
+  return {
+    totals: totalsRequest ? params.loadData(totalsRequest) : undefined,
+    totalsKey,
+    results: needsSortOrLimit && !axisTotalValues ? undefined : params.loadResults(axisTotalValues),
+    setAxisTotalValues: (values: string[], key?: string) =>
+      params.updateSortState({ axisTotalValues: values, axisTotalsKey: key }),
+  };
 };

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -14,13 +14,17 @@ export const getBarStackedChartProData = (
     dimension: Dimension;
     groupDimension: Dimension;
     measure: Measure;
+    axisOrder?: string[];
   },
   theme: Theme,
 ): ChartData<'bar'> => {
   const themeFormatter = getThemeFormatter(theme);
-  const { data = [], dimension, groupDimension, measure } = props;
+  const { data = [], dimension, groupDimension, measure, axisOrder } = props;
 
-  const axis = [...new Set(data.map((d) => d[dimension.name]).filter((d) => d != null))].sort();
+  const dataAxisValues = new Set(data.map((d) => d[dimension.name]).filter((d) => d != null));
+  const axis = axisOrder?.length
+    ? axisOrder.filter((v) => dataAxisValues.has(v))
+    : [...dataAxisValues].sort();
   const groupDimensionName = `${groupDimension.name}${groupDimension.nativeType === CUBE_DIMENSION_TYPE_TIME && groupDimension.inputs?.granularity ? `.${groupDimension.inputs.granularity}` : ''}`;
   const groupBy = [...new Set(data.map((d) => d[groupDimensionName]))].filter((d) => d != null);
 

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -6,6 +6,7 @@ import {
   timeDimensionWithGranularitySelectFieldSubInputs,
 } from './component.subinputs.constants';
 import ComparisonPeriodType from './types/ComparisonPeriod.type.emb';
+import SortDirectionType from './types/SortDirection.type.emb';
 import MarkdownType from '../editors/MarkdownEditor/Markdown.type.emb';
 
 /* -------------------- */
@@ -416,6 +417,21 @@ const yAxisMaxItems = {
   category: 'Axes Settings',
 } as const;
 
+const sortByAxisTotal = {
+  name: 'sortByAxisTotal',
+  type: SortDirectionType,
+  label: 'Sort by x-axis total',
+  category: 'Component Settings',
+} as const;
+
+const limitAxisItems = {
+  name: 'limitAxisItems',
+  type: 'number',
+  label: 'Limit x-axis items',
+  description: 'Load only the top or bottom categories, based on group totals',
+  category: 'Component Settings',
+} as const;
+
 const markdown = {
   name: 'markdown',
   type: MarkdownType,
@@ -472,6 +488,8 @@ export const inputs = {
   xAxisRangeMax,
   xAxisMaxItems,
   yAxisMaxItems,
+  sortByAxisTotal,
+  limitAxisItems,
   granularity,
   granularities,
   markdown,

--- a/src/components/types/SortDirection.type.emb.ts
+++ b/src/components/types/SortDirection.type.emb.ts
@@ -1,0 +1,11 @@
+import { defineOption, defineType } from '@embeddable.com/core';
+
+const SortDirectionType = defineType('sortDirection', {
+  label: 'Sort direction',
+  optionLabel: (value: string) => value,
+});
+
+defineOption(SortDirectionType, 'Ascending');
+defineOption(SortDirectionType, 'Descending');
+
+export default SortDirectionType;


### PR DESCRIPTION
# Why is this pull-request needed?
Builders want to be able to set a sort order for the stacked and grouped bar charts based on the x-axis bar / group totals

# Main changes
Added "Sort by x-axis total" and "Limit x-axis items" inputs to stacked and grouped bar charts (vertical + horizontal).
When configured, a two-query flow runs: first query fetches aggregated category totals with backend sort/limit, then the main query fetches only the matching categories via a backend filter. Chart bars render in the totals query order.

# Test evidence

https://github.com/user-attachments/assets/4923e4c0-9a83-4dd3-a72b-68dc5a538a38




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sorting support for grouped bar charts by axis totals in ascending or descending order, highlighting top and bottom performers
  * Added limiting support to control which categories are displayed in grouped bar charts based on axis totals
  * New configuration options enable flexible customization of category display and ordering in grouped bar charts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->