### PR TITLE
TPS-1249: scrollable markdown fix

### DIFF
--- a/.changeset/old-beds-enjoy.md
+++ b/.changeset/old-beds-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Fix ScrollableTable markdown scroll

--- a/src/components/charts/tables/tables.utils.tsx
+++ b/src/components/charts/tables/tables.utils.tsx
@@ -100,7 +100,9 @@ export const getTableHeaders = (
               <TableBodyCellWithCopy value={value}>
                 {displayFormat === DisplayFormatTypeOptions.MARKDOWN ? (
                   // Markdown
-                  <Markdown content={currentValue} />
+                  <div>
+                    <Markdown content={currentValue} />
+                  </div>
                 ) : (
                   // JSON
                   <pre>{currentValue}</pre>


### PR DESCRIPTION
# Why is this pull-request needed?

This PR fixes the ScrollableTable when a cell has markdown content. The scroll should not be available.


# Test evidence

https://github.com/user-attachments/assets/4cb991e2-3e0a-48e8-9c92-041c62b793f0




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed markdown content scrolling behavior in scrollable tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->