### PR TITLE
RUI-85: timezone support

### DIFF
--- a/.changeset/eighty-spies-sip.md
+++ b/.changeset/eighty-spies-sip.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': minor
+---
+
+Timezone support via client context

--- a/embeddable.theme.ts
+++ b/embeddable.theme.ts
@@ -1,8 +1,12 @@
 import { Theme } from './src/theme/theme.types';
 import { remarkableTheme } from './src/theme/theme.constants';
+import { getClientContextTimezone } from './src/theme/utils/clientContext.utils';
 
-const themeProvider = (): Theme => {
-  return remarkableTheme;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const themeProvider = (clientContext: any): Theme => {
+  const timezone = getClientContextTimezone(clientContext?.timezone);
+
+  return { ...remarkableTheme, clientContext: { ...clientContext, timezone } };
 };
 
 export default themeProvider;

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
@@ -12,6 +12,8 @@ import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 import { subInputs } from '../../../component.subinputs.constants';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'BarChartDefaultHorizontalPro',
@@ -70,14 +72,19 @@ const preview = definePreview(Component, previewConfig);
 const loadDataResultsArgs = (
   inputs: Inputs<typeof meta>,
   dimension?: Dimension,
+  clientContext?: ThemeClientContext,
 ): LoadDataRequest => ({
   from: inputs.dataset,
   select: [...inputs.measures, dimension ?? inputs.dimension],
   limit: inputs.maxResults,
+  timezone: getClientContextTimezone(clientContext?.timezone),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, dimension: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, dimension));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  dimension: Dimension,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, dimension, clientContext));
 
 const events = {
   onBarClicked: (value: { axisDimensionValue?: string }) => ({
@@ -91,6 +98,7 @@ const props = (
     BarChartDefaultHorizontalProState,
     (state: BarChartDefaultHorizontalProState) => void,
   ],
+  clientContext: ThemeClientContext,
 ) => {
   const dimensionWithGranularity = getDimensionWithGranularity(
     inputs.dimension,
@@ -101,7 +109,7 @@ const props = (
     ...inputs,
     dimension: dimensionWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, dimensionWithGranularity),
+    results: loadDataResults(inputs, dimensionWithGranularity, clientContext),
   };
 };
 

--- a/src/components/charts/bars/BarChartDefaultPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/definition.ts
@@ -12,6 +12,8 @@ import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 import { subInputs } from '../../../component.subinputs.constants';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'BarChartDefaultPro',
@@ -73,14 +75,19 @@ const preview = definePreview(Component, previewConfig);
 const loadDataResultsArgs = (
   inputs: Inputs<typeof meta>,
   dimension?: Dimension,
+  clientContext?: ThemeClientContext,
 ): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [...inputs.measures, dimension ?? inputs.dimension],
+  timezone: getClientContextTimezone(clientContext?.timezone),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, dimension: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, dimension));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  dimension: Dimension,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, dimension, clientContext));
 
 const events = {
   onBarClicked: (value: { axisDimensionValue?: string }) => ({
@@ -91,6 +98,7 @@ const events = {
 const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [BarChartDefaultProState, (state: BarChartDefaultProState) => void],
+  clientContext: ThemeClientContext,
 ) => {
   const dimensionWithGranularity = getDimensionWithGranularity(
     inputs.dimension,
@@ -101,7 +109,7 @@ const props = (
     ...inputs,
     dimension: dimensionWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, dimensionWithGranularity),
+    results: loadDataResults(inputs, dimensionWithGranularity, clientContext),
   };
 };
 

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -10,6 +10,8 @@ import {
   loadDataResultsAxisOrder,
   loadDataResults,
 } from '../bars.loadData.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'BarChartGroupedHorizontalPro',
@@ -85,9 +87,11 @@ const props = (
     BarChartGroupedHorizontalProState,
     (state: BarChartGroupedHorizontalProState) => void,
   ],
+  clientContext: ThemeClientContext,
 ) => {
   const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
   const sortDirection = inputs.sortDirectionTopYAxis as OrderDirection | undefined;
+  const timezone = getClientContextTimezone(clientContext?.timezone);
 
   const axisOrderCacheKey = getAxisOrderCacheKey({
     dataset: inputs.dataset,
@@ -95,6 +99,7 @@ const props = (
     measure: inputs.measure,
     sortDirection,
     limit: inputs.limitTopYAxis,
+    timezone,
   });
 
   const cachedAxisOrder = getCachedAxisOrder(axisOrderCacheKey, state);
@@ -113,6 +118,7 @@ const props = (
       axis: yAxisWithGranularity,
       measure: inputs.measure,
       sortDirection,
+      timezone,
     }),
     results: loadDataResults({
       dataset: inputs.dataset,
@@ -123,6 +129,7 @@ const props = (
       limitTopAxis: inputs.limitTopYAxis,
       maxResults: inputs.maxResults,
       axisOrder: cachedAxisOrder,
+      timezone,
     }),
   };
 };

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -10,6 +10,8 @@ import {
   loadDataResultsAxisOrder,
   loadDataResults,
 } from '../bars.loadData.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'BarChartGroupedPro',
@@ -82,9 +84,11 @@ const events = {
 const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [BarChartGroupedProState, (state: BarChartGroupedProState) => void],
+  clientContext: ThemeClientContext,
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
   const sortDirection = inputs.sortDirectionTopXAxis as OrderDirection | undefined;
+  const timezone = getClientContextTimezone(clientContext?.timezone);
 
   const axisOrderCacheKey = getAxisOrderCacheKey({
     dataset: inputs.dataset,
@@ -92,6 +96,7 @@ const props = (
     measure: inputs.measure,
     sortDirection,
     limit: inputs.limitTopXAxis,
+    timezone,
   });
 
   const cachedAxisOrder = getCachedAxisOrder(axisOrderCacheKey, state);
@@ -110,6 +115,7 @@ const props = (
       axis: xAxisWithGranularity,
       measure: inputs.measure,
       sortDirection,
+      timezone,
     }),
     results: loadDataResults({
       dataset: inputs.dataset,
@@ -120,6 +126,7 @@ const props = (
       limitTopAxis: inputs.limitTopXAxis,
       maxResults: inputs.maxResults,
       axisOrder: cachedAxisOrder,
+      timezone,
     }),
   };
 };

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -10,6 +10,8 @@ import {
   loadDataResultsAxisOrder,
   loadDataResults,
 } from '../bars.loadData.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'BarChartStackedHorizontalPro',
@@ -86,9 +88,11 @@ const props = (
     BarChartStackedHorizontalProState,
     (state: BarChartStackedHorizontalProState) => void,
   ],
+  clientContext: ThemeClientContext,
 ) => {
   const yAxisWithGranularity = getDimensionWithGranularity(inputs.yAxis, state?.granularity);
   const sortDirection = inputs.sortDirectionTopYAxis as OrderDirection | undefined;
+  const timezone = getClientContextTimezone(clientContext?.timezone);
 
   const axisOrderCacheKey = getAxisOrderCacheKey({
     dataset: inputs.dataset,
@@ -96,6 +100,7 @@ const props = (
     measure: inputs.measure,
     sortDirection,
     limit: inputs.limitTopYAxis,
+    timezone,
   });
 
   const cachedAxisOrder = getCachedAxisOrder(axisOrderCacheKey, state);
@@ -114,6 +119,7 @@ const props = (
       axis: yAxisWithGranularity,
       measure: inputs.measure,
       sortDirection,
+      timezone,
     }),
     results: loadDataResults({
       dataset: inputs.dataset,
@@ -124,6 +130,7 @@ const props = (
       limitTopAxis: inputs.limitTopYAxis,
       maxResults: inputs.maxResults,
       axisOrder: cachedAxisOrder,
+      timezone,
     }),
   };
 };

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -10,6 +10,8 @@ import {
   loadDataResultsAxisOrder,
   loadDataResults,
 } from '../bars.loadData.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'BarChartStackedPro',
@@ -83,9 +85,11 @@ const events = {
 const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [BarChartStackedProState, (state: BarChartStackedProState) => void],
+  clientContext: ThemeClientContext,
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
   const sortDirection = inputs.sortDirectionTopXAxis as OrderDirection | undefined;
+  const timezone = getClientContextTimezone(clientContext?.timezone);
 
   const axisOrderCacheKey = getAxisOrderCacheKey({
     dataset: inputs.dataset,
@@ -93,6 +97,7 @@ const props = (
     measure: inputs.measure,
     sortDirection,
     limit: inputs.limitTopXAxis,
+    timezone,
   });
 
   const cachedAxisOrder = getCachedAxisOrder(axisOrderCacheKey, state);
@@ -111,6 +116,7 @@ const props = (
       axis: xAxisWithGranularity,
       measure: inputs.measure,
       sortDirection,
+      timezone,
     }),
     results: loadDataResults({
       dataset: inputs.dataset,
@@ -121,6 +127,7 @@ const props = (
       limitTopAxis: inputs.limitTopXAxis,
       maxResults: inputs.maxResults,
       axisOrder: cachedAxisOrder,
+      timezone,
     }),
   };
 };

--- a/src/components/charts/bars/bars.loadData.utils.ts
+++ b/src/components/charts/bars/bars.loadData.utils.ts
@@ -30,6 +30,7 @@ type LoadDataResultsAxisOrderArgs = {
   measure: Measure;
   sortDirection?: OrderDirection;
   limit?: number;
+  timezone?: string;
 };
 
 export const loadDataResultsAxisOrderArgs = ({
@@ -38,6 +39,7 @@ export const loadDataResultsAxisOrderArgs = ({
   measure,
   sortDirection,
   limit,
+  timezone,
 }: LoadDataResultsAxisOrderArgs): LoadDataRequest => {
   return {
     from: dataset,
@@ -49,6 +51,7 @@ export const loadDataResultsAxisOrderArgs = ({
       },
     ],
     limit: getLimit(limit),
+    timezone,
   };
 };
 
@@ -58,6 +61,7 @@ type LoadDataResultsAxisOrder = {
   measure: Measure;
   limitTopAxis?: number;
   sortDirection?: OrderDirection;
+  timezone?: string;
 };
 
 export const loadDataResultsAxisOrder = ({
@@ -66,6 +70,7 @@ export const loadDataResultsAxisOrder = ({
   measure,
   limitTopAxis,
   sortDirection,
+  timezone,
 }: LoadDataResultsAxisOrder): DataResponse | undefined => {
   const needsTopItems = shouldGetTopItems(sortDirection, limitTopAxis);
 
@@ -78,6 +83,7 @@ export const loadDataResultsAxisOrder = ({
       measure,
       sortDirection,
       limit: limitTopAxis,
+      timezone,
     }),
   );
 };
@@ -88,10 +94,11 @@ export const getAxisOrderCacheKey = ({
   measure,
   sortDirection,
   limit,
+  timezone,
 }: LoadDataResultsAxisOrderArgs): string | undefined => {
   if (!shouldGetTopItems(sortDirection, limit)) return undefined;
   return JSON.stringify(
-    loadDataResultsAxisOrderArgs({ dataset, axis, measure, sortDirection, limit }),
+    loadDataResultsAxisOrderArgs({ dataset, axis, measure, sortDirection, limit, timezone }),
   );
 };
 
@@ -112,6 +119,7 @@ type LoadDataResultsArgs = {
   measure: Measure;
   limit?: number;
   axisOrder?: string[];
+  timezone?: string;
 };
 
 export const loadDataResultsArgs = ({
@@ -121,11 +129,13 @@ export const loadDataResultsArgs = ({
   measure,
   limit,
   axisOrder,
+  timezone,
 }: LoadDataResultsArgs): LoadDataRequest => {
   const request: LoadDataRequest = {
     from: dataset,
     select: [axis, groupBy, measure],
     limit: getLimit(limit),
+    timezone,
   };
   if (axisOrder?.length) {
     request['filters'] = [{ property: axis, operator: 'equals', value: axisOrder }];
@@ -143,6 +153,7 @@ type LoadDataResults = {
   limitTopAxis?: number;
   maxResults?: number;
   axisOrder?: string[];
+  timezone?: string;
 };
 
 export const loadDataResults = ({
@@ -155,6 +166,7 @@ export const loadDataResults = ({
   limitTopAxis,
   maxResults,
   axisOrder,
+  timezone,
 }: LoadDataResults): DataResponse | undefined => {
   const needsTopItems = shouldGetTopItems(sortDirection, limitTopAxis);
   const axisWithGranularity = getDimensionWithGranularity(axis, granularity);
@@ -166,6 +178,7 @@ export const loadDataResults = ({
         groupBy,
         measure,
         limit: maxResults,
+        timezone,
       }),
     );
   }
@@ -179,6 +192,7 @@ export const loadDataResults = ({
       measure,
       limit: maxResults,
       axisOrder,
+      timezone,
     }),
   );
 };

--- a/src/components/charts/charts.fillGaps.hooks.ts
+++ b/src/components/charts/charts.fillGaps.hooks.ts
@@ -51,7 +51,7 @@ export function useFillGaps(props: UseFillGapsProps): DataResponse {
     const dateBounds = dateBoundsTmp?.relativeTimeString
       ? theme.defaults.dateRangesOptions
           .find((option) => option.value === dateBoundsTmp?.relativeTimeString)
-          ?.getRange()
+          ?.getRange(theme.clientContext.timezone)
       : dateBoundsTmp;
 
     if (dimension.nativeType !== 'time') return results;

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/definition.ts
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/definition.ts
@@ -3,6 +3,8 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'KpiChartNumberComparisonPro',
@@ -75,10 +77,14 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
   from: inputs.dataset,
   select: [inputs.measure],
   limit: 1,
+  timezone: getClientContextTimezone(clientContext?.timezone),
   filters:
     inputs.primaryDateRange && inputs.timeProperty
       ? [
@@ -91,16 +97,20 @@ const loadDataResultsArgs = (inputs: Inputs<typeof meta>): LoadDataRequest => ({
       : undefined,
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>): DataResponse =>
-  loadData(loadDataResultsArgs(inputs));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, clientContext));
 
 const loadDataResultsComparisonArgs = (
   inputs: Inputs<typeof meta>,
   comparisonDateRange: TimeRange,
+  clientContext?: ThemeClientContext,
 ): LoadDataRequest => ({
   from: inputs.dataset,
   select: [inputs.measure],
   limit: 1,
+  timezone: getClientContextTimezone(clientContext?.timezone),
   filters: [
     {
       property: inputs.timeProperty,
@@ -113,9 +123,12 @@ const loadDataResultsComparisonArgs = (
 const loadDataResultsComparison = (
   inputs: Inputs<typeof meta>,
   state: KpiChartNumberComparisonProState,
+  clientContext: ThemeClientContext,
 ): DataResponse | undefined => {
   if (inputs.primaryDateRange && inputs.timeProperty && state?.comparisonDateRange) {
-    return loadData(loadDataResultsComparisonArgs(inputs, state.comparisonDateRange));
+    return loadData(
+      loadDataResultsComparisonArgs(inputs, state.comparisonDateRange, clientContext),
+    );
   }
   return undefined;
 };
@@ -126,13 +139,14 @@ const props = (
     KpiChartNumberComparisonProState,
     (state: KpiChartNumberComparisonProState) => void,
   ],
+  clientContext: ThemeClientContext,
 ) => ({
   ...inputs,
   comparisonPeriod: inputs.comparisonPeriod as string | undefined,
   comparisonDateRange: state?.comparisonDateRange,
   setComparisonDateRange: (comparisonDateRange: TimeRange) => setState({ comparisonDateRange }),
-  results: loadDataResults(inputs),
-  resultsComparison: loadDataResultsComparison(inputs, state),
+  results: loadDataResults(inputs, clientContext),
+  resultsComparison: loadDataResultsComparison(inputs, state, clientContext),
 });
 
 export const kpiChartNumberComparisonPro = {

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
@@ -169,7 +169,7 @@ const loadDataResultsArgs = (
 const loadDataResults = (
   inputs: Inputs<typeof meta>,
   xAxis: Dimension,
-  clientContext?: ThemeClientContext,
+  clientContext: ThemeClientContext,
 ): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, clientContext));
 
 const loadDataResultsComparisonArgs = (

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
@@ -15,6 +15,8 @@ import { inputs } from '../../../component.inputs.constants';
 import { subInputs } from '../../../component.subinputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'LineChartComparisonDefaultPro',
@@ -141,7 +143,11 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, xAxis?: Dimension): LoadDataRequest => {
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  xAxis?: Dimension,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => {
   const resolvedXAxis = xAxis ?? inputs.xAxis;
   const orderBy: OrderBy[] = [{ property: resolvedXAxis, direction: 'asc' }];
   const timeProperty =
@@ -156,16 +162,21 @@ const loadDataResultsArgs = (inputs: Inputs<typeof meta>, xAxis?: Dimension): Lo
       inputs.primaryDateRange && timeProperty
         ? [{ property: timeProperty, operator: 'inDateRange', value: inputs.primaryDateRange }]
         : undefined,
+    timezone: getClientContextTimezone(clientContext?.timezone),
   };
 };
 
-const loadDataResults = (inputs: Inputs<typeof meta>, xAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, xAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  xAxis: Dimension,
+  clientContext?: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, clientContext));
 
 const loadDataResultsComparisonArgs = (
   inputs: Inputs<typeof meta>,
   xAxis: Dimension,
   comparisonDateRange: TimeRange,
+  clientContext: ThemeClientContext,
 ): LoadDataRequest => {
   const orderBy: OrderBy[] = [{ property: xAxis, direction: 'asc' }];
   const timeProperty =
@@ -177,6 +188,7 @@ const loadDataResultsComparisonArgs = (
     select: [...inputs.measures, xAxis],
     orderBy,
     filters: [{ property: timeProperty, operator: 'inDateRange', value: comparisonDateRange }],
+    timezone: getClientContextTimezone(clientContext?.timezone),
   };
 };
 
@@ -184,12 +196,15 @@ const loadDataResultsComparison = (
   inputs: Inputs<typeof meta>,
   xAxis: Dimension,
   state: LineChartComparisonDefaultProState,
+  clientContext: ThemeClientContext,
 ): DataResponse | undefined => {
   const timeProperty =
     xAxis.nativeType === 'time' ? xAxis : inputs.timePropertyForNonTimeDimensions;
 
   if (inputs.primaryDateRange && timeProperty && state?.comparisonDateRange) {
-    return loadData(loadDataResultsComparisonArgs(inputs, xAxis, state.comparisonDateRange));
+    return loadData(
+      loadDataResultsComparisonArgs(inputs, xAxis, state.comparisonDateRange, clientContext),
+    );
   }
   return undefined;
 };
@@ -206,6 +221,7 @@ const props = (
     LineChartComparisonDefaultProState,
     (state: LineChartComparisonDefaultProState) => void,
   ],
+  clientContext: ThemeClientContext,
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
 
@@ -216,8 +232,13 @@ const props = (
     comparisonDateRange: state?.comparisonDateRange,
     setComparisonDateRange: (comparisonDateRange: TimeRange) =>
       setState({ ...state, comparisonDateRange }),
-    results: loadDataResults(inputs, xAxisWithGranularity),
-    resultsComparison: loadDataResultsComparison(inputs, xAxisWithGranularity, state),
+    results: loadDataResults(inputs, xAxisWithGranularity, clientContext),
+    resultsComparison: loadDataResultsComparison(
+      inputs,
+      xAxisWithGranularity,
+      state,
+      clientContext,
+    ),
   };
 };
 

--- a/src/components/charts/lines/LineChartDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/definition.ts
@@ -13,6 +13,8 @@ import { inputs } from '../../../component.inputs.constants';
 import { subInputs } from '../../../component.subinputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'LineChartDefaultPro',
@@ -87,14 +89,22 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, xAxis?: Dimension): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  xAxis?: Dimension,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [...inputs.measures, xAxis ?? inputs.xAxis],
+  timezone: getClientContextTimezone(clientContext?.timezone),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, xAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, xAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  xAxis: Dimension,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, clientContext));
 
 const events = {
   onLineClicked: (value: LineChartProOptionsClickArg) => ({
@@ -105,6 +115,7 @@ const events = {
 const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [LineChartDefaultProState, (state: LineChartDefaultProState) => void],
+  clientContext: ThemeClientContext,
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
 
@@ -112,7 +123,7 @@ const props = (
     ...inputs,
     xAxis: xAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, xAxisWithGranularity),
+    results: loadDataResults(inputs, xAxisWithGranularity, clientContext),
   };
 };
 

--- a/src/components/charts/lines/LineChartGroupedPro/definition.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/definition.ts
@@ -12,6 +12,8 @@ import { LineChartProOptionsClickArg } from '../lines.utils';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'LineChartGroupedPro',
@@ -88,14 +90,22 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>, xAxis?: Dimension): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  xAxis?: Dimension,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
   limit: inputs.maxResults,
   from: inputs.dataset,
   select: [xAxis ?? inputs.xAxis, inputs.groupBy, inputs.measure],
+  timezone: getClientContextTimezone(clientContext?.timezone),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>, xAxis: Dimension): DataResponse =>
-  loadData(loadDataResultsArgs(inputs, xAxis));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  xAxis: Dimension,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, clientContext));
 
 const events = {
   onLineClicked: (value: LineChartProOptionsClickArg) => ({
@@ -107,6 +117,7 @@ const events = {
 const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [LineChartGroupedProState, (state: LineChartGroupedProState) => void],
+  clientContext: ThemeClientContext,
 ) => {
   const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
 
@@ -114,7 +125,7 @@ const props = (
     ...inputs,
     xAxis: xAxisWithGranularity,
     setGranularity: (granularity: Granularity) => setState({ granularity }),
-    results: loadDataResults(inputs, xAxisWithGranularity),
+    results: loadDataResults(inputs, xAxisWithGranularity, clientContext),
   };
 };
 

--- a/src/components/charts/tables/HeatMapPro/definition.ts
+++ b/src/components/charts/tables/HeatMapPro/definition.ts
@@ -3,6 +3,8 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'HeatMapPro',
@@ -89,19 +91,29 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
   from: inputs.dataset,
   select: [inputs.rowDimension, inputs.columnDimension, inputs.measure],
   limit: inputs.maxResults,
   countRows: true,
+  timezone: getClientContextTimezone(clientContext?.timezone),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>): DataResponse =>
-  loadData(loadDataResultsArgs(inputs));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  clientContext?: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, clientContext));
 
-const props = (inputs: Inputs<typeof meta>) => ({
+const props = (
+  inputs: Inputs<typeof meta>,
+  _state: unknown,
+  clientContext?: ThemeClientContext,
+) => ({
   ...inputs,
-  results: loadDataResults(inputs),
+  results: loadDataResults(inputs, clientContext),
 });
 
 export const heatMapPro = {

--- a/src/components/charts/tables/PivotTablePro/definition.ts
+++ b/src/components/charts/tables/PivotTablePro/definition.ts
@@ -4,6 +4,8 @@ import Component from './index';
 import { inputs } from '../../../component.inputs.constants';
 import { subInputs } from '../../../component.subinputs.constants';
 import { previewData } from '../../../preview.data.constants';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
 
 const meta = {
   name: 'PivotTablePro',
@@ -91,24 +93,32 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = (inputs: Inputs<typeof meta>): LoadDataRequest => ({
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
   from: inputs.dataset,
   select: [inputs.rowDimension, inputs.columnDimension, ...inputs.measures],
   limit: inputs.maxResults,
   countRows: true,
+  timezone: getClientContextTimezone(clientContext?.timezone),
 });
 
-const loadDataResults = (inputs: Inputs<typeof meta>): DataResponse =>
-  loadData(loadDataResultsArgs(inputs));
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  clientContext?: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, clientContext));
 
 const loadDataResultsSubRowsArgs = (
   inputs: Inputs<typeof meta>,
   expandedRowKeys: string[],
+  clientContext?: ThemeClientContext,
 ): LoadDataRequest => ({
   from: inputs.dataset,
   select: [inputs.rowDimension, inputs.subRowDimension, inputs.columnDimension, ...inputs.measures],
   limit: inputs.maxResults,
   countRows: true,
+  timezone: getClientContextTimezone(clientContext?.timezone),
   filters: [
     {
       property: inputs.rowDimension,
@@ -121,9 +131,10 @@ const loadDataResultsSubRowsArgs = (
 const loadDataResultsSubRows = (
   inputs: Inputs<typeof meta>,
   expandedRowKeys: string[],
+  clientContext?: ThemeClientContext,
 ): DataResponse | undefined => {
   if (expandedRowKeys.length > 0) {
-    return loadData(loadDataResultsSubRowsArgs(inputs, expandedRowKeys));
+    return loadData(loadDataResultsSubRowsArgs(inputs, expandedRowKeys, clientContext));
   }
   return undefined;
 };
@@ -131,6 +142,7 @@ const loadDataResultsSubRows = (
 const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [PivotTableProState, (state: PivotTableProState) => void],
+  clientContext: ThemeClientContext,
 ) => {
   const expandedRowKeys = state?.expandedRowKeys ?? [];
 
@@ -140,8 +152,8 @@ const props = (
     expandedRowKeys,
     setExpandedRowKey: (rowKey: string) =>
       setState({ expandedRowKeys: [...expandedRowKeys, rowKey] }),
-    results: loadDataResults(inputs),
-    resultsSubRows: loadDataResultsSubRows(inputs, expandedRowKeys),
+    results: loadDataResults(inputs, clientContext),
+    resultsSubRows: loadDataResultsSubRows(inputs, expandedRowKeys, clientContext),
   };
 };
 

--- a/src/components/editors/ComparisonPeriodSelectFieldPro/index.tsx
+++ b/src/components/editors/ComparisonPeriodSelectFieldPro/index.tsx
@@ -48,6 +48,7 @@ const DateComparisonSelectFieldPro = (props: DateComparisonSelectFieldPro) => {
   const primaryDateRange = getTimeRangeFromPresets(
     props.primaryDateRange,
     theme.defaults.dateRangesOptions,
+    theme.clientContext.timezone,
   );
 
   if (!dayjsLocaleReady) {

--- a/src/components/editors/dates/DateRangePickerCustomPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerCustomPro/index.tsx
@@ -40,7 +40,12 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
   };
 
   const dateRangeOptions = theme.defaults.dateRangesOptions;
-  const displayValue = getTimeRangeLabel(selectedValue, 'MMM DD', dateRangeOptions);
+  const displayValue = getTimeRangeLabel(
+    selectedValue,
+    'MMM DD',
+    dateRangeOptions,
+    theme.clientContext.timezone,
+  );
 
   const locale = theme.i18n.language ?? theme.formatter.locale;
 
@@ -53,7 +58,11 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
         placeholder={placeholder}
         displayValue={displayValue}
         numberOfMonths={showTwoMonths ? 2 : 1}
-        value={getDateRangeFromTimeRange(selectedValue, dateRangeOptions)}
+        value={getDateRangeFromTimeRange(
+          selectedValue,
+          dateRangeOptions,
+          theme.clientContext.timezone,
+        )}
         onChange={handleChange}
         submitLabel={i18n.t('editors.dateRangePicker.apply')}
         avoidCollisions={false}

--- a/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.types.ts
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.types.ts
@@ -4,5 +4,5 @@ export type DateRangeSelectFieldProOption = {
   label: string;
   value: string;
   dateFormat: string;
-  getRange: () => TimeRange;
+  getRange: (timezone?: string) => TimeRange;
 };

--- a/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.utils.ts
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.utils.ts
@@ -5,10 +5,11 @@ import { getTimeRangeLabel } from '../dates.utils';
 
 export const getDateRangeSelectFieldProOptions = (
   dateRangeSelectFieldProOptions: DateRangeSelectFieldProOption[],
+  timezone?: string,
 ): SelectListOptionProps[] => {
   return dateRangeSelectFieldProOptions.map((option) => {
     return {
-      rightLabel: getTimeRangeLabel(option.getRange(), option.dateFormat),
+      rightLabel: getTimeRangeLabel(option.getRange(timezone), option.dateFormat),
       value: option.value,
       label: resolveI18nString(option.label),
     };

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -58,12 +58,16 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
       return;
     }
     // Step 1: Convert relativeTimeString to actual time range (from/to)
-    const newTimeRange = getTimeRangeFromPresets(selectedValue, dateRangeOptions);
+    const newTimeRange = getTimeRangeFromPresets(
+      selectedValue,
+      dateRangeOptions,
+      theme.clientContext.timezone,
+    );
 
     if (!shallowEqual(newTimeRange, selectedValue)) {
       onChange(newTimeRange);
     }
-  }, [selectedValue, dayjsLocaleReady, onChange, dateRangeOptions]);
+  }, [selectedValue, dayjsLocaleReady, onChange, dateRangeOptions, theme.clientContext.timezone]);
 
   if (!dayjsLocaleReady) {
     return null;
@@ -71,12 +75,13 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
 
   const { description, placeholder, title, tooltip } = resolveI18nProps(props);
 
-  const options = getDateRangeSelectFieldProOptions(dateRangeOptions);
+  const options = getDateRangeSelectFieldProOptions(dateRangeOptions, theme.clientContext.timezone);
 
   const handleOptionChange = (newValue: string | undefined) => {
     const newTimeRange = getTimeRangeFromPresets(
       { relativeTimeString: newValue } as TimeRange,
       dateRangeOptions,
+      theme.clientContext.timezone,
     );
 
     onChange(newTimeRange);

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -102,7 +102,7 @@ describe('getDateRangeFromTimeRange', () => {
     expect(getDateRangeFromTimeRange(input, [])).toBe(input);
   });
 
-  it('returns timeRange as-is when relativeTimeString does not match any option', () => {
+  it('returns undefined when relativeTimeString does not match any option', () => {
     const input: TimeRange = { relativeTimeString: 'unknown', from: undefined, to: undefined };
     const opt = makeOption('jan', jan);
     const result = getDateRangeFromTimeRange(input, [opt]);

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -9,6 +9,7 @@ dayjs.extend(utc);
 export const getTimeRangeFromPresets = (
   receivedTimeRange: TimeRange,
   options?: DateRangeOption[],
+  timezone?: string,
 ): TimeRange => {
   if (options?.length === 0) {
     return receivedTimeRange;
@@ -17,7 +18,7 @@ export const getTimeRangeFromPresets = (
   if (receivedTimeRange?.relativeTimeString) {
     const selectedOption = options
       ?.find((dateRange) => dateRange.value === receivedTimeRange?.relativeTimeString)
-      ?.getRange();
+      ?.getRange(timezone);
 
     const { from, to } = selectedOption || {};
 
@@ -33,8 +34,9 @@ export const getTimeRangeLabel = (
   range: TimeRange,
   dateFormat: string,
   options?: DateRangeOption[],
+  timezone?: string,
 ): string => {
-  const dateRange = getDateRangeFromTimeRange(range, options);
+  const dateRange = getDateRangeFromTimeRange(range, options, timezone);
 
   if (!dateRange) {
     return '';
@@ -62,6 +64,7 @@ export const getTimeRangeLabel = (
 export const getDateRangeFromTimeRange = (
   timeRange: TimeRange,
   options?: DateRangeOption[],
+  timezone?: string,
 ): DateRange | undefined => {
   if (!timeRange) {
     return timeRange;
@@ -69,8 +72,8 @@ export const getDateRangeFromTimeRange = (
 
   let finalTimeRange: TimeRange = timeRange;
   if ((!timeRange?.from || !timeRange?.to) && timeRange?.relativeTimeString && options?.length) {
-    const option = options.find((opt) => opt.value === timeRange!.relativeTimeString);
-    finalTimeRange = option?.getRange() as TimeRange;
+    const option = options.find((opt) => opt.value === timeRange.relativeTimeString);
+    finalTimeRange = option?.getRange(timezone);
   }
 
   return finalTimeRange;

--- a/src/components/utils/timeRange.utils.ts
+++ b/src/components/utils/timeRange.utils.ts
@@ -14,7 +14,7 @@ export const getComparisonPeriodDateRange = (
   const primaryDateRangeRange = primaryDateRange?.relativeTimeString
     ? theme.defaults.dateRangesOptions
         .find((option) => option.value === primaryDateRange?.relativeTimeString)
-        ?.getRange()
+        ?.getRange(theme.clientContext.timezone)
     : primaryDateRange;
 
   const comparisonPeriodOption = theme.defaults.comparisonPeriodsOptions.find(

--- a/src/components/utils/timeRange.utils.ts
+++ b/src/components/utils/timeRange.utils.ts
@@ -14,7 +14,7 @@ export const getComparisonPeriodDateRange = (
   const primaryDateRangeRange = primaryDateRange?.relativeTimeString
     ? theme.defaults.dateRangesOptions
         .find((option) => option.value === primaryDateRange?.relativeTimeString)
-        ?.getRange(theme.clientContext.timezone)
+        ?.getRange(theme.clientContext?.timezone)
     : primaryDateRange;
 
   const comparisonPeriodOption = theme.defaults.comparisonPeriodsOptions.find(

--- a/src/theme/defaults/defaults.ComparisonPeriods.constants.ts
+++ b/src/theme/defaults/defaults.ComparisonPeriods.constants.ts
@@ -2,9 +2,11 @@ import { TimeRange, TimeRangeDeserializedValue } from '@embeddable.com/core';
 import dayjs from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek.js';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import utc from 'dayjs/plugin/utc.js';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 dayjs.extend(isoWeek);
 dayjs.extend(quarterOfYear);
 
@@ -18,6 +20,10 @@ export type ComparisonPeriodOption = {
 /*--------------------*/
 /*------Helpers-------*/
 /*--------------------*/
+const getLocalDateString = (date: Date): string => {
+  return dayjs.utc(date).format('YYYY-MM-DD');
+};
+
 function toUtcStartOfDay(d: Date): Date {
   return dayjs.utc(d).startOf('day').toDate();
 }
@@ -78,8 +84,8 @@ const getPreviousPeriodRange = (primaryDateRange: TimeRange) => {
   const { from: primaryFrom, to: primaryTo } = primaryDateRange as TimeRangeDeserializedValue;
   if (!primaryFrom || !primaryTo) return undefined;
 
-  const dateFrom = dayjs.utc(primaryFrom);
-  const gapDays = dayjs.utc(primaryTo).diff(dateFrom, 'day') + 1;
+  const dateFrom = dayjs.utc(getLocalDateString(primaryFrom));
+  const gapDays = dayjs.utc(getLocalDateString(primaryTo)).diff(dateFrom, 'day') + 1;
 
   const prevTo = dateFrom.subtract(1, 'day');
   const prevFrom = prevTo.subtract(gapDays - 1, 'day');
@@ -95,7 +101,7 @@ const getPreviousWeekRange = (primaryDateRange: TimeRange) => {
   const { from: primaryFrom } = primaryDateRange as TimeRangeDeserializedValue;
   if (!primaryFrom) return undefined;
 
-  const dateFrom = dayjs.utc(primaryFrom);
+  const dateFrom = dayjs.utc(getLocalDateString(primaryFrom));
   const prevWeekStart = dateFrom.startOf('isoWeek').subtract(1, 'week');
   const prevWeekEnd = prevWeekStart.endOf('isoWeek');
 
@@ -110,7 +116,7 @@ const getPreviousMonthRange = (primaryDateRange: TimeRange) => {
   const { from: primaryFrom } = primaryDateRange as TimeRangeDeserializedValue;
   if (!primaryFrom) return undefined;
 
-  const dateFrom = dayjs.utc(primaryFrom);
+  const dateFrom = dayjs.utc(getLocalDateString(primaryFrom));
   const prevMonthStart = dateFrom.startOf('month').subtract(1, 'month');
   const prevMonthEnd = prevMonthStart.endOf('month');
 
@@ -125,7 +131,7 @@ const getPreviousQuarterRange = (primaryDateRange: TimeRange) => {
   const { from: primaryFrom } = primaryDateRange as TimeRangeDeserializedValue;
   if (!primaryFrom) return undefined;
 
-  const dateFrom = dayjs.utc(primaryFrom);
+  const dateFrom = dayjs.utc(getLocalDateString(primaryFrom));
   const prevQuarterStart = dateFrom.startOf('quarter').subtract(1, 'quarter');
   const prevQuarterEnd = prevQuarterStart.endOf('quarter');
 
@@ -140,7 +146,7 @@ const getPreviousYearRange = (primaryDateRange: TimeRange) => {
   const { from: primaryFrom } = primaryDateRange as TimeRangeDeserializedValue;
   if (!primaryFrom) return undefined;
 
-  const dateFrom = dayjs.utc(primaryFrom);
+  const dateFrom = dayjs.utc(getLocalDateString(primaryFrom));
   const prevYearStart = dateFrom.startOf('year').subtract(1, 'year');
   const prevYearEnd = prevYearStart.endOf('year');
 

--- a/src/theme/defaults/defaults.DateRanges.constants.test.ts
+++ b/src/theme/defaults/defaults.DateRanges.constants.test.ts
@@ -4,6 +4,8 @@ import { defaultDateRangeOptions } from './defaults.DateRanges.constants';
 // Fixed reference point: Thursday 2024-02-15 at noon UTC
 const FIXED_NOW = new Date('2024-02-15T12:00:00.000Z');
 
+const getOption = (value: string) => defaultDateRangeOptions.find((o) => o.value === value)!;
+
 describe('defaultDateRangeOptions', () => {
   it('has 22 options', () => {
     expect(defaultDateRangeOptions).toHaveLength(22);
@@ -27,11 +29,6 @@ describe('defaultDateRangeOptions', () => {
     afterEach(() => {
       vi.useRealTimers();
     });
-
-    const getOption = (value: string) => {
-      const opt = defaultDateRangeOptions.find((o) => o.value === value)!;
-      return opt;
-    };
 
     it('Today', () => {
       const { from, to } = getOption('Today').getRange() as TimeRangeDeserializedValue;
@@ -163,6 +160,84 @@ describe('defaultDateRangeOptions', () => {
       const { from, to } = getOption('Year to date').getRange() as TimeRangeDeserializedValue;
       expect(from).toEqual(new Date('2024-01-01T00:00:00.000Z'));
       expect(to).toEqual(new Date('2024-02-15T23:59:59.999Z'));
+    });
+  });
+
+  describe('getRange() with timezone — day boundary crossing (UTC+13)', () => {
+    // 2024-02-15T15:00:00Z is Thursday Feb 15 in UTC,
+    // but Friday Feb 16 in Pacific/Auckland (UTC+13).
+    const FIXED_TZ_NOW = new Date('2024-02-15T15:00:00.000Z');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_TZ_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('Today anchors to local date (Feb 16, not Feb 15)', () => {
+      const { from, to } = getOption('Today').getRange(
+        'Pacific/Auckland',
+      ) as TimeRangeDeserializedValue;
+      expect(from).toEqual(new Date('2024-02-16T00:00:00.000Z'));
+      expect(to).toEqual(new Date('2024-02-16T23:59:59.999Z'));
+    });
+
+    it('Yesterday is Feb 15, not Feb 14', () => {
+      const { from, to } = getOption('Yesterday').getRange(
+        'Pacific/Auckland',
+      ) as TimeRangeDeserializedValue;
+      expect(from).toEqual(new Date('2024-02-15T00:00:00.000Z'));
+      expect(to).toEqual(new Date('2024-02-15T23:59:59.999Z'));
+    });
+
+    it('Week to date ends on local today (Mon Feb 12 – Fri Feb 16)', () => {
+      const { from, to } = getOption('Week to date').getRange(
+        'Pacific/Auckland',
+      ) as TimeRangeDeserializedValue;
+      expect(from).toEqual(new Date('2024-02-12T00:00:00.000Z'));
+      expect(to).toEqual(new Date('2024-02-16T23:59:59.999Z'));
+    });
+  });
+
+  describe('getRange() with timezone — month boundary crossing (UTC-1)', () => {
+    // 2024-03-01T00:30:00Z is Friday Mar 1 in UTC,
+    // but Thursday Feb 29 in Atlantic/Cape_Verde (UTC-1).
+    const FIXED_MONTH_BOUNDARY = new Date('2024-03-01T00:30:00.000Z');
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_MONTH_BOUNDARY);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('Today is Feb 29, not Mar 1', () => {
+      const { from, to } = getOption('Today').getRange(
+        'Atlantic/Cape_Verde',
+      ) as TimeRangeDeserializedValue;
+      expect(from).toEqual(new Date('2024-02-29T00:00:00.000Z'));
+      expect(to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
+    });
+
+    it('This month is February (leap year), not March', () => {
+      const { from, to } = getOption('This month').getRange(
+        'Atlantic/Cape_Verde',
+      ) as TimeRangeDeserializedValue;
+      expect(from).toEqual(new Date('2024-02-01T00:00:00.000Z'));
+      expect(to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
+    });
+
+    it('Last month is January, not February', () => {
+      const { from, to } = getOption('Last month').getRange(
+        'Atlantic/Cape_Verde',
+      ) as TimeRangeDeserializedValue;
+      expect(from).toEqual(new Date('2024-01-01T00:00:00.000Z'));
+      expect(to).toEqual(new Date('2024-01-31T23:59:59.999Z'));
     });
   });
 });

--- a/src/theme/defaults/defaults.DateRanges.constants.ts
+++ b/src/theme/defaults/defaults.DateRanges.constants.ts
@@ -10,34 +10,69 @@ dayjs.extend(timezone);
 dayjs.extend(isoWeek);
 dayjs.extend(quarterOfYear);
 
-const getLocalDateString = (date: Date, timezone?: string): string => {
-  return timezone
-    ? dayjs.tz(date, timezone).format('YYYY-MM-DD')
-    : dayjs.utc(date).format('YYYY-MM-DD');
+const makeTimeRange = (from: Date, to: Date): TimeRange => ({ from, to, relativeTimeString: '' });
+
+const getLocalDateString = (date: Date, tz?: string): string =>
+  tz ? dayjs.tz(date, tz).format('YYYY-MM-DD') : dayjs.utc(date).format('YYYY-MM-DD');
+
+const getNow = (tz?: string) => dayjs.utc(getLocalDateString(new Date(), tz));
+
+const getDayBounds = (offset = 0, tz?: string): TimeRange => {
+  const d = getNow(tz).add(offset, 'day');
+  return makeTimeRange(d.startOf('day').toDate(), d.endOf('day').toDate());
 };
 
-const getWeekBounds = (date: Date, offset = 0, timezone?: string): TimeRange => {
-  const d = dayjs.utc(getLocalDateString(date, timezone)).add(offset, 'week');
-  const from = d.startOf('isoWeek').toDate(); // Monday
-  const to = d.endOf('isoWeek').toDate(); // Sunday
-
-  return {
-    from,
-    to,
-    relativeTimeString: '',
-  };
+const getWeekBounds = (offset = 0, tz?: string): TimeRange => {
+  const d = getNow(tz).add(offset, 'week');
+  return makeTimeRange(d.startOf('isoWeek').toDate(), d.endOf('isoWeek').toDate());
 };
 
-const getQuarterBounds = (date: Date, offset = 0, timezone?: string): TimeRange => {
-  const d = dayjs.utc(getLocalDateString(date, timezone)).add(offset, 'quarter');
-  const from = d.startOf('quarter').toDate();
-  const to = d.endOf('quarter').toDate();
+const getMonthBounds = (offset = 0, tz?: string): TimeRange => {
+  const d = getNow(tz).add(offset, 'month');
+  return makeTimeRange(d.startOf('month').toDate(), d.endOf('month').toDate());
+};
 
-  return {
-    from,
-    to,
-    relativeTimeString: '',
-  };
+const getQuarterBounds = (offset = 0, tz?: string): TimeRange => {
+  const d = getNow(tz).add(offset, 'quarter');
+  return makeTimeRange(d.startOf('quarter').toDate(), d.endOf('quarter').toDate());
+};
+
+const getYearBounds = (offset = 0, tz?: string): TimeRange => {
+  const d = getNow(tz).add(offset, 'year');
+  return makeTimeRange(d.startOf('year').toDate(), d.endOf('year').toDate());
+};
+
+const getLastNDays = (n: number, tz?: string): TimeRange => {
+  const now = getNow(tz);
+  return makeTimeRange(
+    now
+      .subtract(n - 1, 'day')
+      .startOf('day')
+      .toDate(),
+    now.endOf('day').toDate(),
+  );
+};
+
+const getNextNDays = (n: number, tz?: string): TimeRange => {
+  const now = getNow(tz);
+  return makeTimeRange(
+    now.startOf('day').toDate(),
+    now
+      .add(n - 1, 'day')
+      .endOf('day')
+      .toDate(),
+  );
+};
+
+const getLastNMonths = (n: number, tz?: string): TimeRange => {
+  const now = getNow(tz);
+  return makeTimeRange(now.subtract(n, 'month').startOf('day').toDate(), now.endOf('day').toDate());
+};
+
+const getUnitToDate = (unit: 'isoWeek' | 'quarter' | 'year', tz?: string): TimeRange => {
+  const now = getNow(tz);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return makeTimeRange(now.startOf(unit as any).toDate(), now.endOf('day').toDate());
 };
 
 export type DateRangeOption = {
@@ -52,321 +87,132 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Today',
     label: 'defaults.dateRangeOptions.today|Today',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const now = timezone
-        ? dayjs.tz(new Date(), timezone).format('YYYY-MM-DD')
-        : dayjs.utc(new Date()).format('YYYY-MM-DD');
-      const from = dayjs.utc(now).startOf('day').toDate();
-      const to = dayjs.utc(now).endOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getDayBounds(0, tz),
   },
   {
     value: 'Yesterday',
     label: 'defaults.dateRangeOptions.yesterday|Yesterday',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const now = timezone
-        ? dayjs.tz(new Date(), timezone).subtract(1, 'day').format('YYYY-MM-DD')
-        : dayjs.utc(new Date()).subtract(1, 'day').format('YYYY-MM-DD');
-      const from = dayjs.utc(now).startOf('day').toDate();
-      const to = dayjs.utc(now).endOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getDayBounds(-1, tz),
   },
   {
     value: 'This week',
     label: 'defaults.dateRangeOptions.thisWeek|This week',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => getWeekBounds(new Date(), 0, timezone),
+    getRange: (tz?: string) => getWeekBounds(0, tz),
   },
   {
     value: 'Last week',
     label: 'defaults.dateRangeOptions.lastWeek|Last week',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => getWeekBounds(new Date(), -1, timezone),
+    getRange: (tz?: string) => getWeekBounds(-1, tz),
   },
   {
     value: 'Week to date',
     label: 'defaults.dateRangeOptions.weekToDate|Week to date',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('isoWeek').toDate(); // Monday as start of week
-      const to = now.endOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getUnitToDate('isoWeek', tz),
   },
   {
     value: 'Last 7 days',
     label: 'defaults.dateRangeOptions.last7Days|Last 7 days',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const to = now.endOf('day').toDate();
-      const from = now.subtract(6, 'day').startOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getLastNDays(7, tz),
   },
   {
     value: 'Next 7 days',
     label: 'defaults.dateRangeOptions.next7Days|Next 7 days',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('day').toDate();
-      const to = now.add(6, 'day').endOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getNextNDays(7, tz),
   },
   {
     value: 'Last 30 days',
     label: 'defaults.dateRangeOptions.last30Days|Last 30 days',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const to = now.endOf('day').toDate();
-      const from = now.subtract(29, 'day').startOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getLastNDays(30, tz),
   },
   {
     value: 'Next 30 days',
     label: 'defaults.dateRangeOptions.next30Days|Next 30 days',
     dateFormat: 'MMM DD',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('day').toDate();
-      const to = now.add(29, 'day').endOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getNextNDays(30, tz),
   },
   {
     value: 'This month',
     label: 'defaults.dateRangeOptions.thisMonth|This month',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('month').toDate();
-      const to = now.endOf('month').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getMonthBounds(0, tz),
   },
   {
     value: 'Last month',
     label: 'defaults.dateRangeOptions.lastMonth|Last month',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.subtract(1, 'month').startOf('month').toDate();
-      const to = now.subtract(1, 'month').endOf('month').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getMonthBounds(-1, tz),
   },
   {
     value: 'Next month',
     label: 'defaults.dateRangeOptions.nextMonth|Next month',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.add(1, 'month').startOf('month').toDate();
-      const to = now.add(1, 'month').endOf('month').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getMonthBounds(1, tz),
   },
   {
     value: 'This quarter',
     label: 'defaults.dateRangeOptions.thisQuarter|This quarter',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => getQuarterBounds(new Date(), 0, timezone),
+    getRange: (tz?: string) => getQuarterBounds(0, tz),
   },
   {
     value: 'Last quarter',
     label: 'defaults.dateRangeOptions.lastQuarter|Last quarter',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => getQuarterBounds(new Date(), -1, timezone),
+    getRange: (tz?: string) => getQuarterBounds(-1, tz),
   },
   {
     value: 'Next quarter',
     label: 'defaults.dateRangeOptions.nextQuarter|Next quarter',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => getQuarterBounds(new Date(), +1, timezone),
+    getRange: (tz?: string) => getQuarterBounds(1, tz),
   },
   {
     value: 'Quarter to date',
     label: 'defaults.dateRangeOptions.quarterToDate|Quarter to date',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('quarter').toDate(); // start of current quarter
-      const to = now.endOf('day').toDate(); // today at 23:59:59.999
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getUnitToDate('quarter', tz),
   },
   {
     value: 'Last 6 months',
     label: 'defaults.dateRangeOptions.last6Months|Last 6 months',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const to = now.endOf('day').toDate();
-      const from = now.subtract(6, 'month').startOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getLastNMonths(6, tz),
   },
   {
     value: 'Last 12 months',
     label: 'defaults.dateRangeOptions.last12Months|Last 12 months',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const to = now.endOf('day').toDate();
-      const from = now.subtract(12, 'month').startOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getLastNMonths(12, tz),
   },
   {
     value: 'This year',
     label: 'defaults.dateRangeOptions.thisYear|This year',
     dateFormat: 'YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('year').toDate();
-      const to = now.endOf('year').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getYearBounds(0, tz),
   },
   {
     value: 'Last year',
     label: 'defaults.dateRangeOptions.lastYear|Last year',
     dateFormat: 'YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.subtract(1, 'year').startOf('year').toDate();
-      const to = now.subtract(1, 'year').endOf('year').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getYearBounds(-1, tz),
   },
   {
     value: 'Next year',
     label: 'defaults.dateRangeOptions.nextYear|Next year',
     dateFormat: 'YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.add(1, 'year').startOf('year').toDate();
-      const to = now.add(1, 'year').endOf('year').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getYearBounds(1, tz),
   },
   {
     value: 'Year to date',
     label: 'defaults.dateRangeOptions.yearToDate|Year to date',
     dateFormat: 'MMM YYYY',
-    getRange: (timezone?: string) => {
-      const localDate = getLocalDateString(new Date(), timezone);
-      const now = dayjs.utc(localDate);
-      const from = now.startOf('year').toDate();
-      const to = now.endOf('day').toDate();
-
-      return {
-        from,
-        to,
-        relativeTimeString: '',
-      };
-    },
+    getRange: (tz?: string) => getUnitToDate('year', tz),
   },
 ];

--- a/src/theme/defaults/defaults.DateRanges.constants.ts
+++ b/src/theme/defaults/defaults.DateRanges.constants.ts
@@ -1,15 +1,23 @@
 import { TimeRange } from '@embeddable.com/core';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import isoWeek from 'dayjs/plugin/isoWeek.js';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear.js';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 dayjs.extend(isoWeek);
 dayjs.extend(quarterOfYear);
 
-const getWeekBounds = (date: Date, offset = 0): TimeRange => {
-  const d = dayjs.utc(date).add(offset, 'week');
+const getLocalDateString = (date: Date, timezone?: string): string => {
+  return timezone
+    ? dayjs.tz(date, timezone).format('YYYY-MM-DD')
+    : dayjs.utc(date).format('YYYY-MM-DD');
+};
+
+const getWeekBounds = (date: Date, offset = 0, timezone?: string): TimeRange => {
+  const d = dayjs.utc(getLocalDateString(date, timezone)).add(offset, 'week');
   const from = d.startOf('isoWeek').toDate(); // Monday
   const to = d.endOf('isoWeek').toDate(); // Sunday
 
@@ -20,8 +28,8 @@ const getWeekBounds = (date: Date, offset = 0): TimeRange => {
   };
 };
 
-const getQuarterBounds = (date: Date, offset = 0): TimeRange => {
-  const d = dayjs.utc(date).add(offset, 'quarter');
+const getQuarterBounds = (date: Date, offset = 0, timezone?: string): TimeRange => {
+  const d = dayjs.utc(getLocalDateString(date, timezone)).add(offset, 'quarter');
   const from = d.startOf('quarter').toDate();
   const to = d.endOf('quarter').toDate();
 
@@ -36,7 +44,7 @@ export type DateRangeOption = {
   value: string;
   label: string;
   dateFormat: string;
-  getRange: () => TimeRange;
+  getRange: (timezone?: string) => TimeRange;
 };
 
 export const defaultDateRangeOptions: DateRangeOption[] = [
@@ -44,10 +52,12 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Today',
     label: 'defaults.dateRangeOptions.today|Today',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
-      const from = now.startOf('day').toDate();
-      const to = now.endOf('day').toDate();
+    getRange: (timezone?: string) => {
+      const now = timezone
+        ? dayjs.tz(new Date(), timezone).format('YYYY-MM-DD')
+        : dayjs.utc(new Date()).format('YYYY-MM-DD');
+      const from = dayjs.utc(now).startOf('day').toDate();
+      const to = dayjs.utc(now).endOf('day').toDate();
 
       return {
         from,
@@ -60,10 +70,12 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Yesterday',
     label: 'defaults.dateRangeOptions.yesterday|Yesterday',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
-      const from = now.subtract(1, 'day').startOf('day').toDate();
-      const to = now.subtract(1, 'day').endOf('day').toDate();
+    getRange: (timezone?: string) => {
+      const now = timezone
+        ? dayjs.tz(new Date(), timezone).subtract(1, 'day').format('YYYY-MM-DD')
+        : dayjs.utc(new Date()).subtract(1, 'day').format('YYYY-MM-DD');
+      const from = dayjs.utc(now).startOf('day').toDate();
+      const to = dayjs.utc(now).endOf('day').toDate();
 
       return {
         from,
@@ -76,20 +88,21 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'This week',
     label: 'defaults.dateRangeOptions.thisWeek|This week',
     dateFormat: 'MMM DD',
-    getRange: () => getWeekBounds(new Date(), 0),
+    getRange: (timezone?: string) => getWeekBounds(new Date(), 0, timezone),
   },
   {
     value: 'Last week',
     label: 'defaults.dateRangeOptions.lastWeek|Last week',
     dateFormat: 'MMM DD',
-    getRange: () => getWeekBounds(new Date(), -1),
+    getRange: (timezone?: string) => getWeekBounds(new Date(), -1, timezone),
   },
   {
     value: 'Week to date',
     label: 'defaults.dateRangeOptions.weekToDate|Week to date',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('isoWeek').toDate(); // Monday as start of week
       const to = now.endOf('day').toDate();
 
@@ -104,8 +117,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Last 7 days',
     label: 'defaults.dateRangeOptions.last7Days|Last 7 days',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const to = now.endOf('day').toDate();
       const from = now.subtract(6, 'day').startOf('day').toDate();
 
@@ -120,8 +134,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Next 7 days',
     label: 'defaults.dateRangeOptions.next7Days|Next 7 days',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('day').toDate();
       const to = now.add(6, 'day').endOf('day').toDate();
 
@@ -136,8 +151,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Last 30 days',
     label: 'defaults.dateRangeOptions.last30Days|Last 30 days',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const to = now.endOf('day').toDate();
       const from = now.subtract(29, 'day').startOf('day').toDate();
 
@@ -152,8 +168,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Next 30 days',
     label: 'defaults.dateRangeOptions.next30Days|Next 30 days',
     dateFormat: 'MMM DD',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('day').toDate();
       const to = now.add(29, 'day').endOf('day').toDate();
 
@@ -168,8 +185,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'This month',
     label: 'defaults.dateRangeOptions.thisMonth|This month',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('month').toDate();
       const to = now.endOf('month').toDate();
 
@@ -184,8 +202,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Last month',
     label: 'defaults.dateRangeOptions.lastMonth|Last month',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.subtract(1, 'month').startOf('month').toDate();
       const to = now.subtract(1, 'month').endOf('month').toDate();
 
@@ -200,8 +219,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Next month',
     label: 'defaults.dateRangeOptions.nextMonth|Next month',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.add(1, 'month').startOf('month').toDate();
       const to = now.add(1, 'month').endOf('month').toDate();
 
@@ -216,26 +236,27 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'This quarter',
     label: 'defaults.dateRangeOptions.thisQuarter|This quarter',
     dateFormat: 'MMM YYYY',
-    getRange: () => getQuarterBounds(new Date(), 0),
+    getRange: (timezone?: string) => getQuarterBounds(new Date(), 0, timezone),
   },
   {
     value: 'Last quarter',
     label: 'defaults.dateRangeOptions.lastQuarter|Last quarter',
     dateFormat: 'MMM YYYY',
-    getRange: () => getQuarterBounds(new Date(), -1),
+    getRange: (timezone?: string) => getQuarterBounds(new Date(), -1, timezone),
   },
   {
     value: 'Next quarter',
     label: 'defaults.dateRangeOptions.nextQuarter|Next quarter',
     dateFormat: 'MMM YYYY',
-    getRange: () => getQuarterBounds(new Date(), +1),
+    getRange: (timezone?: string) => getQuarterBounds(new Date(), +1, timezone),
   },
   {
     value: 'Quarter to date',
     label: 'defaults.dateRangeOptions.quarterToDate|Quarter to date',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('quarter').toDate(); // start of current quarter
       const to = now.endOf('day').toDate(); // today at 23:59:59.999
 
@@ -250,8 +271,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Last 6 months',
     label: 'defaults.dateRangeOptions.last6Months|Last 6 months',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const to = now.endOf('day').toDate();
       const from = now.subtract(6, 'month').startOf('day').toDate();
 
@@ -266,8 +288,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Last 12 months',
     label: 'defaults.dateRangeOptions.last12Months|Last 12 months',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const to = now.endOf('day').toDate();
       const from = now.subtract(12, 'month').startOf('day').toDate();
 
@@ -282,8 +305,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'This year',
     label: 'defaults.dateRangeOptions.thisYear|This year',
     dateFormat: 'YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('year').toDate();
       const to = now.endOf('year').toDate();
 
@@ -298,8 +322,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Last year',
     label: 'defaults.dateRangeOptions.lastYear|Last year',
     dateFormat: 'YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.subtract(1, 'year').startOf('year').toDate();
       const to = now.subtract(1, 'year').endOf('year').toDate();
 
@@ -314,8 +339,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Next year',
     label: 'defaults.dateRangeOptions.nextYear|Next year',
     dateFormat: 'YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.add(1, 'year').startOf('year').toDate();
       const to = now.add(1, 'year').endOf('year').toDate();
 
@@ -330,8 +356,9 @@ export const defaultDateRangeOptions: DateRangeOption[] = [
     value: 'Year to date',
     label: 'defaults.dateRangeOptions.yearToDate|Year to date',
     dateFormat: 'MMM YYYY',
-    getRange: () => {
-      const now = dayjs.utc(new Date());
+    getRange: (timezone?: string) => {
+      const localDate = getLocalDateString(new Date(), timezone);
+      const now = dayjs.utc(localDate);
       const from = now.startOf('year').toDate();
       const to = now.endOf('day').toDate();
 

--- a/src/theme/theme.constants.ts
+++ b/src/theme/theme.constants.ts
@@ -3,7 +3,7 @@ import { de } from './i18n/translations/de';
 import { remarkableThemeFormatter } from './formatter/formatter.constants';
 import { remarkableThemeStyles } from './styles/styles.constants';
 import { ThemeFonts } from './fonts/fonts.types';
-import { Theme, ThemeCharts, ThemeDefaults } from './theme.types';
+import { Theme, ThemeCharts, ThemeClientContext, ThemeDefaults } from './theme.types';
 import { defaultComparisonPeriodOptions } from './defaults/defaults.ComparisonPeriods.constants';
 import { defaultDateRangeOptions } from './defaults/defaults.DateRanges.constants';
 import { defaultChartMenuProOptions } from './defaults/defaults.ChartCardMenu.constants';
@@ -32,6 +32,8 @@ const remarkableThemeFonts: ThemeFonts = {
   google: [{ name: 'Inter', weights: '100..900' }],
 };
 
+const remakableThemeClientContext: ThemeClientContext = { timezone: undefined };
+
 export const remarkableTheme: Theme = {
   i18n: remarkableThemeI18n,
   charts: remarkableThemeCharts,
@@ -39,4 +41,5 @@ export const remarkableTheme: Theme = {
   styles: remarkableThemeStyles,
   defaults: remarkableThemeDefaults,
   fonts: remarkableThemeFonts,
+  clientContext: remakableThemeClientContext,
 } as const;

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -53,6 +53,9 @@ export type ThemeDefaults = {
   tableCellStyleOptions?: TableCellStyleOption[];
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type ThemeClientContext = Record<string, any> & { timezone?: string };
+
 export type Theme = {
   i18n: ThemeI18n;
   charts: ThemeCharts;
@@ -60,4 +63,5 @@ export type Theme = {
   formatter: ThemeFormatter;
   defaults: ThemeDefaults;
   fonts?: ThemeFonts;
+  clientContext: ThemeClientContext;
 };

--- a/src/theme/utils/clientContext.utils.ts
+++ b/src/theme/utils/clientContext.utils.ts
@@ -1,0 +1,9 @@
+export const getClientContextTimezone = (tz?: string): string | undefined => {
+  if (!tz) return undefined;
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return tz;
+  } catch {
+    return undefined;
+  }
+};

--- a/src/theme/utils/clientContext.utils.ts
+++ b/src/theme/utils/clientContext.utils.ts
@@ -1,5 +1,10 @@
 export const getClientContextTimezone = (tz?: string): string | undefined => {
   if (!tz) return undefined;
+
+  if (typeof Intl.supportedValuesOf === 'function') {
+    return Intl.supportedValuesOf('timeZone').includes(tz) ? tz : undefined;
+  }
+
   try {
     Intl.DateTimeFormat(undefined, { timeZone: tz });
     return tz;


### PR DESCRIPTION
# Why is this pull-request needed?

Embeddable currently shows all time-based data in UTC, which means relative date ranges like "Today" or "Yesterday" are computed against UTC midnight — incorrect for customers in the US, Asia, or anywhere outside UTC. Additionally, international teams need a single consistent **business timezone** so every team member sees the same numbers, regardless of their browser locale. This PR adds timezone support via `clientContext`, letting customers supply their preferred timezone so that both data queries and date-range controls behave correctly for their business.

# Main changes

### New types & theme integration
- Added `ThemeClientContext` type (`Record<string, any> & { timezone?: string }`) to `theme.types.ts` and a `clientContext` field to the `Theme` type.
- Updated `embeddable.theme.ts` so `themeProvider(clientContext)` validates and merges the timezone into the theme object using the new `getClientContextTimezone` utility.

### New utility: `clientContext.utils.ts`
- `getClientContextTimezone(tz?)` — validates an IANA timezone string via `Intl.DateTimeFormat` and returns it (or `undefined` if invalid/absent), preventing invalid timezones from reaching downstream APIs.
  > **Note:** IANA timezones follow the `Region/City` format (e.g. `America/New_York`, `Asia/Dubai`, `Europe/London`). They are preferred over raw UTC offsets because they account for daylight saving time automatically.

### Date range constants
- Updated all 20+ `getRange()` functions in `defaults.DateRanges.constants.ts` to accept an optional `timezone` parameter.
- Added `getLocalDateString(date, timezone?)` helper that uses `dayjs.tz` to determine the calendar date in the target timezone, then anchors all UTC computations to that date string — avoiding browser-timezone leakage.
- Same fix applied to comparison period helpers in `defaults.ComparisonPeriods.constants.ts`.
- Updated the `DateRangeOption` / `DateRangeSelectFieldProOption` type signatures accordingly (`getRange: (timezone?: string) => TimeRange`).

### Date utils propagation
- `getTimeRangeFromPresets`, `getTimeRangeLabel`, and `getDateRangeFromTimeRange` in `dates.utils.ts` all accept and propagate an optional `timezone` parameter.

### Component definitions (14 components)
- All `props()` functions now receive `clientContext` as the 3rd parameter and extract `timezone` via `getClientContextTimezone` before passing it into every `loadData` call.
- Affected components: `BarChartDefaultPro`, `BarChartDefaultHorizontalPro`, `BarChartGroupedPro`, `BarChartGroupedHorizontalPro`, `BarChartStackedPro`, `BarChartStackedHorizontalPro`, `LineChartDefaultPro`, `LineChartGroupedPro`, `LineChartComparisonDefaultPro`, `KpiChartNumberComparisonPro`, `HeatMapPro`, `PivotTablePro`.
- Shared bar-chart load-data helpers in `bars.loadData.utils.ts` updated to accept and thread `timezone` through.

### UI editors & hooks
- `DateRangePickerPresetsPro`, `DateRangePickerCustomPro`, and `ComparisonPeriodSelectFieldPro` now pass `theme.clientContext.timezone` through to all date-resolution helpers.
- `charts.fillGaps.hooks.ts` and `timeRange.utils.ts` use `theme.clientContext.timezone` when resolving relative date ranges.

# Test evidence


https://github.com/user-attachments/assets/c90d0791-bd3b-494f-86c1-4789c44e0753


