### PR TITLE
Pin transitive axios version to prevent supply chain attack

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,5 +107,8 @@
   "peerDependencies": {
     "react": ">=19.1.1",
     "react-dom": ">=19.1.1"
+  },
+  "overrides": {
+    "axios": "1.13.6"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `overrides` to pin transitive axios dependency at `1.13.6`, preventing automatic upgrade to compromised versions (`1.14.1` / `0.30.4`) from the [axios npm supply chain attack](https://github.com/theNetworkChuck/axios-attack-guide)
- axios is not a direct dependency in this repo but is pulled in transitively

## Test plan
- [ ] Verify `npm install` resolves axios to `1.13.6`
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management to ensure consistent library versions across installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->