### PR TITLE
R UI 266 hide sort on table charts

### DIFF
--- a/.changeset/wild-taxis-sit.md
+++ b/.changeset/wild-taxis-sit.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Hide sort button on table charts. Default sort is now provided by specific input fields.

--- a/src/components/charts/tables/TableChartPaginated/definition.ts
+++ b/src/components/charts/tables/TableChartPaginated/definition.ts
@@ -52,7 +52,7 @@ const meta = {
       required: false,
     },
     {
-      ...inputs.dimensionOrMeasure,
+      ...inputs.sortDimensionOrMeasure,
       name: 'sortColumn',
       label: 'Default sort column',
       category: 'Component Settings',

--- a/src/components/charts/tables/TableChartPaginated/definition.ts
+++ b/src/components/charts/tables/TableChartPaginated/definition.ts
@@ -175,7 +175,9 @@ const props = (
     ...state,
   };
 
-  const sortColumn = inputs.dimensionsAndMeasures.find((x) => x.name === mergedState.sort?.id);
+  const sortColumn =
+    inputs.dimensionsAndMeasures.find((x) => x.name === mergedState.sort?.id) ??
+    (inputs.sortColumn?.name === mergedState.sort?.id ? inputs.sortColumn : undefined);
   const orderBy: OrderBy[] =
     sortColumn && mergedState.sort
       ? [{ property: sortColumn, direction: mergedState.sort.direction }]
@@ -187,7 +189,7 @@ const props = (
 
   const dimensionsAndMeasuresToLoad = [
     ...inputs.dimensionsAndMeasures,
-    ...(hasClickDimension ? [] : [inputs.clickDimension]),
+    ...(inputs.clickDimension && !hasClickDimension ? [inputs.clickDimension] : []),
   ];
 
   return {

--- a/src/components/charts/tables/TableChartPaginated/definition.ts
+++ b/src/components/charts/tables/TableChartPaginated/definition.ts
@@ -1,11 +1,18 @@
-import { DataResponse, LoadDataRequest, OrderBy, Value, loadData } from '@embeddable.com/core';
+import {
+  DataResponse,
+  LoadDataRequest,
+  OrderBy,
+  OrderDirection,
+  Value,
+  loadData,
+} from '@embeddable.com/core';
 import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 import TablePaginatedChart, {
   TableChartPaginatedProOnRowClickArg,
   TableChartPaginatedProState,
 } from './index';
-import { mergician } from 'mergician';
 import { inputs } from '../../../component.inputs.constants';
+import { getSortDirectionValue } from '../../../types/SortDirection.type.emb';
 import { subInputs } from '../../../component.subinputs.constants';
 import { previewData } from '../../../preview.data.constants';
 
@@ -14,7 +21,7 @@ const meta = {
   label: 'Table Chart - Paginated',
   category: 'Table Charts',
   inputs: [
-    inputs.dataset,
+    { ...inputs.dataset, config: { hideSort: true } },
     {
       ...inputs.dimensionsAndMeasures,
       label: 'Columns',
@@ -44,6 +51,13 @@ const meta = {
       category: 'Data Mapping for Interactions',
       required: false,
     },
+    {
+      ...inputs.dimensionOrMeasure,
+      name: 'sortColumn',
+      label: 'Default sort column',
+      category: 'Component Settings',
+    },
+    { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
   ],
   events: [
     {
@@ -80,12 +94,19 @@ const previewConfig = {
 
 const preview = definePreview(TablePaginatedChart, previewConfig);
 
-export const defaultTableChartPaginatedState: TableChartPaginatedProState = {
+export const defaultTableChartPaginatedState = (
+  inputs?: Inputs<typeof meta>,
+): TableChartPaginatedProState => ({
   page: 0,
   pageSize: undefined,
-  sort: undefined,
+  sort: inputs?.sortColumn
+    ? {
+        id: inputs.sortColumn.name,
+        direction: getSortDirectionValue(inputs.sortDirection as OrderDirection) ?? 'asc',
+      }
+    : undefined,
   isLoadingDownloadData: false,
-};
+});
 
 const loadDataResultsArgs = (
   inputs: Inputs<typeof meta>,
@@ -141,7 +162,7 @@ const loadDataAllResults = (inputs: Inputs<typeof meta>, orderBy: OrderBy[]): Da
 
 const events = {
   onRowClicked: (rowDimensionValue: TableChartPaginatedProOnRowClickArg) => ({
-    rowDimensionValue: rowDimensionValue !== undefined ? rowDimensionValue : Value.noFilter(),
+    rowDimensionValue: rowDimensionValue === undefined ? Value.noFilter() : rowDimensionValue,
   }),
 };
 
@@ -149,33 +170,41 @@ const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [TableChartPaginatedProState, (state: TableChartPaginatedProState) => void],
 ) => {
-  const orderDimensionAndMeasure = inputs.dimensionsAndMeasures.find(
-    (x) => x.name === state?.sort?.id,
-  );
+  const mergedState: TableChartPaginatedProState = {
+    ...defaultTableChartPaginatedState(inputs),
+    ...state,
+  };
 
+  const sortColumn = inputs.dimensionsAndMeasures.find((x) => x.name === mergedState.sort?.id);
   const orderBy: OrderBy[] =
-    orderDimensionAndMeasure && state?.sort
-      ? [{ property: orderDimensionAndMeasure, direction: state.sort.direction }]
+    sortColumn && mergedState.sort
+      ? [{ property: sortColumn, direction: mergedState.sort.direction }]
       : [];
 
-  const clickDimensionInDimensionsAndMeasures = inputs.dimensionsAndMeasures.some(
-    (dimOrMeas) => dimOrMeas.name === inputs.clickDimension?.name,
+  const hasClickDimension = inputs.dimensionsAndMeasures.some(
+    (col) => col.name === inputs.clickDimension?.name,
   );
 
   const dimensionsAndMeasuresToLoad = [
     ...inputs.dimensionsAndMeasures,
-    ...(clickDimensionInDimensionsAndMeasures ? [] : [inputs.clickDimension]),
+    ...(hasClickDimension ? [] : [inputs.clickDimension]),
   ];
 
   return {
     ...inputs,
-    state: mergician(defaultTableChartPaginatedState, state ?? {}),
+    state: mergedState,
     setState,
-    results: state?.pageSize
-      ? loadDataResults(inputs, state.page, state.pageSize, orderBy, dimensionsAndMeasuresToLoad)
+    results: mergedState.pageSize
+      ? loadDataResults(
+          inputs,
+          mergedState.page,
+          mergedState.pageSize,
+          orderBy,
+          dimensionsAndMeasuresToLoad,
+        )
       : undefined,
     totalResults: loadDataTotalResults(inputs, dimensionsAndMeasuresToLoad),
-    allResults: state?.isLoadingDownloadData ? loadDataAllResults(inputs, orderBy) : undefined,
+    allResults: mergedState.isLoadingDownloadData ? loadDataAllResults(inputs, orderBy) : undefined,
   };
 };
 

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -1,11 +1,18 @@
-import { DataResponse, LoadDataRequest, OrderBy, Value, loadData } from '@embeddable.com/core';
+import {
+  DataResponse,
+  LoadDataRequest,
+  OrderBy,
+  OrderDirection,
+  Value,
+  loadData,
+} from '@embeddable.com/core';
 import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 import TableScrollableChart, {
   TableScrollableProOnRowClickArg,
   TableScrollableProState,
 } from './index';
-import { mergician } from 'mergician';
 import { inputs } from '../../../component.inputs.constants';
+import { getSortDirectionValue } from '../../../types/SortDirection.type.emb';
 import { subInputs } from '../../../component.subinputs.constants';
 import { TABLE_SCROLLABLE_SIZE } from './TableScrollable.utils';
 import { previewData } from '../../../preview.data.constants';
@@ -15,7 +22,7 @@ const meta = {
   label: 'Table Chart - Scrollable',
   category: 'Table Charts',
   inputs: [
-    inputs.dataset,
+    { ...inputs.dataset, config: { hideSort: true } },
     {
       ...inputs.dimensionsAndMeasures,
       label: 'Columns',
@@ -46,6 +53,13 @@ const meta = {
       category: 'Data mapping for interactions',
       required: false,
     },
+    {
+      ...inputs.dimensionOrMeasure,
+      name: 'sortColumn',
+      label: 'Default sort column',
+      category: 'Component Settings',
+    },
+    { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
   ],
   events: [
     {
@@ -71,11 +85,18 @@ const previewConfig = {
 
 const preview = definePreview(TableScrollableChart, previewConfig);
 
-export const defaultTableScrollableState: TableScrollableProState = {
+export const defaultTableScrollableState = (
+  inputs?: Inputs<typeof meta>,
+): TableScrollableProState => ({
   page: 0,
-  sort: undefined,
+  sort: inputs?.sortColumn
+    ? {
+        id: inputs.sortColumn.name,
+        direction: getSortDirectionValue(inputs.sortDirection as OrderDirection) ?? 'asc',
+      }
+    : undefined,
   isLoadingDownloadData: false,
-};
+});
 
 const loadDataResultsArgs = (
   inputs: Inputs<typeof meta>,
@@ -121,7 +142,7 @@ const loadDataAllResults = (
 
 const events = {
   onRowClicked: (rowDimensionValue: TableScrollableProOnRowClickArg) => ({
-    rowDimensionValue: rowDimensionValue !== undefined ? rowDimensionValue : Value.noFilter(),
+    rowDimensionValue: rowDimensionValue === undefined ? Value.noFilter() : rowDimensionValue,
   }),
 };
 
@@ -129,35 +150,30 @@ const props = (
   inputs: Inputs<typeof meta>,
   [state, setState]: [TableScrollableProState, (state: TableScrollableProState) => void],
 ) => {
-  const orderDimensionAndMeasure = inputs.dimensionsAndMeasures.find(
-    (x) => x.name === state?.sort?.id,
-  );
+  const mergedState: TableScrollableProState = { ...defaultTableScrollableState(inputs), ...state };
 
+  const sortColumn = inputs.dimensionsAndMeasures.find((x) => x.name === mergedState.sort?.id);
   const orderBy: OrderBy[] =
-    orderDimensionAndMeasure && state?.sort
-      ? [{ property: orderDimensionAndMeasure, direction: state.sort.direction }]
+    sortColumn && mergedState.sort
+      ? [{ property: sortColumn, direction: mergedState.sort.direction }]
       : [];
 
-  const clickDimensionInDimensionsAndMeasures = inputs.dimensionsAndMeasures.some(
-    (dimOrMeas) => dimOrMeas.name === inputs.clickDimension?.name,
+  const hasClickDimension = inputs.dimensionsAndMeasures.some(
+    (col) => col.name === inputs.clickDimension?.name,
   );
 
   const dimensionsAndMeasuresToLoad = [
     ...inputs.dimensionsAndMeasures,
-    ...(clickDimensionInDimensionsAndMeasures ? [] : [inputs.clickDimension]),
+    ...(hasClickDimension ? [] : [inputs.clickDimension]),
   ];
 
+  console.log('order by', orderBy);
   return {
     ...inputs,
-    state: mergician(defaultTableScrollableState, state ?? {}),
+    state: mergedState,
     setState,
-    results: loadDataResults(
-      inputs,
-      state?.page ? state.page : defaultTableScrollableState.page,
-      orderBy,
-      dimensionsAndMeasuresToLoad,
-    ),
-    allResults: loadDataAllResults(inputs, orderBy, state),
+    results: loadDataResults(inputs, mergedState.page, orderBy, dimensionsAndMeasuresToLoad),
+    // allResults: loadDataAllResults(inputs, orderBy, mergedState),
   };
 };
 

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -54,7 +54,7 @@ const meta = {
       required: false,
     },
     {
-      ...inputs.dimensionOrMeasure,
+      ...inputs.sortDimensionOrMeasure,
       name: 'sortColumn',
       label: 'Default sort column',
       category: 'Component Settings',

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -152,7 +152,9 @@ const props = (
 ) => {
   const mergedState: TableScrollableProState = { ...defaultTableScrollableState(inputs), ...state };
 
-  const sortColumn = inputs.dimensionsAndMeasures.find((x) => x.name === mergedState.sort?.id);
+  const sortColumn =
+    inputs.dimensionsAndMeasures.find((x) => x.name === mergedState.sort?.id) ??
+    (inputs.sortColumn?.name === mergedState.sort?.id ? inputs.sortColumn : undefined);
   const orderBy: OrderBy[] =
     sortColumn && mergedState.sort
       ? [{ property: sortColumn, direction: mergedState.sort.direction }]
@@ -164,10 +166,9 @@ const props = (
 
   const dimensionsAndMeasuresToLoad = [
     ...inputs.dimensionsAndMeasures,
-    ...(hasClickDimension ? [] : [inputs.clickDimension]),
+    ...(inputs.clickDimension && !hasClickDimension ? [inputs.clickDimension] : []),
   ];
 
-  console.log('order by', orderBy);
   return {
     ...inputs,
     state: mergedState,

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -417,18 +417,23 @@ const yAxisMaxItems = {
   category: 'Axes Settings',
 } as const;
 
-const sortDirectionTopXAxis = {
-  name: 'sortDirectionTopXAxis',
+const sortDirection = {
+  name: 'sortDirection',
   type: SortDirectionType,
-  label: 'Sort by x-axis total',
+  label: 'Sort direction',
   category: 'Component Settings',
 } as const;
 
+const sortDirectionTopXAxis = {
+  ...sortDirection,
+  name: 'sortDirectionTopXAxis',
+  label: 'Sort by x-axis total',
+} as const;
+
 const sortDirectionTopYAxis = {
+  ...sortDirection,
   name: 'sortDirectionTopYAxis',
-  type: SortDirectionType,
   label: 'Sort by y-axis total',
-  category: 'Component Settings',
 } as const;
 
 const limitTopXAxis = {
@@ -511,6 +516,7 @@ export const inputs = {
   xAxisRangeMax,
   xAxisMaxItems,
   yAxisMaxItems,
+  sortDirection,
   sortDirectionTopXAxis,
   sortDirectionTopYAxis,
   limitTopXAxis,

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -191,6 +191,17 @@ const dimensionOrMeasure = {
   inputs: dimensionMeasureSubInputs,
 } as const;
 
+const sortDimensionOrMeasure = {
+  name: 'sortDimensionOrMeasure',
+  type: 'dimensionOrMeasure',
+  label: 'Sort dimension or measure',
+  config: {
+    dataset: 'dataset',
+  },
+  category: 'Component Data',
+  inputs: undefined, // No need to show the sub-inputs in the UI for this input
+} as const;
+
 const dimensionsAndMeasures = {
   name: 'dimensionsAndMeasures',
   type: 'dimensionOrMeasure',
@@ -493,6 +504,7 @@ export const inputs = {
   measureOptions,
   dimensionOptions,
   dimensionAndMeasureOptions,
+  sortDimensionOrMeasure,
   comparisonPeriod,
   maxResults,
   placeholder,


### PR DESCRIPTION
# Why is this pull-request needed?

Currently, when a user configures dataset-level sorting via component inputs, dynamic sorting (e.g. clicking a column header in a table) stops working — the two mechanisms cannot coexist. This PR resolves the conflict by hiding the sort button on the dataset configuration for table charts, and instead exposing dedicated input fields for a default sort column and sort direction. This allows the component to own default sort state without blocking runtime interaction.

Related ticket: [RUI-266](https://trevorio.atlassian.net/browse/RUI-266)

# Main changes

**Both `TableChartPaginated` and `TableScrollable`:**
- `dataset` input now passes `config: { hideSort: true }` to hide the sort button in the dataset panel
- Two new `Component Settings` inputs added:
  - `sortColumn` — Default sort column (DimensionOrMeasure)
  - `sortDirection` — Default sort direction (asc/desc)
- `defaultState` changed from a static object to a function that accepts optional `inputs`, computing the initial sort from `sortColumn`/`sortDirection` if provided
- State merging refactored: a `mergedState` is now derived by combining the default state (with inputs applied) and the current runtime state — removing the need for the `mergician` dependency
- Minor cleanup: `clickDimensionInDimensionsAndMeasures` → `hasClickDimension`, simplified `rowDimensionValue` conditional

**Changeset:** patch bump added for `@embeddable.com/remarkable-pro`

# Test evidence

https://github.com/user-attachments/assets/802a19fb-3ca0-4f74-a6c7-c42f3f8ba1fe


[RUI-266]: https://trevorio.atlassian.net/browse/RUI-266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable input fields for setting default sort column and direction in table charts, enabling pre-configured sorting behavior.

* **Changes**
  * Table chart sort button is now hidden; sorting is configured exclusively through dedicated input fields instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->