### PR TITLE
TPS-1277: Scrollable table fails to display a dimension column when the first data row is missing that key

### DIFF
--- a/.changeset/lovely-glasses-sin.md
+++ b/.changeset/lovely-glasses-sin.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Bug fix: Scrollable table fails to display a dimension column when the first data row is missing that key

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",
@@ -25,8 +25,8 @@
         "xlsx": "npm:@e965/xlsx@^0.20.3"
       },
       "devDependencies": {
-        "@embeddable.com/sdk-core": "4.3.3",
-        "@embeddable.com/sdk-react": "4.3.5",
+        "@embeddable.com/sdk-core": "4.4.0",
+        "@embeddable.com/sdk-react": "4.3.6",
         "@eslint/css": "^0.13.0",
         "@stencil/core": "^4.43.2",
         "@testing-library/react": "^16.3.2",
@@ -936,9 +936,9 @@
       }
     },
     "node_modules/@embeddable.com/sdk-core": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.3.3.tgz",
-      "integrity": "sha512-f1D9DZo4+5iHF+PdTw1zOkohSUoObnNPZsW2jbVasQyYHUfiU3YVG3VoJt2WiKo5ER59sSDHGVazk5m9PH6gYQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.4.0.tgz",
+      "integrity": "sha512-fSKZXuKgQoCp03aaL8MpBBSaPzUPdZ3Hd4gSzenJgyjdRfNPiG2uizSSmR6d4CjIRD4F5+kmmabqZ1R1f0w7bw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -961,7 +961,8 @@
         "vite": "^6.2.2",
         "ws": "^8.18.0",
         "yaml": "^2.6.1",
-        "yazl": "^2.5.1"
+        "yazl": "^2.5.1",
+        "zod": "^3.24.2"
       },
       "bin": {
         "embeddable": "bin/embeddable"
@@ -979,16 +980,16 @@
       }
     },
     "node_modules/@embeddable.com/sdk-react": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.3.5.tgz",
-      "integrity": "sha512-+4TsowVrrF5S0A/kQIffC3HOqL0udDdJqwtDFrlQTPUC9I9VkT/Vy7R7DED90HG2DloqdUSzMredmOw/C7qhvA==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.3.6.tgz",
+      "integrity": "sha512-YPxQGNZ7lM7ILIdVL4xi8+xXS6bNBXBp0sAqhb4V6F3rjtQaELYfE/JJ5wR+pvgdY8/nd9UeIF8XzCXmwzd29g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.23.0",
         "@babel/parser": "^7.26.2",
         "@babel/traverse": "^7.24.7",
-        "@embeddable.com/sdk-core": "4.3.3",
+        "@embeddable.com/sdk-core": "4.4.0",
         "@embeddable.com/sdk-utils": "0.9.0",
         "@happy-dom/global-registrator": "^20.3.7",
         "@vitejs/plugin-react": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "xlsx": "npm:@e965/xlsx@^0.20.3"
   },
   "devDependencies": {
-    "@embeddable.com/sdk-core": "4.3.3",
-    "@embeddable.com/sdk-react": "4.3.5",
+    "@embeddable.com/sdk-core": "4.4.0",
+    "@embeddable.com/sdk-react": "4.3.6",
     "@eslint/css": "^0.13.0",
     "@stencil/core": "^4.43.2",
     "@testing-library/react": "^16.3.2",

--- a/src/components/charts/tables/tables.utils.test.tsx
+++ b/src/components/charts/tables/tables.utils.test.tsx
@@ -235,6 +235,12 @@ describe('getTableRows', () => {
     expect(result).toEqual([{ city: 'Paris', revenue: 100 }]);
   });
 
+  it('returns rows as-is when clickDimension key exists in a later row but not the first', () => {
+    const dim = { name: 'manufacturer' } as Dimension;
+    const rows = [{ count: '0' }, { manufacturer: 'IGT', count: '295' }];
+    expect(getTableRows({ clickDimension: dim, rows })).toBe(rows);
+  });
+
   it('does not mutate original rows when removing clickDimension', () => {
     const dim = { name: 'id' } as Dimension;
     const rows = [{ city: 'Paris', id: 1 }];

--- a/src/components/charts/tables/tables.utils.tsx
+++ b/src/components/charts/tables/tables.utils.tsx
@@ -122,7 +122,7 @@ export const getTableRows = (props: { clickDimension?: Dimension; rows: DataResp
 
   const clickDimensionName = props.clickDimension?.name;
 
-  if (!clickDimensionName || Object.keys(props.rows[0]!).includes(clickDimensionName)) {
+  if (!clickDimensionName || props.rows.some((row) => clickDimensionName in row)) {
     return props.rows;
   }
 


### PR DESCRIPTION
# Why is this pull-request needed?

When the clickDimension key was absent from the first row of the result set (e.g. due to a sort order change that moves a sparse row to the top), getTableRows incorrectly stripped that key from every subsequent row that did have it — blanking the entire column.

# Main changes

Changed the guard in getTableRows from checking only rows[0] to rows.some(row => key in row), so the column is preserved as long as any row carries the value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in scrollable tables where dimension columns would fail to display when the first data row lacked the corresponding key.

* **Chores**
  * Updated SDK dependencies to latest compatible versions.

* **Tests**
  * Added test coverage for dimension column edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->