### PR TITLE
R UI 259 formatting improvements

### DIFF
--- a/.changeset/whole-ducks-tickle.md
+++ b/.changeset/whole-ducks-tickle.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Avoid formatting in tooltips and export

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.2.3",
+      "version": "0.2.4",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",
@@ -28,7 +28,6 @@
         "@embeddable.com/sdk-core": "4.4.0",
         "@embeddable.com/sdk-react": "4.3.6",
         "@eslint/css": "^0.13.0",
-        "@stencil/core": "^4.43.2",
         "@testing-library/react": "^16.3.2",
         "@types/chroma-js": "^3.1.1",
         "@types/react": "^19.1.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "@embeddable.com/sdk-core": "4.4.0",
     "@embeddable.com/sdk-react": "4.3.6",
     "@eslint/css": "^0.13.0",
-    "@stencil/core": "^4.43.2",
     "@testing-library/react": "^16.3.2",
     "@types/chroma-js": "^3.1.1",
     "@types/react": "^19.1.9",

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -4,7 +4,7 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
-import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
+import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
@@ -88,8 +88,15 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
   );
 
   const options = mergician(
-    getBarChartProOptions(
-      { measures: [measure], horizontal: true, onBarClicked, data, dimension: yAxis },
+    getBarStackedChartProOptions(
+      {
+        measures: [measure],
+        groupDimension: groupBy,
+        horizontal: true,
+        onBarClicked,
+        data,
+        dimension: yAxis,
+      },
       theme,
     ),
     theme.charts?.barChartGroupedHorizontalPro?.options ?? {},

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -4,7 +4,7 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
-import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
+import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
@@ -88,8 +88,15 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
   );
 
   const options = mergician(
-    getBarChartProOptions(
-      { measures: [measure], horizontal: false, onBarClicked, data, dimension: xAxis },
+    getBarStackedChartProOptions(
+      {
+        measures: [measure],
+        horizontal: false,
+        onBarClicked,
+        data,
+        dimension: xAxis,
+        groupDimension: groupBy,
+      },
       theme,
     ),
     theme.charts?.barChartGroupedPro?.options ?? {},

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -4,7 +4,7 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
-import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
+import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
@@ -88,8 +88,15 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
   );
 
   const options = mergician(
-    getBarChartProOptions(
-      { measures: [measure], horizontal: true, onBarClicked, data, dimension: yAxis },
+    getBarStackedChartProOptions(
+      {
+        measures: [measure],
+        groupDimension: groupBy,
+        horizontal: true,
+        onBarClicked,
+        data,
+        dimension: yAxis,
+      },
       theme,
     ),
     theme.charts?.barChartStackedHorizontalPro?.options || {},

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -4,7 +4,7 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
-import { getBarChartProOptions, getBarStackedChartProData } from '../bars.utils';
+import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
 import { mergician } from 'mergician';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
@@ -88,8 +88,15 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
   );
 
   const options = mergician(
-    getBarChartProOptions(
-      { measures: [measure], horizontal: false, onBarClicked, data, dimension: xAxis },
+    getBarStackedChartProOptions(
+      {
+        measures: [measure],
+        groupDimension: groupBy,
+        horizontal: false,
+        onBarClicked,
+        data,
+        dimension: xAxis,
+      },
       theme,
     ),
     theme.charts?.barChartStackedPro?.options || {},

--- a/src/components/charts/bars/bars.utils.test.ts
+++ b/src/components/charts/bars/bars.utils.test.ts
@@ -563,7 +563,7 @@ describe('getBarChartProOptions', () => {
       const result = options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
 
       expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
-      expect(result).toBe('fmt:Revenue: fmt:50 (50%)');
+      expect(result).toBe('Revenue: fmt:50 (50%)');
     });
   });
 

--- a/src/components/charts/bars/bars.utils.test.ts
+++ b/src/components/charts/bars/bars.utils.test.ts
@@ -1,5 +1,10 @@
 import type { Dimension, Measure } from '@embeddable.com/core';
-import { getBarStackedChartProData, getBarChartProData, getBarChartProOptions } from './bars.utils';
+import {
+  getBarStackedChartProData,
+  getBarChartProData,
+  getBarChartProOptions,
+  getBarStackedChartProOptions,
+} from './bars.utils';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { getDatalabelPercentage, groupTailAsOther } from '../charts.utils';
 import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
@@ -684,5 +689,141 @@ describe('getBarChartProOptions', () => {
     );
 
     expect(options.plugins!.legend!.position).toBe('top');
+  });
+});
+
+// ----------------------------------------------------------------------------
+
+describe('getBarStackedChartProOptions', () => {
+  let mockFormatter: ReturnType<typeof makeMockFormatter>;
+
+  const measures = [makeMeasure({ name: 'revenue', title: 'Revenue' })];
+  const dimension = makeDimension({ name: 'product' });
+  const groupDimension = makeDimension({ name: 'region' });
+
+  const makeChartData = (labels: string[], datasetValues: number[][]) => ({
+    labels,
+    datasets: datasetValues.map((vals) => ({ data: vals })),
+  });
+
+  beforeEach(() => {
+    mockFormatter = makeMockFormatter();
+    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
+  });
+
+  // -- tooltip.label ----------------------------------------------------------
+
+  describe('tooltip.label', () => {
+    it('uses rawLabel formatted via groupDimension as the prefix', () => {
+      const data = makeChartData(['A'], [[50]]);
+      const options = getBarStackedChartProOptions(
+        { measures, dimension, groupDimension, horizontal: false, data: data as never },
+        makeTheme(),
+      );
+
+      const context = {
+        datasetIndex: 0,
+        raw: 50,
+        dataset: { label: 'Should not appear', rawLabel: 'North', data: [50] },
+      } as never;
+      options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(groupDimension, 'North');
+    });
+
+    it('formats the measure value and returns "groupLabel: measureValue "', () => {
+      mockFormatter.data.mockImplementation((_, value) => `fmt:${value}`);
+
+      const data = makeChartData(['A'], [[50]]);
+      const options = getBarStackedChartProOptions(
+        { measures, dimension, groupDimension, horizontal: false, data: data as never },
+        makeTheme(),
+      );
+
+      const context = {
+        datasetIndex: 0,
+        raw: 50,
+        dataset: { rawLabel: 'North', data: [50] },
+      } as never;
+      const result = options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
+
+      expect(result).toBe('fmt:North: fmt:50 ');
+    });
+
+    it('appends percentage when showValueAsPercentage is true', () => {
+      vi.mocked(getDatalabelPercentage).mockReturnValue('33%');
+      mockFormatter.data.mockImplementation((_, value) => `fmt:${value}`);
+
+      const measureWithPct = makeMeasure({
+        name: 'revenue',
+        inputs: { showValueAsPercentage: true },
+      });
+      const data = makeChartData(['A'], [[50]]);
+      const options = getBarStackedChartProOptions(
+        {
+          measures: [measureWithPct],
+          dimension,
+          groupDimension,
+          horizontal: false,
+          data: data as never,
+        },
+        makeTheme(),
+      );
+
+      const context = {
+        datasetIndex: 0,
+        raw: 50,
+        dataset: { rawLabel: 'North', data: [50] },
+      } as never;
+      const result = options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
+
+      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
+      expect(result).toBe('fmt:North: fmt:50 (33%)');
+    });
+
+    it('wraps measure index using modulo when multiple measures', () => {
+      const measures2 = [makeMeasure({ name: 'revenue' }), makeMeasure({ name: 'cost' })];
+      const data = makeChartData(['A'], [[10], [20], [30]]);
+      const options = getBarStackedChartProOptions(
+        { measures: measures2, dimension, groupDimension, horizontal: false, data: data as never },
+        makeTheme(),
+      );
+
+      // datasetIndex 3, measures.length 2 → index 1
+      const context = {
+        datasetIndex: 3,
+        raw: 30,
+        dataset: { rawLabel: 'East', data: [30] },
+      } as never;
+      options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(measures2[1], 30);
+    });
+  });
+
+  // -- inherited from base ----------------------------------------------------
+
+  it('preserves the tooltip title callback from the base', () => {
+    const data = makeChartData(['Widget'], [[100]]);
+    const options = getBarStackedChartProOptions(
+      { measures, dimension, groupDimension, horizontal: false, data: data as never },
+      makeTheme(),
+    );
+
+    const context = [{ label: 'Widget' }] as never;
+    options.plugins!.tooltip!.callbacks!.title!.call({} as never, context);
+
+    expect(mockFormatter.data).toHaveBeenCalledWith(dimension, 'Widget');
+  });
+
+  it('retains base scales and onClick from getBarChartProOptions', () => {
+    const data = makeChartData(['A'], [[10]]);
+    const options = getBarStackedChartProOptions(
+      { measures, dimension, groupDimension, horizontal: false, data: data as never },
+      makeTheme(),
+    );
+
+    expect(options.scales).toBeDefined();
+    expect(options.onClick).toBeDefined();
   });
 });

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -3,7 +3,11 @@ import { Theme } from '../../../theme/theme.types';
 import { remarkableTheme } from '../../../theme/theme.constants';
 import { ChartData, ChartOptions } from 'chart.js';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
-import { getDatalabelPercentage, groupTailAsOther } from '../charts.utils';
+import {
+  getDatalabelPercentage,
+  getDimensionWithoutTruncation,
+  groupTailAsOther,
+} from '../charts.utils';
 import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { Context } from 'chartjs-plugin-datalabels';
@@ -179,21 +183,21 @@ export const getBarChartProOptions = (
         callbacks: {
           title: (context) => {
             const label = context[0]?.label;
-            return themeFormatter.data(dimension, label);
+            return themeFormatter.data(getDimensionWithoutTruncation(dimension), label);
           },
 
           label: (context) => {
             const measure = measures[context.datasetIndex % measures.length]!;
             const raw = context.raw as number;
 
-            const dimensionLabel = themeFormatter.data(dimension, context.dataset.label) || '';
             const measureValue = themeFormatter.data(measure, raw);
 
             let percentage = '';
             if (measure.inputs?.showValueAsPercentage) {
               percentage = `(${getDatalabelPercentage(raw, context.dataset.data)})`;
             }
-            return `${dimensionLabel}: ${measureValue} ${percentage}`;
+
+            return `${context.dataset.label}: ${measureValue} ${percentage}`;
           },
         },
       },
@@ -246,4 +250,47 @@ export const getBarChartProOptions = (
       });
     },
   };
+};
+
+export const getBarStackedChartProOptions = (
+  options: {
+    onBarClicked?: (args: {
+      axisDimensionValue: string | null;
+      groupingDimensionValue: string | null;
+    }) => void;
+    measures: Measure[];
+    dimension: Dimension;
+    groupDimension: Dimension;
+    horizontal: boolean;
+    data: ChartData<'bar'>;
+  },
+  theme: Theme,
+): Partial<ChartOptions<'bar'>> => {
+  const { measures, groupDimension } = options;
+  const themeFormatter = getThemeFormatter(theme);
+  const base = getBarChartProOptions(options, theme);
+
+  base.plugins!.tooltip = {
+    callbacks: {
+      ...base.plugins!.tooltip!.callbacks,
+      label: (context) => {
+        const measure = measures[context.datasetIndex % measures.length]!;
+        const raw = context.raw as number;
+        const measureValue = themeFormatter.data(measure, raw);
+
+        let percentage = '';
+        if (measure.inputs?.showValueAsPercentage) {
+          percentage = `(${getDatalabelPercentage(raw, context.dataset.data)})`;
+        }
+
+        const label = themeFormatter.data(
+          getDimensionWithoutTruncation(groupDimension),
+          (context.dataset as { rawLabel?: string }).rawLabel,
+        );
+        return `${label}: ${measureValue} ${percentage}`;
+      },
+    },
+  };
+
+  return base;
 };

--- a/src/components/charts/charts.utils.test.ts
+++ b/src/components/charts/charts.utils.test.ts
@@ -1,5 +1,9 @@
 import type { Dimension, Measure } from '@embeddable.com/core';
-import { getDatalabelPercentage, groupTailAsOther } from './charts.utils';
+import {
+  getDatalabelPercentage,
+  getDimensionWithoutTruncation,
+  groupTailAsOther,
+} from './charts.utils';
 import { i18n } from '../../theme/i18n/i18n';
 
 // -- mocks -------------------------------------------------------------------
@@ -45,6 +49,23 @@ describe('getDatalabelPercentage', () => {
   it('handles string numbers in the data array', () => {
     // data is unknown[], so strings are valid — parseFloat handles them
     expect(getDatalabelPercentage(50, ['50', '50'] as unknown[])).toBe('50%');
+  });
+});
+
+describe('getDimensionWithoutTruncation', () => {
+  it('returns a new dimension object with maxCharacters set to null', () => {
+    const dimensionWithMaxChars: Dimension = {
+      name: 'category',
+      __type__: 'dimension',
+      inputs: { maxCharacters: 10 },
+    } as unknown as Dimension;
+
+    const result = getDimensionWithoutTruncation(dimensionWithMaxChars);
+
+    expect(result).not.toBe(dimensionWithMaxChars); // should be a new object
+    expect(result.name).toBe(dimensionWithMaxChars.name); // name should be unchanged
+    expect(result.__type__).toBe(dimensionWithMaxChars.__type__); // type should be unchanged
+    expect(result.inputs?.maxCharacters).toBeNull(); // maxCharacters should be null
   });
 });
 

--- a/src/components/charts/charts.utils.ts
+++ b/src/components/charts/charts.utils.ts
@@ -1,5 +1,11 @@
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+
 import { i18n } from '../../theme/i18n/i18n';
+
+export const getDimensionWithoutTruncation = (dimension: Dimension): Dimension => ({
+  ...dimension,
+  inputs: { ...dimension.inputs, maxCharacters: null },
+});
 
 export const groupTailAsOther = (
   data: DataResponse['data'] = [],

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.utils.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/LineChartComparisonDefaultPro.utils.ts
@@ -13,6 +13,7 @@ import { i18n } from '../../../../theme/i18n/i18n';
 import { mergician } from 'mergician';
 import { isColorValid, setColorAlpha } from '../../../../utils/color.utils';
 import { getLineChartProOptionsOnClick, LineChartProOptionsClick } from '../lines.utils';
+import { getDimensionWithoutTruncation } from '../../charts.utils';
 
 const AXIS_ID_MAIN = 'mainAxis';
 const AXIS_ID_COMPARISON = 'comparisonAxis';
@@ -197,7 +198,10 @@ const getLineChartComparisonNonTimeOptions = (
           title: (context) => {
             if (!context[0]) return '';
 
-            return themeFormatter.data(dimension, context[0].label);
+            return themeFormatter.data(
+              { ...dimension, inputs: { ...dimension.inputs, maxCharacters: null } }, // tooltips titles do not truncate labels
+              context[0].label,
+            );
           },
           label: (context) => {
             const measure = measures[context.datasetIndex % measures.length]!;
@@ -283,7 +287,10 @@ const getLineChartComparisonTimeOptions = (
             const contextItem = context[0];
 
             if (!showDataComparison && contextItem) {
-              return themeFormatter.data(dimension, contextItem.label);
+              return themeFormatter.data(
+                getDimensionWithoutTruncation(dimension),
+                contextItem.label,
+              );
             }
 
             const dataIndex = contextItem?.dataIndex;
@@ -292,10 +299,16 @@ const getLineChartComparisonTimeOptions = (
 
             const main =
               mainDimensionLabels[dataIndex] &&
-              themeFormatter.data(dimension, mainDimensionLabels[dataIndex]);
+              themeFormatter.data(
+                getDimensionWithoutTruncation(dimension),
+                mainDimensionLabels[dataIndex],
+              );
             const comparison =
               comparisonDimensionLabels[dataIndex] &&
-              themeFormatter.data(dimension, comparisonDimensionLabels[dataIndex]);
+              themeFormatter.data(
+                getDimensionWithoutTruncation(dimension),
+                comparisonDimensionLabels[dataIndex],
+              );
 
             return `${main ?? '-'} vs ${comparison ?? '-'}`;
           },

--- a/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.utils.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/LineChartDefaultPro.utils.ts
@@ -7,6 +7,7 @@ import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils'
 import { mergician } from 'mergician';
 import { isColorValid, setColorAlpha } from '../../../../utils/color.utils';
 import { LineChartProOptionsClick } from '../lines.utils';
+import { getDimensionWithoutTruncation } from '../../charts.utils';
 
 export const getLineChartProData = (
   props: {
@@ -66,14 +67,14 @@ export const getLineChartProData = (
         data: values,
         backgroundColor: setColorAlpha(backgroundColor, 0.5),
         pointBackgroundColor: backgroundColor,
-        borderDash: measure.inputs?.['dashedLine']
+        borderDash: measure.inputs?.dashedLine
           ? [
               getStyleNumber('--em-linechart-line-dash', '0.25rem'),
               getStyleNumber('--em-linechart-line-gap', '0.25rem'),
             ]
           : undefined,
         borderColor,
-        fill: Boolean(measure.inputs?.['fillUnderLine']),
+        fill: Boolean(measure.inputs?.fillUnderLine),
       } as ChartData<'line'>['datasets'][number];
     }),
   };
@@ -107,12 +108,12 @@ export const getLineChartProOptions = (
         callbacks: {
           title: (context) => {
             const label = context[0]?.label;
-            return themeFormatter.data(dimension, label);
+            return themeFormatter.data(getDimensionWithoutTruncation(dimension), label);
           },
           label: (context) => {
             const measure = measures[context.datasetIndex]!;
             const raw = context.raw as number;
-            return `${themeFormatter.data(dimension, context.dataset.label) || ''}: ${themeFormatter.data(measure, raw)}`;
+            return `${context.dataset.label}: ${themeFormatter.data(measure, raw)}`;
           },
         },
       },

--- a/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.test.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Dimension, Measure } from '@embeddable.com/core';
+import { getLineChartGroupedProOptions } from './LineChartGroupedPro.utils';
+import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
+import { getDimensionWithoutTruncation } from '../../charts.utils';
+import { getLineChartProOptionsOnClick } from '../lines.utils';
+
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({ getThemeFormatter: vi.fn() }));
+vi.mock('@embeddable.com/remarkable-ui', () => ({ getChartColors: vi.fn() }));
+vi.mock('../../charts.utils', () => ({
+  getDimensionWithoutTruncation: vi.fn((d) => d),
+}));
+vi.mock('../lines.utils', () => ({
+  getLineChartProOptionsOnClick: vi.fn(({ onLineClicked }) =>
+    onLineClicked ? { onClick: vi.fn() } : {},
+  ),
+}));
+
+// -- helpers -----------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeDimension = (overrides: Record<string, any> = {}): Dimension =>
+  ({
+    name: 'date',
+    title: 'Date',
+    nativeType: 'string',
+    inputs: {},
+    ...overrides,
+  }) as unknown as Dimension;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeMeasure = (overrides: Record<string, any> = {}): Measure =>
+  ({
+    name: 'revenue',
+    title: 'Revenue',
+    nativeType: 'number',
+    inputs: {},
+    ...overrides,
+  }) as unknown as Measure;
+
+const makeTheme = (overrides = {}) => ({ charts: {}, ...overrides }) as never;
+
+const makeMockFormatter = () => ({
+  data: vi.fn((_: unknown, value: unknown) => `fmt:${value}`),
+});
+
+const makeChartData = (
+  labels: string[],
+  datasets: { rawLabel?: string; data: number[] }[] = [],
+) => ({ labels, datasets });
+
+// ----------------------------------------------------------------------------
+
+describe('getLineChartGroupedProOptions', () => {
+  let mockFormatter: ReturnType<typeof makeMockFormatter>;
+
+  beforeEach(() => {
+    mockFormatter = makeMockFormatter();
+    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
+    vi.mocked(getDimensionWithoutTruncation).mockImplementation((d) => d);
+  });
+
+  // -- datalabels.labels.value.formatter ---------------------------------------
+
+  describe('plugins.datalabels.labels.value.formatter', () => {
+    it('formats the value using the measure', () => {
+      const measure = makeMeasure({ name: 'revenue' });
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure,
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (options.plugins!.datalabels!.labels as any)!.value!.formatter!(42, {});
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(measure, 42);
+    });
+
+    it('returns the formatted value', () => {
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (options.plugins!.datalabels!.labels as any)!.value!.formatter!(99, {});
+
+      expect(result).toBe('fmt:99');
+    });
+  });
+
+  // -- tooltip.callbacks.title -------------------------------------------------
+
+  describe('plugins.tooltip.callbacks.title', () => {
+    it('passes the label through getDimensionWithoutTruncation(dimension)', () => {
+      const dimension = makeDimension({ name: 'date' });
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension,
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      options.plugins?.tooltip?.callbacks?.title?.call(
+        {} as never,
+        [{ label: 'Jan 2024' }] as never,
+      );
+
+      expect(getDimensionWithoutTruncation).toHaveBeenCalledWith(dimension);
+      expect(mockFormatter.data).toHaveBeenCalledWith(dimension, 'Jan 2024');
+    });
+
+    it('returns the formatted title', () => {
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      const result = options.plugins!.tooltip!.callbacks!.title!.call(
+        {} as never,
+        [{ label: 'March' }] as never,
+      );
+
+      expect(result).toBe('fmt:March');
+    });
+  });
+
+  // -- tooltip.callbacks.label -------------------------------------------------
+
+  describe('plugins.tooltip.callbacks.label', () => {
+    it('formats the rawLabel using groupDimension and the raw value using the measure', () => {
+      const groupDimension = makeDimension({ name: 'region' });
+      const measure = makeMeasure({ name: 'revenue' });
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension,
+          measure,
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      options.plugins!.tooltip!.callbacks!.label!.call(
+        {} as never,
+        {
+          raw: 200,
+          dataset: { rawLabel: 'North' },
+        } as never,
+      );
+
+      expect(getDimensionWithoutTruncation).toHaveBeenCalledWith(groupDimension);
+      expect(mockFormatter.data).toHaveBeenCalledWith(groupDimension, 'North');
+      expect(mockFormatter.data).toHaveBeenCalledWith(measure, 200);
+    });
+
+    it('returns "groupLabel: measureValue" format', () => {
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      const result = options.plugins!.tooltip!.callbacks!.label!.call(
+        {} as never,
+        {
+          raw: 500,
+          dataset: { rawLabel: 'East' },
+        } as never,
+      );
+
+      expect(result).toBe('fmt:East: fmt:500');
+    });
+  });
+
+  // -- scales.x.ticks.callback -------------------------------------------------
+
+  describe('scales.x.ticks.callback', () => {
+    it('formats the label from data.labels at the given numeric index using dimension', () => {
+      const dimension = makeDimension({ name: 'date' });
+      const data = makeChartData(['Jan', 'Feb', 'Mar']);
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension,
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: data as never,
+        },
+        makeTheme(),
+      );
+
+      options.scales!.x!.ticks!.callback!.call({} as never, 1, 1, []);
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(dimension, 'Feb');
+    });
+
+    it('returns undefined when data.labels is absent', () => {
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: {} as never,
+        },
+        makeTheme(),
+      );
+
+      const result = options.scales!.x!.ticks!.callback!.call({} as never, 0, 0, []);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  // -- scales.y.ticks.callback -------------------------------------------------
+
+  describe('scales.y.ticks.callback', () => {
+    it('formats the value using the measure', () => {
+      const measure = makeMeasure({ name: 'revenue' });
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure,
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      options.scales!.y!.ticks!.callback!.call({} as never, 1000, 0, []);
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(measure, 1000);
+    });
+  });
+
+  // -- onClick delegation ------------------------------------------------------
+
+  describe('onClick delegation', () => {
+    it('passes onLineClicked to getLineChartProOptionsOnClick', () => {
+      const onLineClicked = vi.fn();
+      getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+          onLineClicked,
+        },
+        makeTheme(),
+      );
+
+      expect(getLineChartProOptionsOnClick).toHaveBeenCalledWith({ onLineClicked });
+    });
+
+    it('includes an onClick handler in the merged options when onLineClicked is provided', () => {
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+          onLineClicked: vi.fn(),
+        },
+        makeTheme(),
+      );
+
+      expect(options.onClick).toBeDefined();
+    });
+
+    it('does not include onClick when onLineClicked is omitted', () => {
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+        },
+        makeTheme(),
+      );
+
+      expect(options.onClick).toBeUndefined();
+    });
+  });
+
+  // -- theme merge -------------------------------------------------------------
+
+  describe('theme.charts.lineChartGroupedPro.options merge', () => {
+    it('merges theme-level chart options into the result', () => {
+      const theme = {
+        charts: {
+          lineChartGroupedPro: {
+            options: { animation: false },
+          },
+        },
+      } as never;
+
+      const options = getLineChartGroupedProOptions(
+        {
+          dimension: makeDimension(),
+          groupDimension: makeDimension({ name: 'region' }),
+          measure: makeMeasure(),
+          data: makeChartData([]) as never,
+        },
+        theme,
+      );
+
+      expect((options as { animation?: unknown }).animation).toBe(false);
+    });
+  });
+});

--- a/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/LineChartGroupedPro.utils.ts
@@ -7,6 +7,7 @@ import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils'
 import { setColorAlpha } from '../../../../utils/color.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
 import { getLineChartProOptionsOnClick, LineChartProOptionsClick } from '../lines.utils';
+import { getDimensionWithoutTruncation } from '../../charts.utils';
 
 export const getLineChartGroupedProData = (
   props: {
@@ -72,13 +73,14 @@ export const getLineChartGroupedProData = (
 export const getLineChartGroupedProOptions = (
   options: {
     dimension: Dimension;
+    groupDimension: Dimension;
     measure: Measure;
     data: ChartData<'line'>;
     onLineClicked?: LineChartProOptionsClick;
   },
   theme: Theme,
 ): ChartOptions<'line'> => {
-  const { dimension, data, measure, onLineClicked } = options;
+  const { dimension, groupDimension, data, measure, onLineClicked } = options;
   const themeFormatter = getThemeFormatter(theme);
 
   const lineChartOptions: ChartOptions<'line'> = {
@@ -96,11 +98,16 @@ export const getLineChartGroupedProOptions = (
         callbacks: {
           title: (context) => {
             const label = context[0]?.label;
-            return themeFormatter.data(dimension, label);
+            return themeFormatter.data(getDimensionWithoutTruncation(dimension), label);
           },
           label: (context) => {
             const raw = context.raw as number;
-            return `${context.dataset.label}: ${themeFormatter.data(measure, raw)}`;
+
+            const label = themeFormatter.data(
+              getDimensionWithoutTruncation(groupDimension),
+              (context.dataset as { rawLabel?: string }).rawLabel,
+            );
+            return `${label}: ${themeFormatter.data(measure, raw)}`;
           },
         },
       },

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -73,7 +73,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
     theme,
   );
   const options = getLineChartGroupedProOptions(
-    { data, dimension: xAxis, measure, onLineClicked },
+    { data, dimension: xAxis, groupDimension: groupBy, measure, onLineClicked },
     theme,
   );
 

--- a/src/components/charts/lines/lines.utils.ts
+++ b/src/components/charts/lines/lines.utils.ts
@@ -6,7 +6,7 @@ export type LineChartProOptionsClickArg = {
 };
 export type LineChartProOptionsClick = (arg: LineChartProOptionsClickArg) => void;
 
-type LineDataset = ChartDataset<'line'> & {
+export type LineDataset = ChartDataset<'line'> & {
   rawLabel?: string;
 };
 

--- a/src/components/charts/pies/DonutChartPro/index.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.tsx
@@ -39,7 +39,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
   );
 
   const options = mergician(
-    getPieChartProOptions(measure, theme),
+    getPieChartProOptions({ measure, dimension }, theme),
     theme.charts.donutChartPro?.options ?? {},
   );
 

--- a/src/components/charts/pies/DonutLabelChartPro/index.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.tsx
@@ -56,7 +56,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
   );
 
   const options = mergician(
-    getPieChartProOptions(measure, theme),
+    getPieChartProOptions({ measure, dimension }, theme),
     theme.charts.donutLabelChartPro?.options ?? {},
   );
 

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -35,7 +35,7 @@ const PieChartPro = (props: PieChartProProps) => {
   );
 
   const options = mergician(
-    getPieChartProOptions(measure, theme),
+    getPieChartProOptions({ measure, dimension }, theme),
     theme.charts.pieChartPro?.options ?? {},
   );
 

--- a/src/components/charts/pies/pies.utils.test.ts
+++ b/src/components/charts/pies/pies.utils.test.ts
@@ -29,6 +29,7 @@ vi.mock('../../../theme/i18n/i18n', () => ({
 }));
 
 vi.mock('../charts.utils', () => ({
+  getDimensionWithoutTruncation: vi.fn((dimension: unknown) => dimension),
   groupTailAsOther: vi.fn((data: unknown[]) => data),
   getDatalabelPercentage: vi.fn((value: number, data: number[]) => {
     const total = data.reduce((sum, v) => sum + v, 0);

--- a/src/components/charts/pies/pies.utils.test.ts
+++ b/src/components/charts/pies/pies.utils.test.ts
@@ -188,4 +188,109 @@ describe('getPieChartProOptions', () => {
 
     expect(result).toBe('1 (33%)');
   });
+
+  // -- legend.labels.generateLabels -------------------------------------------
+
+  describe('legend.labels.generateLabels', () => {
+    const makeChart = (labels: string[], visibilities: boolean[] = []) => ({
+      data: { labels },
+      getDatasetMeta: vi.fn(() => ({
+        controller: {
+          getStyle: vi.fn((i: number) => ({
+            backgroundColor: `bg-${i}`,
+            borderColor: `border-${i}`,
+            borderWidth: i + 1,
+          })),
+        },
+      })),
+      getDataVisibility: vi.fn((i: number) => visibilities[i] ?? true),
+    });
+
+    it('generates one legend item per label', () => {
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      const chart = makeChart(['Apple', 'Banana', 'Cherry']);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const items = options.plugins!.legend!.labels!.generateLabels!(chart as any);
+      expect(items).toHaveLength(3);
+    });
+
+    it('formats label text via themeFormatter.data(dimension, label)', () => {
+      const dataFn = vi.fn((_dim: unknown, v: unknown) => `fmt:${v}`);
+      vi.mocked(getThemeFormatter).mockReturnValueOnce({ data: dataFn } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      const chart = makeChart(['Apple']);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const items = options.plugins!.legend!.labels!.generateLabels!(chart as any);
+
+      expect(dataFn).toHaveBeenCalledWith(dimension, 'Apple');
+      expect(items[0]!.text).toBe('fmt:Apple');
+    });
+
+    it('maps fillStyle, strokeStyle, and lineWidth from chart style', () => {
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      const chart = makeChart(['X', 'Y']);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const items = options.plugins!.legend!.labels!.generateLabels!(chart as any);
+
+      expect(items[0]!.fillStyle).toBe('bg-0');
+      expect(items[0]!.strokeStyle).toBe('border-0');
+      expect(items[0]!.lineWidth).toBe(1);
+      expect(items[1]!.fillStyle).toBe('bg-1');
+      expect(items[1]!.strokeStyle).toBe('border-1');
+      expect(items[1]!.lineWidth).toBe(2);
+    });
+
+    it('sets hidden to true when data visibility is false', () => {
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      const chart = makeChart(['A', 'B'], [true, false]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const items = options.plugins!.legend!.labels!.generateLabels!(chart as any);
+
+      expect(items[0]!.hidden).toBe(false);
+      expect(items[1]!.hidden).toBe(true);
+    });
+
+    it('sets index to the position of each label', () => {
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      const chart = makeChart(['A', 'B', 'C']);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const items = options.plugins!.legend!.labels!.generateLabels!(chart as any);
+
+      expect(items.map((item) => item.index)).toEqual([0, 1, 2]);
+    });
+
+    it('returns empty array when chart has no labels', () => {
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      const chart = makeChart([]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const items = options.plugins!.legend!.labels!.generateLabels!(chart as any);
+
+      expect(items).toEqual([]);
+    });
+  });
+
+  // -- tooltip.callbacks.title ------------------------------------------------
+
+  describe('tooltip.callbacks.title', () => {
+    it('formats the first context label via getDimensionWithoutTruncation(dimension)', () => {
+      const dataFn = vi.fn((_dim: unknown, v: unknown) => `title:${v}`);
+      vi.mocked(getThemeFormatter).mockReturnValueOnce({ data: dataFn } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const titleFn = options.plugins!.tooltip!.callbacks!.title as (ctx: any) => string;
+      const result = titleFn([{ label: 'Segment A' }]);
+
+      expect(dataFn).toHaveBeenCalledWith(dimension, 'Segment A');
+      expect(result).toBe('title:Segment A');
+    });
+
+    it('handles an empty context array without throwing', () => {
+      const options = getPieChartProOptions({ measure, dimension }, makeTheme());
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const titleFn = options.plugins!.tooltip!.callbacks!.title as (ctx: any) => string;
+      expect(() => titleFn([])).not.toThrow();
+    });
+  });
 });

--- a/src/components/charts/pies/pies.utils.test.ts
+++ b/src/components/charts/pies/pies.utils.test.ts
@@ -134,14 +134,18 @@ describe('getPieChartProData', () => {
 
 describe('getPieChartProOptions', () => {
   const measure = makeMeasure('revenue');
+  const dimension = makeDimension('total');
 
   it('uses legendPosition from theme', () => {
-    const options = getPieChartProOptions(measure, makeTheme({ legendPosition: 'right' }));
+    const options = getPieChartProOptions(
+      { measure, dimension },
+      makeTheme({ legendPosition: 'right' }),
+    );
     expect(options.plugins?.legend?.position).toBe('right');
   });
 
   it('defaults legendPosition to "bottom" when theme does not specify one', () => {
-    const options = getPieChartProOptions(measure, makeTheme({}));
+    const options = getPieChartProOptions({ measure, dimension }, makeTheme({}));
     expect(options.plugins?.legend?.position).toBe('bottom');
   });
 
@@ -149,7 +153,7 @@ describe('getPieChartProOptions', () => {
     const dataFn = vi.fn(() => '42');
     vi.mocked(getThemeFormatter).mockReturnValueOnce({ data: dataFn } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    const options = getPieChartProOptions(measure, makeTheme());
+    const options = getPieChartProOptions({ measure, dimension }, makeTheme());
     const formatter = options.plugins?.datalabels?.formatter as (v: unknown) => string;
     formatter(42);
 
@@ -161,7 +165,7 @@ describe('getPieChartProOptions', () => {
       data: vi.fn((_m: unknown, v: unknown) => `$${v}`),
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    const options = getPieChartProOptions(measure, makeTheme());
+    const options = getPieChartProOptions({ measure, dimension }, makeTheme());
     const labelFn = options.plugins?.tooltip?.callbacks?.label as (ctx: any) => string; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     // raw = 25, total = 100 → 25 %
@@ -175,7 +179,7 @@ describe('getPieChartProOptions', () => {
       data: vi.fn((_m: unknown, v: unknown) => String(v)),
     } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
-    const options = getPieChartProOptions(measure, makeTheme());
+    const options = getPieChartProOptions({ measure, dimension }, makeTheme());
     const labelFn = options.plugins?.tooltip?.callbacks?.label as (ctx: any) => string; // eslint-disable-line @typescript-eslint/no-explicit-any
 
     // 1 / 3 = 33.33… → rounds to 33 %

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -1,12 +1,15 @@
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { ChartData, ChartOptions } from 'chart.js';
-import { getDatalabelPercentage, groupTailAsOther } from '../charts.utils';
+import {
+  getDatalabelPercentage,
+  getDimensionWithoutTruncation,
+  groupTailAsOther,
+} from '../charts.utils';
 import { Theme } from '../../../theme/theme.types';
 import { remarkableTheme } from '../../../theme/theme.constants';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
-import { i18n } from '../../../theme/i18n/i18n';
 
 export const getPieChartProData = (
   props: {
@@ -17,8 +20,6 @@ export const getPieChartProData = (
   },
   theme: Theme = remarkableTheme,
 ): ChartData<'pie'> => {
-  const themeFormatter = getThemeFormatter(theme);
-
   if (!props.data)
     return {
       labels: [],
@@ -57,14 +58,14 @@ export const getPieChartProData = (
 
   return {
     labels: groupedData.map((item) => {
-      const value = item[props.dimension.name];
-      const formattedValue = themeFormatter.data(props.dimension, value);
+      return item[props.dimension.name];
+      // const formattedValue = themeFormatter.data(props.dimension, value);
 
-      // If formatter did not work, try i18n translation
-      if (value === formattedValue) {
-        return i18n.t(value);
-      }
-      return formattedValue;
+      // // If formatter did not work, try i18n translation
+      // if (value === formattedValue) {
+      //   return i18n.t(value);
+      // }
+      // return formattedValue;
     }),
     datasets: [
       {
@@ -77,14 +78,34 @@ export const getPieChartProData = (
 };
 
 export const getPieChartProOptions = (
-  measure: Measure,
+  props: { measure: Measure; dimension: Dimension },
   theme: Theme = remarkableTheme,
 ): Partial<ChartOptions<'pie'>> => {
+  const { dimension, measure } = props;
   const themeFormatter = getThemeFormatter(theme);
 
   return {
     plugins: {
-      legend: { position: theme.charts.legendPosition ?? 'bottom' },
+      legend: {
+        position: theme.charts.legendPosition ?? 'bottom',
+        labels: {
+          generateLabels: (chart) => {
+            const labels = chart.data.labels ?? [];
+            return labels.map((label, i) => {
+              const meta = chart.getDatasetMeta(0);
+              const style = meta.controller.getStyle(i, false);
+              return {
+                text: themeFormatter.data(dimension, label as string),
+                fillStyle: style.backgroundColor as string,
+                strokeStyle: style.borderColor as string,
+                lineWidth: style.borderWidth,
+                hidden: !chart.getDataVisibility(i),
+                index: i,
+              };
+            });
+          },
+        },
+      },
       datalabels: {
         formatter: (value: string | number, context) => {
           if (measure.inputs?.showValueAsPercentage) {
@@ -95,6 +116,10 @@ export const getPieChartProOptions = (
       },
       tooltip: {
         callbacks: {
+          title: (context) => {
+            const label = context[0]?.label;
+            return themeFormatter.data(getDimensionWithoutTruncation(dimension), label);
+          },
           label(context) {
             const raw = context.raw as number;
             return `${themeFormatter.data(measure, raw)} (${getDatalabelPercentage(raw, context.dataset.data)})`;

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -10,6 +10,7 @@ import { remarkableTheme } from '../../../theme/theme.constants';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { getDimensionMeasureColor } from '../../../theme/styles/styles.utils';
 import { getChartColors } from '@embeddable.com/remarkable-ui';
+import { i18n } from '../../../theme/i18n/i18n';
 
 export const getPieChartProData = (
   props: {
@@ -56,16 +57,21 @@ export const getPieChartProData = (
     }),
   );
 
+  const themeFormatter = getThemeFormatter(theme);
+
   return {
     labels: groupedData.map((item) => {
-      return item[props.dimension.name];
-      // const formattedValue = themeFormatter.data(props.dimension, value);
+      const value = item[props.dimension.name];
+      const formattedValue = themeFormatter.data(
+        getDimensionWithoutTruncation(props.dimension),
+        value,
+      );
 
-      // // If formatter did not work, try i18n translation
-      // if (value === formattedValue) {
-      //   return i18n.t(value);
-      // }
-      // return formattedValue;
+      // If formatter did not work, try i18n translation
+      if (value === formattedValue) {
+        return i18n.t(value);
+      }
+      return formattedValue;
     }),
     datasets: [
       {

--- a/src/theme/utils/export.utils.ts
+++ b/src/theme/utils/export.utils.ts
@@ -33,7 +33,7 @@ const formatData = (
   const body = data!.map((dataRow) => {
     const row: Array<string> = [];
     dimensionsAndMeasures.forEach((dimensionOrMeasure) => {
-      const value = themeFormatter.data(dimensionOrMeasure, dataRow[dimensionOrMeasure.name]);
+      const value = dataRow[dimensionOrMeasure.name];
       if (value !== undefined && value !== null) {
         row.push(String(value));
       } else {


### PR DESCRIPTION
## Why is this PR needed?

Formatting (truncation, number abbreviation, date formatting) was applied uniformly across every surface where labels are displayed. This caused two problems:

- **Truncated tooltips** — a label truncated to fit an axis would also appear truncated in the hover tooltip, where space is not an issue.
- **Formatted CSV exports** — values like `90000000` were written as `90M`, making them useless for downstream calculations or analysis.

## Solution

We went with an opinionated, fixed set of rules rather than exposing a granular theme map per surface:

| Surface | Behaviour |
|---|---|
| **Tooltips** | No truncation (`maxCharacters` ignored). All other formatting still applies. |
| **Exports** | Raw values — no formatter applied at all. |
| **Everything else** | Formatting applies as configured. |

## Main changes

- **`charts.utils.ts`** — added `getDimensionWithoutTruncation(dimension)` helper: clones a dimension with `maxCharacters: null`. Used for all tooltip title/label callbacks.
- **`bars.utils.ts`** — added `getBarStackedChartProOptions` which extends the base bar options with a tooltip override that correctly formats the *group* dimension (not the axis dimension). Used by `BarChartGroupedPro`.
- **`pies.utils.ts`** — refactored `getPieChartProOptions` to accept `{ measure, dimension }`. Adds a `generateLabels` override to the legend so labels are formatted correctly, and applies `getDimensionWithoutTruncation` to tooltip titles. Pie/donut data now stores raw dimension values; formatting is deferred to the legend callback.
- **`LineChartGroupedPro`** — passes `groupDimension` into options so tooltip labels format the group dimension value correctly.
- **`LineChartComparisonDefaultPro` / `LineChartDefaultPro`** — tooltip titles now use `getDimensionWithoutTruncation`.
- **`export.utils.ts`** — removed `themeFormatter.data()` call; raw dimension/measure values are now written directly to CSV/Excel.

## Test evidence

[Preview link](https://app.us.embeddable.com/en/workspace/3bdc145b-6518-4e29-91a4-b3d8c9051143/preview/95939cc8-25b2-4be1-8a44-2ac3c60672d2?securityContext=All+artists)

## Linked ticket

[RUI-259](https://trevorio.atlassian.net/browse/RUI-259)


[RUI-259]: https://trevorio.atlassian.net/browse/RUI-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ