### PR TITLE
[RUI-240]: Add BarLineChartPro component

### DIFF
--- a/.changeset/plenty-hornets-thank.md
+++ b/.changeset/plenty-hornets-thank.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Add BarLineChartPro component

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.2.9",
+      "version": "0.2.10",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",
@@ -4009,9 +4009,9 @@
       }
     },
     "node_modules/@tabler/icons": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.43.0.tgz",
-      "integrity": "sha512-qXwS17Op9jqr3Asvu31fejyw8+OnRDKH7oR8nQXyUgW1pI44ET8OKG9kssy+XIvvAIyej6gZdGmviNUn1VMfPw==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.44.0.tgz",
+      "integrity": "sha512-Wn0AOZG9sg0L+bjfMqq4eNhC6pQjIrk94LvvWYNYkY8KH8wC3YILRzQlrnVJc4FUeMxH/AK97QsYCX35H3LndA==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4019,12 +4019,12 @@
       }
     },
     "node_modules/@tabler/icons-react": {
-      "version": "3.43.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.43.0.tgz",
-      "integrity": "sha512-rXUuCQEeRbEk3lJxs3gwzdtaaITSwc/JUbp+AkqsGff5uBpzZw7eKPDk53xKoKLyjrbj82Ai4GuVG0kO89Jf5g==",
+      "version": "3.44.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.44.0.tgz",
+      "integrity": "sha512-8+rvzBbVm/1Z3sG3x7GUNAaxIKxwgz8xaMhRs23nrCnMTKRFAhEC+82zAIFeAA0seXdrAGX5HFCkaLpGK2rVHg==",
       "license": "MIT",
       "dependencies": {
-        "@tabler/icons": "3.43.0"
+        "@tabler/icons": "3.44.0"
       },
       "funding": {
         "type": "github",
@@ -4362,9 +4362,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
-      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "version": "25.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4612,9 +4612,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5288,9 +5288,9 @@
       }
     },
     "node_modules/ast-module-types": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.1.tgz",
-      "integrity": "sha512-WHw67kLXYbZuHTmcdbIrVArCq5wxo6NEuj3hiYAWr8mwJeC+C2mMCIBIWCiDoCye/OF/xelc+teJ1ERoWmnEIA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-6.0.2.tgz",
+      "integrity": "sha512-6KuK/7nZ/2Qh7sGuVEiwxjCxzTY2Pdb5mTo5z1e6/J8BA0tvjR7G8vQJKrQMTqwmnA3UPEyKIFX4YUS1DO1Hvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5433,9 +5433,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.29",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
+      "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -6705,9 +6705,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.352",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-      "integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+      "version": "1.5.353",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.353.tgz",
+      "integrity": "sha512-kOrWphBi8TOZyiJZqsgqIle0lw+tzmnQK83pV9dZUd01Nm2POECSyFQMAuarzZdYqQW7FH9RaYOuaRo3h+bQ3w==",
       "dev": true,
       "license": "ISC"
     },
@@ -6729,9 +6729,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
-      "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
+      "version": "5.21.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.2.tgz",
+      "integrity": "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7603,9 +7603,9 @@
       }
     },
     "node_modules/filing-cabinet": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.4.2.tgz",
-      "integrity": "sha512-Qjh7TLeO/J2wipPA/6rlEiMAqQU6MLw2OdgXhwUdJG2lyHFQ1vdxssXVQUE6mlNuNU8aK5B6T6KMKjrfawq+ZQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/filing-cabinet/-/filing-cabinet-5.5.1.tgz",
+      "integrity": "sha512-PzLBTChlVPn6LnNxF0KWs+XqPziVh3Sfmz/3TXOymHxu6a9yhrDcQn7YwgpcRM6mqhR2WHVGPR8RU4fmcF1IVA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7921,9 +7921,9 @@
       }
     },
     "node_modules/get-east-asian-width": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -12780,9 +12780,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.emb.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.emb.ts
@@ -1,0 +1,7 @@
+import { defineComponent } from '@embeddable.com/react';
+import { barLineChartPro } from './definition';
+
+export const preview = barLineChartPro.preview;
+export const meta = barLineChartPro.meta;
+
+export default defineComponent(barLineChartPro.Component, meta, barLineChartPro.config);

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.test.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.test.ts
@@ -1,0 +1,878 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Dimension, Measure } from '@embeddable.com/core';
+import {
+  getBarLineChartProData,
+  getBarLineChartProOptions,
+  createBarLineClickHandler,
+} from './BarLineChartPro.utils';
+import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
+import { getDimensionWithoutTruncation, groupTailAsOther } from '../../charts.utils';
+import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
+import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
+import { getBarChartProOptions } from '../../bars/bars.utils';
+
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({ getThemeFormatter: vi.fn() }));
+vi.mock('../../charts.utils', () => ({
+  groupTailAsOther: vi.fn(),
+  getDimensionWithoutTruncation: vi.fn((d) => d),
+}));
+vi.mock('../../../../theme/styles/styles.utils', () => ({ getDimensionMeasureColor: vi.fn() }));
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  getChartColors: vi.fn(() => []),
+  getStyleNumber: vi.fn(() => 4),
+}));
+vi.mock('../../../../utils/color.utils', () => ({
+  isColorValid: vi.fn(() => false),
+  setColorAlpha: vi.fn((color: string) => `${color}-alpha`),
+}));
+vi.mock('../../bars/bars.utils', () => ({ getBarChartProOptions: vi.fn(() => ({})) }));
+vi.mock('../../../utils/dimension.utils', () => ({ getTimeRangeFromDimensionValue: vi.fn() }));
+vi.mock('mergician', () => ({
+  mergician: vi.fn((...args: object[]) => Object.assign({}, ...args)),
+}));
+
+// -- helpers -----------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeDimension = (overrides: Record<string, any> = {}): Dimension =>
+  ({
+    name: 'date',
+    title: 'Date',
+    nativeType: 'string',
+    inputs: {},
+    ...overrides,
+  }) as unknown as Dimension;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeMeasure = (overrides: Record<string, any> = {}): Measure =>
+  ({
+    name: 'revenue',
+    title: 'Revenue',
+    nativeType: 'number',
+    inputs: {},
+    ...overrides,
+  }) as unknown as Measure;
+
+const makeTheme = (overrides = {}) => ({ charts: {}, ...overrides }) as never;
+
+const makeMockFormatter = () => ({
+  data: vi.fn((_: unknown, value: unknown) => `fmt:${value}`),
+  dimensionOrMeasureTitle: vi.fn((m: { title: string }) => m.title),
+});
+
+// ----------------------------------------------------------------------------
+
+describe('getBarLineChartProData', () => {
+  let mockFormatter: ReturnType<typeof makeMockFormatter>;
+
+  beforeEach(() => {
+    mockFormatter = makeMockFormatter();
+    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
+    vi.mocked(getDimensionMeasureColor).mockImplementation(({ color, index }) =>
+      color === 'background' ? `#bg-${index}` : `#bd-${index}`,
+    );
+    vi.mocked(groupTailAsOther).mockImplementation((data) => data ?? []);
+  });
+
+  it('returns empty datasets when data is undefined', () => {
+    const result = getBarLineChartProData(
+      {
+        data: undefined as never,
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        lineMeasures: [],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.labels).toEqual([]);
+    expect(result.datasets).toEqual([{ data: [] }]);
+  });
+
+  it('maps dimension values to labels', () => {
+    const dimension = makeDimension({ name: 'date' });
+    const data = [{ date: 'Jan' }, { date: 'Feb' }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      { data, dimension, measures: [makeMeasure()], lineMeasures: [], showSecondaryAxis: false },
+      makeTheme(),
+    );
+
+    expect(result.labels).toEqual(['Jan', 'Feb']);
+  });
+
+  it('creates one bar dataset per measure', () => {
+    const data = [{ date: 'Jan', revenue: 100, cost: 40 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [makeMeasure({ name: 'revenue' }), makeMeasure({ name: 'cost' })],
+        lineMeasures: [],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    const barDatasets = result.datasets.filter((ds) => !('type' in ds));
+    expect(barDatasets).toHaveLength(2);
+  });
+
+  it('creates one line dataset per line measure with type "line"', () => {
+    const data = [{ date: 'Jan', revenue: 100, avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [makeMeasure({ name: 'revenue' })],
+        lineMeasures: [makeMeasure({ name: 'avg' })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    const lineDatasets = result.datasets.filter((ds) => (ds as { type?: string }).type === 'line');
+    expect(lineDatasets).toHaveLength(1);
+  });
+
+  it('bar datasets have order 1, line datasets have order 0', () => {
+    const data = [{ date: 'Jan', revenue: 100, avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [makeMeasure({ name: 'revenue' })],
+        lineMeasures: [makeMeasure({ name: 'avg' })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { order?: number }).order).toBe(1);
+    expect((result.datasets[1] as { order?: number }).order).toBe(0);
+  });
+
+  it('bar measure missing values default to 0', () => {
+    const data = [{ date: 'Jan', revenue: 100 }, { date: 'Feb' }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [makeMeasure({ name: 'revenue' })],
+        lineMeasures: [],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.datasets[0]?.data).toEqual([100, 0]);
+  });
+
+  it('line measure missing values are null when connectGaps is false', () => {
+    const data = [{ date: 'Jan', avg: 45 }, { date: 'Feb' }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { connectGaps: false } })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.datasets[0]?.data).toEqual([45, null]);
+  });
+
+  it('line measure missing values are 0 when connectGaps is true', () => {
+    const data = [{ date: 'Jan', avg: 45 }, { date: 'Feb' }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { connectGaps: true } })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.datasets[0]?.data).toEqual([45, 0]);
+  });
+
+  it('sets borderDash on line dataset when dashedLine is true', () => {
+    const data = [{ date: 'Jan', avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { dashedLine: true } })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { borderDash?: unknown }).borderDash).toBeDefined();
+  });
+
+  it('borderDash is undefined when dashedLine is false', () => {
+    const data = [{ date: 'Jan', avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { dashedLine: false } })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { borderDash?: unknown }).borderDash).toBeUndefined();
+  });
+
+  it('sets fill on line dataset when fillUnderLine is true', () => {
+    const data = [{ date: 'Jan', avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { fillUnderLine: true } })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { fill?: unknown }).fill).toBe(true);
+  });
+
+  it('assigns yAxisID "y1" to line measure when showSecondaryAxis and useSecondaryAxis are both true', () => {
+    const data = [{ date: 'Jan', avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { useSecondaryAxis: true } })],
+        showSecondaryAxis: true,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { yAxisID?: string }).yAxisID).toBe('y1');
+  });
+
+  it('assigns yAxisID "y" when showSecondaryAxis is false even if useSecondaryAxis is true', () => {
+    const data = [{ date: 'Jan', avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { useSecondaryAxis: true } })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { yAxisID?: string }).yAxisID).toBe('y');
+  });
+
+  it('assigns yAxisID "y" when useSecondaryAxis is false', () => {
+    const data = [{ date: 'Jan', avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    const result = getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [],
+        lineMeasures: [makeMeasure({ name: 'avg', inputs: { useSecondaryAxis: false } })],
+        showSecondaryAxis: true,
+      },
+      makeTheme(),
+    );
+
+    expect((result.datasets[0] as { yAxisID?: string }).yAxisID).toBe('y');
+  });
+
+  it('offsets color index for line measures by the number of bar measures', () => {
+    const data = [{ date: 'Jan', revenue: 100, avg: 45 }];
+    vi.mocked(groupTailAsOther).mockReturnValue(data);
+
+    getBarLineChartProData(
+      {
+        data,
+        dimension: makeDimension(),
+        measures: [makeMeasure({ name: 'revenue' })],
+        lineMeasures: [makeMeasure({ name: 'avg' })],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    const calls = vi.mocked(getDimensionMeasureColor).mock.calls;
+    const lineColorCall = calls.find((call) => call[0].value === 'avg');
+    expect(lineColorCall?.[0].index).toBe(1);
+  });
+
+  it('calls groupTailAsOther with all measures (bar + line)', () => {
+    const dimension = makeDimension();
+    const barMeasure = makeMeasure({ name: 'revenue' });
+    const lineMeasure = makeMeasure({ name: 'avg' });
+    const data = [{ date: 'Jan', revenue: 100, avg: 45 }];
+
+    getBarLineChartProData(
+      {
+        data,
+        dimension,
+        measures: [barMeasure],
+        lineMeasures: [lineMeasure],
+        showSecondaryAxis: false,
+      },
+      makeTheme(),
+    );
+
+    expect(vi.mocked(groupTailAsOther)).toHaveBeenCalledWith(
+      data,
+      dimension,
+      [barMeasure, lineMeasure],
+      undefined,
+    );
+  });
+});
+
+// ----------------------------------------------------------------------------
+
+describe('getBarLineChartProOptions', () => {
+  let mockFormatter: ReturnType<typeof makeMockFormatter>;
+
+  beforeEach(() => {
+    mockFormatter = makeMockFormatter();
+    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
+    vi.mocked(getDimensionWithoutTruncation).mockImplementation((d) => d);
+    vi.mocked(getBarChartProOptions).mockReturnValue({});
+  });
+
+  const makeChartData = (labels: string[] = [], datasets: { data: number[] }[] = []) => ({
+    labels,
+    datasets,
+  });
+
+  // -- interaction -------------------------------------------------------------
+
+  describe('interaction', () => {
+    it('sets interaction mode to "index"', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      expect(options.interaction?.mode).toBe('index');
+    });
+
+    it('sets intersect to false', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      expect(options.interaction?.intersect).toBe(false);
+    });
+  });
+
+  // -- datalabels.display ------------------------------------------------------
+
+  describe('datalabels.display', () => {
+    it('returns false for bar series when showValueLabels is false', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+          showValueLabels: false,
+        },
+        makeTheme(),
+      );
+
+      const display = options.plugins?.datalabels?.display as (ctx: {
+        datasetIndex: number;
+        dataset: { data: unknown[] };
+        dataIndex: number;
+      }) => boolean | 'auto';
+      const context = { datasetIndex: 0, dataset: { data: [100] }, dataIndex: 0 };
+      expect(display(context)).toBe(false);
+    });
+
+    it('returns "auto" for bar series when showValueLabels is true and value is non-zero', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+          showValueLabels: true,
+        },
+        makeTheme(),
+      );
+
+      const display = options.plugins?.datalabels?.display as (ctx: {
+        datasetIndex: number;
+        dataset: { data: unknown[] };
+        dataIndex: number;
+      }) => boolean | 'auto';
+      const context = { datasetIndex: 0, dataset: { data: [100] }, dataIndex: 0 };
+      expect(display(context)).toBe('auto');
+    });
+
+    it('returns false for line series when showValueLabelsLine is false', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure({ name: 'revenue' })],
+          lineMeasures: [makeMeasure({ name: 'avg' })],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+          showValueLabelsLine: false,
+        },
+        makeTheme(),
+      );
+
+      const display = options.plugins?.datalabels?.display as (ctx: {
+        datasetIndex: number;
+        dataset: { data: unknown[] };
+        dataIndex: number;
+      }) => boolean | 'auto';
+      // datasetIndex 1 >= measures.length 1 → line series
+      const context = { datasetIndex: 1, dataset: { data: [45] }, dataIndex: 0 };
+      expect(display(context)).toBe(false);
+    });
+
+    it('returns "auto" for line series when showValueLabelsLine is true and value is non-zero', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure({ name: 'revenue' })],
+          lineMeasures: [makeMeasure({ name: 'avg' })],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+          showValueLabelsLine: true,
+        },
+        makeTheme(),
+      );
+
+      const display = options.plugins?.datalabels?.display as (ctx: {
+        datasetIndex: number;
+        dataset: { data: unknown[] };
+        dataIndex: number;
+      }) => boolean | 'auto';
+      const context = { datasetIndex: 1, dataset: { data: [45] }, dataIndex: 0 };
+      expect(display(context)).toBe('auto');
+    });
+
+    it('returns false for zero values regardless of showValueLabels', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+          showValueLabels: true,
+        },
+        makeTheme(),
+      );
+
+      const display = options.plugins?.datalabels?.display as (ctx: {
+        datasetIndex: number;
+        dataset: { data: unknown[] };
+        dataIndex: number;
+      }) => boolean | 'auto';
+      const context = { datasetIndex: 0, dataset: { data: [0] }, dataIndex: 0 };
+      expect(display(context)).toBe(false);
+    });
+  });
+
+  // -- tooltip -----------------------------------------------------------------
+
+  describe('tooltip callbacks', () => {
+    it('title callback formats the dimension label via getDimensionWithoutTruncation', () => {
+      const dimension = makeDimension({ name: 'date' });
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension,
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      options.plugins?.tooltip?.callbacks?.title?.call({} as never, [{ label: 'Jan' }] as never);
+
+      expect(getDimensionWithoutTruncation).toHaveBeenCalledWith(dimension);
+      expect(mockFormatter.data).toHaveBeenCalledWith(dimension, 'Jan');
+    });
+
+    it('label callback uses bar measure for datasetIndex within measures.length', () => {
+      const barMeasure = makeMeasure({ name: 'revenue' });
+      const options = getBarLineChartProOptions(
+        {
+          measures: [barMeasure],
+          lineMeasures: [makeMeasure({ name: 'avg' })],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      options.plugins?.tooltip?.callbacks?.label?.call(
+        {} as never,
+        { datasetIndex: 0, raw: 100, dataset: { label: 'Revenue' } } as never,
+      );
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(barMeasure, 100);
+    });
+
+    it('label callback uses line measure for datasetIndex >= measures.length', () => {
+      const barMeasure = makeMeasure({ name: 'revenue' });
+      const lineMeasure = makeMeasure({ name: 'avg' });
+      const options = getBarLineChartProOptions(
+        {
+          measures: [barMeasure],
+          lineMeasures: [lineMeasure],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      options.plugins?.tooltip?.callbacks?.label?.call(
+        {} as never,
+        { datasetIndex: 1, raw: 45, dataset: { label: 'Average' } } as never,
+      );
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(lineMeasure, 45);
+    });
+
+    it('label callback returns "datasetLabel: formattedValue"', () => {
+      mockFormatter.data.mockReturnValue('fmt:100');
+
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      const result = options.plugins?.tooltip?.callbacks?.label?.call(
+        {} as never,
+        { datasetIndex: 0, raw: 100, dataset: { label: 'Revenue' } } as never,
+      );
+
+      expect(result).toBe('Revenue: fmt:100');
+    });
+  });
+
+  // -- secondary axis ----------------------------------------------------------
+
+  describe('secondary axis (y1)', () => {
+    it('does not add y1 scale when showSecondaryAxis is false', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: false,
+        },
+        makeTheme(),
+      );
+
+      expect(options.scales?.['y1']).toBeUndefined();
+    });
+
+    it('adds y1 scale when showSecondaryAxis is true', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [makeMeasure()],
+          lineMeasures: [makeMeasure({ name: 'avg' })],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: true,
+        },
+        makeTheme(),
+      );
+
+      expect(options.scales?.['y1']).toBeDefined();
+    });
+
+    it('y1 is positioned on the right', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [],
+          lineMeasures: [makeMeasure({ name: 'avg' })],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: true,
+        },
+        makeTheme(),
+      );
+
+      expect(options.scales?.['y1']?.position).toBe('right');
+    });
+
+    it('y1 respects yAxisSecondaryMin and yAxisSecondaryMax', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [],
+          lineMeasures: [makeMeasure({ name: 'avg' })],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: true,
+          yAxisSecondaryMin: 10,
+          yAxisSecondaryMax: 100,
+        },
+        makeTheme(),
+      );
+
+      expect(options.scales?.['y1']?.min).toBe(10);
+      expect(options.scales?.['y1']?.max).toBe(100);
+    });
+
+    it('y1 tick callback formats using first line measure', () => {
+      const lineMeasure = makeMeasure({ name: 'avg' });
+      const options = getBarLineChartProOptions(
+        {
+          measures: [],
+          lineMeasures: [lineMeasure],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: true,
+        },
+        makeTheme(),
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (options.scales?.['y1'] as any)?.ticks?.callback?.call({} as never, 50, 0, []);
+
+      expect(mockFormatter.data).toHaveBeenCalledWith(lineMeasure, 50);
+    });
+
+    it('y1 title is displayed when yAxisSecondaryLabel is provided', () => {
+      const options = getBarLineChartProOptions(
+        {
+          measures: [],
+          lineMeasures: [makeMeasure()],
+          dimension: makeDimension(),
+          data: makeChartData() as never,
+          showSecondaryAxis: true,
+          yAxisSecondaryLabel: 'Avg',
+        },
+        makeTheme(),
+      );
+
+      expect(options.scales?.['y1']?.title?.display).toBe(true);
+      expect(options.scales?.['y1']?.title?.text).toBe('Avg');
+    });
+  });
+
+  // -- theme merge -------------------------------------------------------------
+
+  it('merges theme-level barLineChartPro options', () => {
+    const theme = {
+      charts: { barLineChartPro: { options: { animation: false } } },
+    } as never;
+
+    vi.mocked(getBarChartProOptions).mockReturnValue({});
+
+    const options = getBarLineChartProOptions(
+      {
+        measures: [makeMeasure()],
+        lineMeasures: [],
+        dimension: makeDimension(),
+        data: makeChartData() as never,
+        showSecondaryAxis: false,
+      },
+      theme,
+    );
+
+    expect((options as { animation?: unknown }).animation).toBe(false);
+  });
+});
+
+// ----------------------------------------------------------------------------
+
+describe('createBarLineClickHandler', () => {
+  beforeEach(() => {
+    vi.mocked(getTimeRangeFromDimensionValue).mockReturnValue(undefined);
+  });
+
+  it('calls onBarClicked when datasetIndex is within bar measures range', () => {
+    const onBarClicked = vi.fn();
+    const dimension = makeDimension();
+    const measures = [makeMeasure({ name: 'revenue' })];
+    const data = { labels: ['Jan', 'Feb'], datasets: [] };
+
+    const handler = createBarLineClickHandler({
+      data: data as never,
+      dimension,
+      measures,
+      onBarClicked,
+    });
+
+    handler({ elementAtEvent: [{ index: 0, datasetIndex: 0 }] } as never);
+
+    expect(onBarClicked).toHaveBeenCalledWith({
+      dimensionValue: 'Jan',
+      dimensionTimeRange: undefined,
+    });
+  });
+
+  it('calls onLineClicked when datasetIndex is >= measures.length', () => {
+    const onLineClicked = vi.fn();
+    const dimension = makeDimension();
+    const measures = [makeMeasure({ name: 'revenue' })];
+    const data = { labels: ['Jan', 'Feb'], datasets: [] };
+
+    const handler = createBarLineClickHandler({
+      data: data as never,
+      dimension,
+      measures,
+      onLineClicked,
+    });
+
+    handler({ elementAtEvent: [{ index: 1, datasetIndex: 1 }] } as never);
+
+    expect(onLineClicked).toHaveBeenCalledWith({
+      dimensionValue: 'Feb',
+      dimensionTimeRange: undefined,
+    });
+  });
+
+  it('does not call either handler when elementAtEvent is empty', () => {
+    const onBarClicked = vi.fn();
+    const onLineClicked = vi.fn();
+
+    const handler = createBarLineClickHandler({
+      data: { labels: ['Jan'], datasets: [] } as never,
+      dimension: makeDimension(),
+      measures: [makeMeasure()],
+      onBarClicked,
+      onLineClicked,
+    });
+
+    handler({ elementAtEvent: [] } as never);
+
+    expect(onBarClicked).not.toHaveBeenCalled();
+    expect(onLineClicked).not.toHaveBeenCalled();
+  });
+
+  it('does not call onLineClicked when a bar is clicked', () => {
+    const onLineClicked = vi.fn();
+    const measures = [makeMeasure()];
+
+    const handler = createBarLineClickHandler({
+      data: { labels: ['Jan'], datasets: [] } as never,
+      dimension: makeDimension(),
+      measures,
+      onLineClicked,
+    });
+
+    handler({ elementAtEvent: [{ index: 0, datasetIndex: 0 }] } as never);
+
+    expect(onLineClicked).not.toHaveBeenCalled();
+  });
+
+  it('does not call onBarClicked when a line is clicked', () => {
+    const onBarClicked = vi.fn();
+    const measures = [makeMeasure()];
+
+    const handler = createBarLineClickHandler({
+      data: { labels: ['Jan'], datasets: [] } as never,
+      dimension: makeDimension(),
+      measures,
+      onBarClicked,
+    });
+
+    handler({ elementAtEvent: [{ index: 0, datasetIndex: 1 }] } as never);
+
+    expect(onBarClicked).not.toHaveBeenCalled();
+  });
+
+  it('passes dimensionValue and dimensionTimeRange from getTimeRangeFromDimensionValue', () => {
+    const fakeTimeRange = { from: '2024-01-01', to: '2024-01-31' };
+    vi.mocked(getTimeRangeFromDimensionValue).mockReturnValue(fakeTimeRange as never);
+
+    const onBarClicked = vi.fn();
+    const dimension = makeDimension();
+
+    const handler = createBarLineClickHandler({
+      data: { labels: ['Jan'], datasets: [] } as never,
+      dimension,
+      granularity: 'month' as never,
+      measures: [makeMeasure()],
+      onBarClicked,
+    });
+
+    handler({ elementAtEvent: [{ index: 0, datasetIndex: 0 }] } as never);
+
+    expect(getTimeRangeFromDimensionValue).toHaveBeenCalledWith({
+      value: 'Jan',
+      stateGranularity: 'month',
+      dimension,
+    });
+    expect(onBarClicked).toHaveBeenCalledWith({
+      dimensionValue: 'Jan',
+      dimensionTimeRange: fakeTimeRange,
+    });
+  });
+});

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.test.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.test.ts
@@ -28,7 +28,28 @@ vi.mock('../../../../utils/color.utils', () => ({
 vi.mock('../../bars/bars.utils', () => ({ getBarChartProOptions: vi.fn(() => ({})) }));
 vi.mock('../../../utils/dimension.utils', () => ({ getTimeRangeFromDimensionValue: vi.fn() }));
 vi.mock('mergician', () => ({
-  mergician: vi.fn((...args: object[]) => Object.assign({}, ...args)),
+  mergician: vi.fn((...args: object[]) => {
+    const deepMerge = (
+      target: Record<string, unknown>,
+      ...sources: Record<string, unknown>[]
+    ): Record<string, unknown> => {
+      for (const source of sources) {
+        for (const key of Object.keys(source)) {
+          const val = source[key];
+          if (val && typeof val === 'object' && !Array.isArray(val)) {
+            target[key] = deepMerge(
+              (target[key] as Record<string, unknown>) ?? {},
+              val as Record<string, unknown>,
+            );
+          } else {
+            target[key] = val;
+          }
+        }
+      }
+      return target;
+    };
+    return deepMerge({}, ...(args as Record<string, unknown>[]));
+  }),
 }));
 
 // -- helpers -----------------------------------------------------------------

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.test.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.test.ts
@@ -100,7 +100,7 @@ describe('getBarLineChartProData', () => {
       {
         data: undefined as never,
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        barMeasures: [makeMeasure()],
         lineMeasures: [],
         showSecondaryAxis: false,
       },
@@ -117,7 +117,7 @@ describe('getBarLineChartProData', () => {
     vi.mocked(groupTailAsOther).mockReturnValue(data);
 
     const result = getBarLineChartProData(
-      { data, dimension, measures: [makeMeasure()], lineMeasures: [], showSecondaryAxis: false },
+      { data, dimension, barMeasures: [makeMeasure()], lineMeasures: [], showSecondaryAxis: false },
       makeTheme(),
     );
 
@@ -132,7 +132,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [makeMeasure({ name: 'revenue' }), makeMeasure({ name: 'cost' })],
+        barMeasures: [makeMeasure({ name: 'revenue' }), makeMeasure({ name: 'cost' })],
         lineMeasures: [],
         showSecondaryAxis: false,
       },
@@ -151,7 +151,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [makeMeasure({ name: 'revenue' })],
+        barMeasures: [makeMeasure({ name: 'revenue' })],
         lineMeasures: [makeMeasure({ name: 'avg' })],
         showSecondaryAxis: false,
       },
@@ -170,7 +170,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [makeMeasure({ name: 'revenue' })],
+        barMeasures: [makeMeasure({ name: 'revenue' })],
         lineMeasures: [makeMeasure({ name: 'avg' })],
         showSecondaryAxis: false,
       },
@@ -189,7 +189,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [makeMeasure({ name: 'revenue' })],
+        barMeasures: [makeMeasure({ name: 'revenue' })],
         lineMeasures: [],
         showSecondaryAxis: false,
       },
@@ -207,7 +207,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { connectGaps: false } })],
         showSecondaryAxis: false,
       },
@@ -225,7 +225,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { connectGaps: true } })],
         showSecondaryAxis: false,
       },
@@ -243,7 +243,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { dashedLine: true } })],
         showSecondaryAxis: false,
       },
@@ -261,7 +261,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { dashedLine: false } })],
         showSecondaryAxis: false,
       },
@@ -279,7 +279,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { fillUnderLine: true } })],
         showSecondaryAxis: false,
       },
@@ -297,7 +297,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { useSecondaryAxis: true } })],
         showSecondaryAxis: true,
       },
@@ -315,7 +315,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { useSecondaryAxis: true } })],
         showSecondaryAxis: false,
       },
@@ -333,7 +333,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [],
+        barMeasures: [],
         lineMeasures: [makeMeasure({ name: 'avg', inputs: { useSecondaryAxis: false } })],
         showSecondaryAxis: true,
       },
@@ -351,7 +351,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension: makeDimension(),
-        measures: [makeMeasure({ name: 'revenue' })],
+        barMeasures: [makeMeasure({ name: 'revenue' })],
         lineMeasures: [makeMeasure({ name: 'avg' })],
         showSecondaryAxis: false,
       },
@@ -373,7 +373,7 @@ describe('getBarLineChartProData', () => {
       {
         data,
         dimension,
-        measures: [barMeasure],
+        barMeasures: [barMeasure],
         lineMeasures: [lineMeasure],
         showSecondaryAxis: false,
       },
@@ -412,7 +412,7 @@ describe('getBarLineChartProOptions', () => {
     it('sets interaction mode to "index"', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -427,7 +427,7 @@ describe('getBarLineChartProOptions', () => {
     it('sets intersect to false', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -446,7 +446,7 @@ describe('getBarLineChartProOptions', () => {
     it('returns false for bar series when showValueLabels is false', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -468,7 +468,7 @@ describe('getBarLineChartProOptions', () => {
     it('returns "auto" for bar series when showValueLabels is true and value is non-zero', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -490,7 +490,7 @@ describe('getBarLineChartProOptions', () => {
     it('returns false for line series when showValueLabelsLine is false', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure({ name: 'revenue' })],
+          barMeasures: [makeMeasure({ name: 'revenue' })],
           lineMeasures: [makeMeasure({ name: 'avg' })],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -513,7 +513,7 @@ describe('getBarLineChartProOptions', () => {
     it('returns "auto" for line series when showValueLabelsLine is true and value is non-zero', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure({ name: 'revenue' })],
+          barMeasures: [makeMeasure({ name: 'revenue' })],
           lineMeasures: [makeMeasure({ name: 'avg' })],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -535,7 +535,7 @@ describe('getBarLineChartProOptions', () => {
     it('returns false for zero values regardless of showValueLabels', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -562,7 +562,7 @@ describe('getBarLineChartProOptions', () => {
       const dimension = makeDimension({ name: 'date' });
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension,
           data: makeChartData() as never,
@@ -581,7 +581,7 @@ describe('getBarLineChartProOptions', () => {
       const barMeasure = makeMeasure({ name: 'revenue' });
       const options = getBarLineChartProOptions(
         {
-          measures: [barMeasure],
+          barMeasures: [barMeasure],
           lineMeasures: [makeMeasure({ name: 'avg' })],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -603,7 +603,7 @@ describe('getBarLineChartProOptions', () => {
       const lineMeasure = makeMeasure({ name: 'avg' });
       const options = getBarLineChartProOptions(
         {
-          measures: [barMeasure],
+          barMeasures: [barMeasure],
           lineMeasures: [lineMeasure],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -625,7 +625,7 @@ describe('getBarLineChartProOptions', () => {
 
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -649,7 +649,7 @@ describe('getBarLineChartProOptions', () => {
     it('does not add y1 scale when showSecondaryAxis is false', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -664,7 +664,7 @@ describe('getBarLineChartProOptions', () => {
     it('adds y1 scale when showSecondaryAxis is true', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [makeMeasure()],
+          barMeasures: [makeMeasure()],
           lineMeasures: [makeMeasure({ name: 'avg' })],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -679,7 +679,7 @@ describe('getBarLineChartProOptions', () => {
     it('y1 is positioned on the right', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [],
+          barMeasures: [],
           lineMeasures: [makeMeasure({ name: 'avg' })],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -694,7 +694,7 @@ describe('getBarLineChartProOptions', () => {
     it('y1 respects yAxisSecondaryMin and yAxisSecondaryMax', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [],
+          barMeasures: [],
           lineMeasures: [makeMeasure({ name: 'avg' })],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -713,7 +713,7 @@ describe('getBarLineChartProOptions', () => {
       const lineMeasure = makeMeasure({ name: 'avg' });
       const options = getBarLineChartProOptions(
         {
-          measures: [],
+          barMeasures: [],
           lineMeasures: [lineMeasure],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -731,7 +731,7 @@ describe('getBarLineChartProOptions', () => {
     it('y1 title is displayed when yAxisSecondaryLabel is provided', () => {
       const options = getBarLineChartProOptions(
         {
-          measures: [],
+          barMeasures: [],
           lineMeasures: [makeMeasure()],
           dimension: makeDimension(),
           data: makeChartData() as never,
@@ -757,7 +757,7 @@ describe('getBarLineChartProOptions', () => {
 
     const options = getBarLineChartProOptions(
       {
-        measures: [makeMeasure()],
+        barMeasures: [makeMeasure()],
         lineMeasures: [],
         dimension: makeDimension(),
         data: makeChartData() as never,
@@ -780,13 +780,13 @@ describe('createBarLineClickHandler', () => {
   it('calls onBarClicked when datasetIndex is within bar measures range', () => {
     const onBarClicked = vi.fn();
     const dimension = makeDimension();
-    const measures = [makeMeasure({ name: 'revenue' })];
+    const barMeasures = [makeMeasure({ name: 'revenue' })];
     const data = { labels: ['Jan', 'Feb'], datasets: [] };
 
     const handler = createBarLineClickHandler({
       data: data as never,
       dimension,
-      measures,
+      barMeasures,
       onBarClicked,
     });
 
@@ -801,13 +801,13 @@ describe('createBarLineClickHandler', () => {
   it('calls onLineClicked when datasetIndex is >= measures.length', () => {
     const onLineClicked = vi.fn();
     const dimension = makeDimension();
-    const measures = [makeMeasure({ name: 'revenue' })];
+    const barMeasures = [makeMeasure({ name: 'revenue' })];
     const data = { labels: ['Jan', 'Feb'], datasets: [] };
 
     const handler = createBarLineClickHandler({
       data: data as never,
       dimension,
-      measures,
+      barMeasures,
       onLineClicked,
     });
 
@@ -826,7 +826,7 @@ describe('createBarLineClickHandler', () => {
     const handler = createBarLineClickHandler({
       data: { labels: ['Jan'], datasets: [] } as never,
       dimension: makeDimension(),
-      measures: [makeMeasure()],
+      barMeasures: [makeMeasure()],
       onBarClicked,
       onLineClicked,
     });
@@ -839,12 +839,12 @@ describe('createBarLineClickHandler', () => {
 
   it('does not call onLineClicked when a bar is clicked', () => {
     const onLineClicked = vi.fn();
-    const measures = [makeMeasure()];
+    const barMeasures = [makeMeasure()];
 
     const handler = createBarLineClickHandler({
       data: { labels: ['Jan'], datasets: [] } as never,
       dimension: makeDimension(),
-      measures,
+      barMeasures,
       onLineClicked,
     });
 
@@ -855,12 +855,12 @@ describe('createBarLineClickHandler', () => {
 
   it('does not call onBarClicked when a line is clicked', () => {
     const onBarClicked = vi.fn();
-    const measures = [makeMeasure()];
+    const barMeasures = [makeMeasure()];
 
     const handler = createBarLineClickHandler({
       data: { labels: ['Jan'], datasets: [] } as never,
       dimension: makeDimension(),
-      measures,
+      barMeasures,
       onBarClicked,
     });
 
@@ -880,7 +880,7 @@ describe('createBarLineClickHandler', () => {
       data: { labels: ['Jan'], datasets: [] } as never,
       dimension,
       granularity: 'month' as never,
-      measures: [makeMeasure()],
+      barMeasures: [makeMeasure()],
       onBarClicked,
     });
 

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
@@ -16,7 +16,7 @@ export const getBarLineChartProData = (
   props: {
     data: DataResponse['data'];
     dimension: Dimension;
-    measures: Measure[];
+    barMeasures: Measure[];
     lineMeasures: Measure[];
     maxItems?: number;
     showSecondaryAxis: boolean;
@@ -27,15 +27,15 @@ export const getBarLineChartProData = (
     return { labels: [], datasets: [{ data: [] }] };
   }
 
-  const { data, dimension, measures, lineMeasures, maxItems, showSecondaryAxis } = props;
-  const allMeasures = [...measures, ...lineMeasures];
-  const groupedData = groupTailAsOther(data, dimension, allMeasures, maxItems);
+  const { data, dimension, barMeasures, lineMeasures, maxItems, showSecondaryAxis } = props;
+  const measures = [...barMeasures, ...lineMeasures];
+  const groupedData = groupTailAsOther(data, dimension, measures, maxItems);
   const themeFormatter = getThemeFormatter(theme);
   const chartColors = getChartColors();
 
   const labels = groupedData.map((item) => item[dimension.name]);
 
-  const barDatasets = measures.map((measure, index) => ({
+  const barDatasets = barMeasures.map((measure, index) => ({
     order: 1,
     label: themeFormatter.dimensionOrMeasureTitle(measure),
     data: groupedData.map((item) => item[measure.name] ?? 0),
@@ -58,7 +58,7 @@ export const getBarLineChartProData = (
   }));
 
   const lineDatasets = lineMeasures.map((measure, index) => {
-    const colorIndex = measures.length + index;
+    const colorIndex = barMeasures.length + index;
     const lineColor = measure.inputs?.['lineColor'];
     const zeroFill = Boolean(measure.inputs?.['connectGaps']);
 
@@ -111,7 +111,7 @@ export const getBarLineChartProData = (
 
 export const getBarLineChartProOptions = (
   options: {
-    measures: Measure[];
+    barMeasures: Measure[];
     lineMeasures: Measure[];
     dimension: Dimension;
     data: ChartData<'bar'>;
@@ -125,7 +125,7 @@ export const getBarLineChartProOptions = (
   theme: Theme,
 ): Partial<ChartOptions<'bar'>> => {
   const {
-    measures,
+    barMeasures,
     lineMeasures,
     dimension,
     data,
@@ -137,11 +137,11 @@ export const getBarLineChartProOptions = (
     yAxisSecondaryMax,
   } = options;
 
-  const allMeasures = [...measures, ...lineMeasures];
+  const measures = [...barMeasures, ...lineMeasures];
   const themeFormatter = getThemeFormatter(theme);
 
   const baseOptions = getBarChartProOptions(
-    { measures, horizontal: false, data, dimension },
+    { measures: barMeasures, horizontal: false, data, dimension },
     theme,
   );
 
@@ -149,14 +149,14 @@ export const getBarLineChartProOptions = (
     plugins: {
       datalabels: {
         display: (context) => {
-          const isLineSeries = context.datasetIndex >= measures.length;
+          const isLineSeries = context.datasetIndex >= barMeasures.length;
           const show = isLineSeries ? showValueLabelsLine : showValueLabels;
           return show && context.dataset.data[context.dataIndex] !== 0 ? 'auto' : false;
         },
         labels: {
           value: {
             formatter: (value, context) => {
-              const measure = allMeasures[context.datasetIndex];
+              const measure = measures[context.datasetIndex];
               if (!measure) return value;
               return themeFormatter.data(measure, value);
             },
@@ -175,7 +175,7 @@ export const getBarLineChartProOptions = (
             return themeFormatter.data(getDimensionWithoutTruncation(dimension), label);
           },
           label: (context) => {
-            const measure = allMeasures[context.datasetIndex];
+            const measure = measures[context.datasetIndex];
             if (!measure) return '';
             const raw = context.raw as number;
             return `${context.dataset.label}: ${themeFormatter.data(measure, raw)}`;
@@ -231,14 +231,14 @@ export const createBarLineClickHandler = ({
   data,
   dimension,
   granularity,
-  measures,
+  barMeasures,
   onBarClicked,
   onLineClicked,
 }: {
   data: ChartData;
   dimension: Dimension;
   granularity?: Granularity;
-  measures: Measure[];
+  barMeasures: Measure[];
   onBarClicked?: (args: BarLineChartProClickArg) => void;
   onLineClicked?: (args: BarLineChartProClickArg) => void;
 }): ((args: ChartClickArgs) => void) => {
@@ -254,7 +254,7 @@ export const createBarLineClickHandler = ({
     });
     const clickArg: BarLineChartProClickArg = { dimensionValue, dimensionTimeRange };
 
-    if (element.datasetIndex < measures.length) {
+    if (element.datasetIndex < barMeasures.length) {
       onBarClicked?.(clickArg);
     } else {
       onLineClicked?.(clickArg);

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
@@ -1,0 +1,263 @@
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
+import { ChartData, ChartOptions } from 'chart.js';
+import { mergician } from 'mergician';
+import type { ChartClickArgs } from '@embeddable.com/remarkable-ui';
+import { getChartColors, getStyleNumber } from '@embeddable.com/remarkable-ui';
+import { Theme } from '../../../../theme/theme.types';
+import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
+import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
+import { isColorValid, setColorAlpha } from '../../../../utils/color.utils';
+import { getDimensionWithoutTruncation, groupTailAsOther } from '../../charts.utils';
+import { getBarChartProOptions } from '../../bars/bars.utils';
+import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
+import { BarLineChartProClickArg } from '../combo.types';
+
+export const getBarLineChartProData = (
+  props: {
+    data: DataResponse['data'];
+    dimension: Dimension;
+    measures: Measure[];
+    lineMeasures: Measure[];
+    maxItems?: number;
+    showSecondaryAxis: boolean;
+  },
+  theme: Theme,
+): ChartData<'bar'> => {
+  if (!props.data) {
+    return { labels: [], datasets: [{ data: [] }] };
+  }
+
+  const { data, dimension, measures, lineMeasures, maxItems, showSecondaryAxis } = props;
+  const allMeasures = [...measures, ...lineMeasures];
+  const groupedData = groupTailAsOther(data, dimension, allMeasures, maxItems);
+  const themeFormatter = getThemeFormatter(theme);
+  const chartColors = getChartColors();
+
+  const labels = groupedData.map((item) => item[dimension.name]);
+
+  const barDatasets = measures.map((measure, index) => ({
+    order: 1,
+    label: themeFormatter.dimensionOrMeasureTitle(measure),
+    data: groupedData.map((item) => item[measure.name] ?? 0),
+    backgroundColor: getDimensionMeasureColor({
+      dimensionOrMeasure: measure,
+      theme,
+      color: 'background',
+      value: measure.name,
+      index,
+      chartColors,
+    }),
+    borderColor: getDimensionMeasureColor({
+      dimensionOrMeasure: measure,
+      theme,
+      color: 'border',
+      value: measure.name,
+      index,
+      chartColors,
+    }),
+  }));
+
+  const lineDatasets = lineMeasures.map((measure, index) => {
+    const colorIndex = measures.length + index;
+    const lineColor = measure.inputs?.['lineColor'];
+    const zeroFill = Boolean(measure.inputs?.['connectGaps']);
+
+    const backgroundColor = isColorValid(lineColor)
+      ? lineColor
+      : getDimensionMeasureColor({
+          dimensionOrMeasure: measure,
+          theme,
+          color: 'background',
+          value: measure.name,
+          index: colorIndex,
+          chartColors,
+        });
+
+    const borderColor = isColorValid(lineColor)
+      ? lineColor
+      : getDimensionMeasureColor({
+          dimensionOrMeasure: measure,
+          theme,
+          color: 'border',
+          value: measure.name,
+          index: colorIndex,
+          chartColors,
+        });
+
+    return {
+      type: 'line' as const,
+      order: 0,
+      label: themeFormatter.dimensionOrMeasureTitle(measure),
+      data: groupedData.map((item) => item[measure.name] ?? (zeroFill ? 0 : null)),
+      backgroundColor: setColorAlpha(backgroundColor, 0.5),
+      pointBackgroundColor: backgroundColor,
+      borderColor,
+      borderDash: measure.inputs?.['dashedLine']
+        ? [
+            getStyleNumber('--em-linechart-line-dash', '0.25rem'),
+            getStyleNumber('--em-linechart-line-gap', '0.25rem'),
+          ]
+        : undefined,
+      fill: Boolean(measure.inputs?.['fillUnderLine']),
+      yAxisID: showSecondaryAxis && Boolean(measure.inputs?.['useSecondaryAxis']) ? 'y1' : 'y',
+    };
+  });
+
+  return {
+    labels,
+    datasets: [...barDatasets, ...lineDatasets] as ChartData<'bar'>['datasets'],
+  };
+};
+
+export const getBarLineChartProOptions = (
+  options: {
+    measures: Measure[];
+    lineMeasures: Measure[];
+    dimension: Dimension;
+    data: ChartData<'bar'>;
+    showSecondaryAxis: boolean;
+    showValueLabels?: boolean;
+    showValueLabelsLine?: boolean;
+    yAxisSecondaryLabel?: string;
+    yAxisSecondaryMin?: number;
+    yAxisSecondaryMax?: number;
+  },
+  theme: Theme,
+): Partial<ChartOptions<'bar'>> => {
+  const {
+    measures,
+    lineMeasures,
+    dimension,
+    data,
+    showSecondaryAxis,
+    showValueLabels,
+    showValueLabelsLine,
+    yAxisSecondaryLabel,
+    yAxisSecondaryMin,
+    yAxisSecondaryMax,
+  } = options;
+
+  const allMeasures = [...measures, ...lineMeasures];
+  const themeFormatter = getThemeFormatter(theme);
+
+  const baseOptions = getBarChartProOptions(
+    { measures, horizontal: false, data, dimension },
+    theme,
+  );
+
+  const datalabelsOptions: Partial<ChartOptions<'bar'>> = {
+    plugins: {
+      datalabels: {
+        display: (context) => {
+          const isLineSeries = context.datasetIndex >= measures.length;
+          const show = isLineSeries ? showValueLabelsLine : showValueLabels;
+          return show && context.dataset.data[context.dataIndex] !== 0 ? 'auto' : false;
+        },
+        labels: {
+          value: {
+            formatter: (value, context) => {
+              const measure = allMeasures[context.datasetIndex];
+              if (!measure) return value;
+              return themeFormatter.data(measure, value);
+            },
+          },
+        },
+      },
+    },
+  };
+
+  const tooltipOptions: Partial<ChartOptions<'bar'>> = {
+    plugins: {
+      tooltip: {
+        callbacks: {
+          title: (context) => {
+            const label = context[0]?.label;
+            return themeFormatter.data(getDimensionWithoutTruncation(dimension), label);
+          },
+          label: (context) => {
+            const measure = allMeasures[context.datasetIndex];
+            if (!measure) return '';
+            const raw = context.raw as number;
+            return `${context.dataset.label}: ${themeFormatter.data(measure, raw)}`;
+          },
+        },
+      },
+    },
+  };
+
+  const interactionOptions: Partial<ChartOptions<'bar'>> = {
+    interaction: {
+      mode: 'index',
+      intersect: false,
+    },
+  };
+
+  const secondaryAxisOptions: Partial<ChartOptions<'bar'>> = showSecondaryAxis
+    ? {
+        scales: {
+          y1: {
+            type: 'linear',
+            position: 'right',
+            min: yAxisSecondaryMin,
+            max: yAxisSecondaryMax,
+            title: {
+              display: Boolean(yAxisSecondaryLabel),
+              text: yAxisSecondaryLabel ?? '',
+            },
+            grid: { drawOnChartArea: false },
+            ticks: {
+              callback: (value) => {
+                const firstLineMeasure = lineMeasures[0];
+                if (!firstLineMeasure) return value;
+                return themeFormatter.data(firstLineMeasure, value);
+              },
+            },
+          },
+        },
+      }
+    : {};
+
+  return mergician(
+    baseOptions,
+    datalabelsOptions,
+    tooltipOptions,
+    interactionOptions,
+    secondaryAxisOptions,
+    theme.charts?.barLineChartPro?.options ?? {},
+  );
+};
+
+export const createBarLineClickHandler = ({
+  data,
+  dimension,
+  granularity,
+  measures,
+  onBarClicked,
+  onLineClicked,
+}: {
+  data: ChartData;
+  dimension: Dimension;
+  granularity?: Granularity;
+  measures: Measure[];
+  onBarClicked?: (args: BarLineChartProClickArg) => void;
+  onLineClicked?: (args: BarLineChartProClickArg) => void;
+}): ((args: ChartClickArgs) => void) => {
+  return ({ elementAtEvent }) => {
+    const element = elementAtEvent[0];
+    if (!element) return;
+
+    const dimensionValue = data?.labels?.[element.index] as string | undefined;
+    const dimensionTimeRange = getTimeRangeFromDimensionValue({
+      value: dimensionValue,
+      stateGranularity: granularity,
+      dimension,
+    });
+    const clickArg: BarLineChartProClickArg = { dimensionValue, dimensionTimeRange };
+
+    if (element.datasetIndex < measures.length) {
+      onBarClicked?.(clickArg);
+    } else {
+      onLineClicked?.(clickArg);
+    }
+  };
+};

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
@@ -7,7 +7,11 @@ import { Theme } from '../../../../theme/theme.types';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { getDimensionMeasureColor } from '../../../../theme/styles/styles.utils';
 import { isColorValid, setColorAlpha } from '../../../../utils/color.utils';
-import { getDimensionWithoutTruncation, groupTailAsOther } from '../../charts.utils';
+import {
+  getDatalabelPercentage,
+  getDimensionWithoutTruncation,
+  groupTailAsOther,
+} from '../../charts.utils';
 import { getBarChartProOptions } from '../../bars/bars.utils';
 import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
 import { BarLineChartProClickArg } from '../combo.types';
@@ -158,6 +162,9 @@ export const getBarLineChartProOptions = (
             formatter: (value, context) => {
               const measure = measures[context.datasetIndex];
               if (!measure) return value;
+              if (measure.inputs?.showValueAsPercentage) {
+                return getDatalabelPercentage(Number(value), context.dataset.data);
+              }
               return themeFormatter.data(measure, value);
             },
           },
@@ -178,7 +185,11 @@ export const getBarLineChartProOptions = (
             const measure = measures[context.datasetIndex];
             if (!measure) return '';
             const raw = context.raw as number;
-            return `${context.dataset.label}: ${themeFormatter.data(measure, raw)}`;
+            const formatted = themeFormatter.data(measure, raw);
+            const percentage = measure.inputs?.showValueAsPercentage
+              ? ` (${getDatalabelPercentage(raw, context.dataset.data)})`
+              : '';
+            return `${context.dataset.label}: ${formatted}${percentage}`;
           },
         },
       },

--- a/src/components/charts/combo/BarLineChartPro/definition.ts
+++ b/src/components/charts/combo/BarLineChartPro/definition.ts
@@ -60,12 +60,29 @@ const meta = {
       ...inputs.boolean,
       name: 'showSecondaryAxis',
       label: 'Show secondary axis',
+      description:
+        'Adds a right-hand Y-axis for line series. Use "Use secondary axis" on each line measure to assign it.',
       defaultValue: false,
       category: 'Axes Settings',
     },
-    { ...inputs.yAxisLabel, name: 'yAxisSecondaryLabel', label: 'Secondary Y-axis label' },
-    { ...inputs.yAxisRangeMin, name: 'yAxisSecondaryMin', label: 'Secondary Y-axis min' },
-    { ...inputs.yAxisRangeMax, name: 'yAxisSecondaryMax', label: 'Secondary Y-axis max' },
+    {
+      ...inputs.yAxisLabel,
+      name: 'yAxisSecondaryLabel',
+      label: 'Secondary Y-axis label',
+      description: 'Label for the right-hand Y-axis used by line series.',
+    },
+    {
+      ...inputs.yAxisRangeMin,
+      name: 'yAxisSecondaryMin',
+      label: 'Secondary Y-axis min',
+      description: 'Minimum value for the right-hand Y-axis used by line series.',
+    },
+    {
+      ...inputs.yAxisRangeMax,
+      name: 'yAxisSecondaryMax',
+      label: 'Secondary Y-axis max',
+      description: 'Maximum value for the right-hand Y-axis used by line series.',
+    },
     inputs.maxResults,
   ],
   events: [

--- a/src/components/charts/combo/BarLineChartPro/definition.ts
+++ b/src/components/charts/combo/BarLineChartPro/definition.ts
@@ -38,7 +38,7 @@ const meta = {
         { ...subInputs.boolean, name: 'dashedLine', label: 'Dashed line', defaultValue: false },
         { ...subInputs.boolean, name: 'connectGaps', label: 'Connect gaps', defaultValue: true },
         { ...subInputs.boolean, name: 'fillUnderLine', label: 'Fill under line' },
-        { ...subInputs.boolean, name: 'useSecondaryAxis', label: 'Use secondary axis' },
+        { ...subInputs.boolean, name: 'useSecondaryAxis', label: 'Assign to secondary axis' },
       ],
     },
     { ...inputs.dimensionWithGranularitySelectField, label: 'X-axis' },
@@ -56,15 +56,6 @@ const meta = {
     inputs.yAxisRangeMax,
     inputs.reverseXAxis,
     inputs.xAxisMaxItems,
-    {
-      ...inputs.boolean,
-      name: 'showSecondaryAxis',
-      label: 'Show secondary axis',
-      description:
-        'Adds a right-hand Y-axis for line series. Use "Use secondary axis" on each line measure to assign it.',
-      defaultValue: false,
-      category: 'Axes Settings',
-    },
     {
       ...inputs.yAxisLabel,
       name: 'yAxisSecondaryLabel',

--- a/src/components/charts/combo/BarLineChartPro/definition.ts
+++ b/src/components/charts/combo/BarLineChartPro/definition.ts
@@ -1,0 +1,177 @@
+import {
+  DataResponse,
+  Dimension,
+  Granularity,
+  LoadDataRequest,
+  Value,
+  loadData,
+} from '@embeddable.com/core';
+import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
+import Component from './index';
+import { inputs } from '../../../component.inputs.constants';
+import { subInputs } from '../../../component.subinputs.constants';
+import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
+import { BarLineChartProClickArg } from '../combo.types';
+
+const meta = {
+  name: 'BarLineChartPro',
+  label: 'Bar + Line Chart',
+  category: 'Combo Charts',
+  inputs: [
+    inputs.dataset,
+    {
+      ...inputs.measures,
+      label: 'Bar measures',
+      inputs: [...inputs.measures.inputs, subInputs.color, subInputs.showValueAsPercentage],
+    },
+    {
+      ...inputs.measures,
+      name: 'lineMeasures',
+      label: 'Line measures',
+      required: false,
+      inputs: [
+        ...inputs.measures.inputs,
+        { ...subInputs.color, name: 'lineColor', label: 'Line color' },
+        { ...subInputs.boolean, name: 'dashedLine', label: 'Dashed line', defaultValue: false },
+        { ...subInputs.boolean, name: 'connectGaps', label: 'Connect gaps', defaultValue: true },
+        { ...subInputs.boolean, name: 'fillUnderLine', label: 'Fill under line' },
+        { ...subInputs.boolean, name: 'useSecondaryAxis', label: 'Use secondary axis' },
+      ],
+    },
+    { ...inputs.dimensionWithGranularitySelectField, label: 'X-axis' },
+    inputs.title,
+    inputs.description,
+    inputs.tooltip,
+    inputs.showLegend,
+    inputs.showTooltips,
+    inputs.showValueLabels,
+    { ...inputs.showValueLabels, name: 'showValueLabelsLine', label: 'Show value labels - line' },
+    inputs.showLogarithmicScale,
+    inputs.xAxisLabel,
+    inputs.yAxisLabel,
+    inputs.yAxisRangeMin,
+    inputs.yAxisRangeMax,
+    inputs.reverseXAxis,
+    inputs.xAxisMaxItems,
+    {
+      ...inputs.boolean,
+      name: 'showSecondaryAxis',
+      label: 'Show secondary axis',
+      defaultValue: false,
+      category: 'Axes Settings',
+    },
+    { ...inputs.yAxisLabel, name: 'yAxisSecondaryLabel', label: 'Secondary Y-axis label' },
+    { ...inputs.yAxisRangeMin, name: 'yAxisSecondaryMin', label: 'Secondary Y-axis min' },
+    { ...inputs.yAxisRangeMax, name: 'yAxisSecondaryMax', label: 'Secondary Y-axis max' },
+    inputs.maxResults,
+  ],
+  events: [
+    {
+      name: 'onBarClicked',
+      label: 'A bar is clicked',
+      properties: [
+        { name: 'axisDimensionValue', label: 'Clicked axis dimension value', type: 'string' },
+        {
+          name: 'axisDimensionTimeRange',
+          label: 'Clicked axis dimension time range',
+          type: 'timeRange',
+        },
+      ],
+    },
+    {
+      name: 'onLineClicked',
+      label: 'A line is clicked',
+      properties: [
+        { name: 'axisDimensionValue', label: 'Clicked axis dimension value', type: 'string' },
+        {
+          name: 'axisDimensionTimeRange',
+          label: 'Clicked axis dimension time range',
+          type: 'timeRange',
+        },
+      ],
+    },
+  ],
+} as const satisfies EmbeddedComponentMeta;
+
+export type BarLineChartProState = {
+  granularity?: Granularity;
+};
+
+const previewConfig = {
+  dimension: previewData.dimension,
+  measures: [previewData.measure],
+  lineMeasures: [previewData.measureVariant],
+  results: previewData.results2Measures1Dimension,
+  hideMenu: true,
+};
+
+const preview = definePreview(Component, previewConfig);
+
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  dimension?: Dimension,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
+  limit: inputs.maxResults,
+  from: inputs.dataset,
+  select: [
+    ...(inputs.measures ?? []),
+    ...(inputs.lineMeasures ?? []),
+    dimension ?? inputs.dimension,
+  ],
+  timezone: getClientContextTimezone(clientContext?.timezone),
+});
+
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  dimension: Dimension,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, dimension, clientContext));
+
+const events = {
+  onBarClicked: (value: BarLineChartProClickArg) => ({
+    axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
+    axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
+  }),
+  onLineClicked: (value: BarLineChartProClickArg) => ({
+    axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
+    axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
+  }),
+};
+
+const props = (
+  inputs: Inputs<typeof meta>,
+  [state, setState]: [BarLineChartProState, (state: BarLineChartProState) => void],
+  clientContext: ThemeClientContext,
+) => {
+  const dimensionWithGranularity = getDimensionWithGranularity(
+    inputs.dimension,
+    state?.granularity,
+  );
+
+  return {
+    ...inputs,
+    dimension: dimensionWithGranularity,
+    granularity: state?.granularity,
+    setGranularity: (granularity: Granularity) => setState({ granularity }),
+    results: loadDataResults(inputs, dimensionWithGranularity, clientContext),
+  };
+};
+
+export const barLineChartPro = {
+  Component,
+  meta,
+  preview,
+  previewConfig,
+  config: {
+    props,
+    events,
+  },
+  results: {
+    loadDataArgs: loadDataResultsArgs,
+    loadData: loadDataResults,
+  },
+} as const;

--- a/src/components/charts/combo/BarLineChartPro/index.test.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.test.tsx
@@ -1,0 +1,252 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarLineChartPro, { BarLineChartProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+import {
+  createBarLineClickHandler,
+  getBarLineChartProData,
+  getBarLineChartProOptions,
+} from './BarLineChartPro.utils';
+
+vi.mock('chart.js', () => ({
+  Chart: { register: vi.fn() },
+  LineController: {},
+  LineElement: {},
+  PointElement: {},
+}));
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-card">{children}</div>
+  ),
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: (props: Record<string, unknown>) => (
+    <div data-testid="bar-chart" data-show-value-labels={String(props.showValueLabels)} />
+  ),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: ({ hasMarginTop }: { hasMarginTop?: boolean }) => (
+    <div data-testid="granularity-select-field" data-has-margin-top={String(hasMarginTop)} />
+  ),
+}));
+
+vi.mock('./BarLineChartPro.utils', () => ({
+  getBarLineChartProData: vi.fn(() => ({ datasets: [], labels: [] })),
+  getBarLineChartProOptions: vi.fn(() => ({})),
+  createBarLineClickHandler: vi.fn(() => vi.fn()),
+}));
+
+const makeMeasure = (name: string): Measure => ({ name }) as unknown as Measure;
+const makeDimension = (): Dimension => ({ name: 'date', inputs: {} }) as unknown as Dimension;
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+
+const defaultProps: BarLineChartProProps = {
+  measures: [makeMeasure('revenue')],
+  dimension: makeDimension(),
+  results: emptyResults,
+};
+
+describe('BarLineChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  describe('rendering', () => {
+    it('renders ChartCard and BarChart', () => {
+      render(<BarLineChartPro {...defaultProps} />);
+      expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+  });
+
+  describe('useFillGaps', () => {
+    it('is called with results and dimension', () => {
+      render(<BarLineChartPro {...defaultProps} />);
+      expect(useFillGaps).toHaveBeenCalledWith({
+        results: defaultProps.results,
+        dimension: defaultProps.dimension,
+      });
+    });
+  });
+
+  describe('getBarLineChartProData', () => {
+    it('is called with barMeasures, lineMeasures, dimension, and showSecondaryAxis', () => {
+      const lineMeasures = [makeMeasure('orders')];
+      render(<BarLineChartPro {...defaultProps} lineMeasures={lineMeasures} showSecondaryAxis />);
+      expect(vi.mocked(getBarLineChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          barMeasures: defaultProps.measures,
+          lineMeasures,
+          dimension: defaultProps.dimension,
+          showSecondaryAxis: true,
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('defaults lineMeasures to [] when not provided', () => {
+      render(<BarLineChartPro {...defaultProps} />);
+      expect(vi.mocked(getBarLineChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({ lineMeasures: [] }),
+        expect.anything(),
+      );
+    });
+
+    it('defaults showSecondaryAxis to false', () => {
+      render(<BarLineChartPro {...defaultProps} />);
+      expect(vi.mocked(getBarLineChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({ showSecondaryAxis: false }),
+        expect.anything(),
+      );
+    });
+
+    it('passes xAxisMaxItems as maxItems', () => {
+      render(<BarLineChartPro {...defaultProps} xAxisMaxItems={20} />);
+      expect(vi.mocked(getBarLineChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({ maxItems: 20 }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('getBarLineChartProOptions', () => {
+    it('is called with secondary axis props', () => {
+      render(
+        <BarLineChartPro
+          {...defaultProps}
+          showSecondaryAxis
+          yAxisSecondaryLabel="Units"
+          yAxisSecondaryMin={0}
+          yAxisSecondaryMax={100}
+        />,
+      );
+      expect(vi.mocked(getBarLineChartProOptions)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          showSecondaryAxis: true,
+          yAxisSecondaryLabel: 'Units',
+          yAxisSecondaryMin: 0,
+          yAxisSecondaryMax: 100,
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('is called with showValueLabels and showValueLabelsLine', () => {
+      render(<BarLineChartPro {...defaultProps} showValueLabels showValueLabelsLine />);
+      expect(vi.mocked(getBarLineChartProOptions)).toHaveBeenCalledWith(
+        expect.objectContaining({ showValueLabels: true, showValueLabelsLine: true }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('createBarLineClickHandler', () => {
+    it('is called with barMeasures, onBarClicked, onLineClicked, dimension, and granularity', () => {
+      const onBarClicked = vi.fn();
+      const onLineClicked = vi.fn();
+      render(
+        <BarLineChartPro
+          {...defaultProps}
+          onBarClicked={onBarClicked}
+          onLineClicked={onLineClicked}
+        />,
+      );
+      expect(vi.mocked(createBarLineClickHandler)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          barMeasures: defaultProps.measures,
+          onBarClicked,
+          onLineClicked,
+          dimension: defaultProps.dimension,
+        }),
+      );
+    });
+  });
+
+  describe('BarChart showValueLabels prop', () => {
+    it('passes true when showValueLabels is true', () => {
+      render(<BarLineChartPro {...defaultProps} showValueLabels />);
+      expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-show-value-labels', 'true');
+    });
+
+    it('passes true when showValueLabelsLine is true', () => {
+      render(<BarLineChartPro {...defaultProps} showValueLabelsLine />);
+      expect(screen.getByTestId('bar-chart')).toHaveAttribute('data-show-value-labels', 'true');
+    });
+
+    it('passes undefined when neither showValueLabels nor showValueLabelsLine is set', () => {
+      render(<BarLineChartPro {...defaultProps} />);
+      expect(screen.getByTestId('bar-chart')).toHaveAttribute(
+        'data-show-value-labels',
+        'undefined',
+      );
+    });
+  });
+
+  describe('granularity selector', () => {
+    it('renders ChartGranularitySelectField when setGranularity is provided', () => {
+      render(<BarLineChartPro {...defaultProps} setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toBeInTheDocument();
+    });
+
+    it('does not render ChartGranularitySelectField when setGranularity is not provided', () => {
+      render(<BarLineChartPro {...defaultProps} />);
+      expect(screen.queryByTestId('granularity-select-field')).not.toBeInTheDocument();
+    });
+
+    it('passes hasMarginTop=true when title, description and tooltip are all absent', () => {
+      render(<BarLineChartPro {...defaultProps} setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'true',
+      );
+    });
+
+    it('passes hasMarginTop=false when title is present', () => {
+      render(<BarLineChartPro {...defaultProps} title="My Chart" setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'false',
+      );
+    });
+
+    it('passes hasMarginTop=false when description is present', () => {
+      render(
+        <BarLineChartPro {...defaultProps} description="Some desc" setGranularity={vi.fn()} />,
+      );
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'false',
+      );
+    });
+
+    it('passes hasMarginTop=false when tooltip is present', () => {
+      render(<BarLineChartPro {...defaultProps} tooltip="Tip" setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'false',
+      );
+    });
+  });
+});

--- a/src/components/charts/combo/BarLineChartPro/index.test.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.test.tsx
@@ -56,7 +56,8 @@ vi.mock('./BarLineChartPro.utils', () => ({
   createBarLineClickHandler: vi.fn(() => vi.fn()),
 }));
 
-const makeMeasure = (name: string): Measure => ({ name }) as unknown as Measure;
+const makeMeasure = (name: string, inputs: Record<string, unknown> = {}): Measure =>
+  ({ name, inputs }) as unknown as Measure;
 const makeDimension = (): Dimension => ({ name: 'date', inputs: {} }) as unknown as Dimension;
 
 const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
@@ -92,9 +93,9 @@ describe('BarLineChartPro', () => {
   });
 
   describe('getBarLineChartProData', () => {
-    it('is called with barMeasures, lineMeasures, dimension, and showSecondaryAxis', () => {
-      const lineMeasures = [makeMeasure('orders')];
-      render(<BarLineChartPro {...defaultProps} lineMeasures={lineMeasures} showSecondaryAxis />);
+    it('is called with barMeasures, lineMeasures, dimension, and showSecondaryAxis derived from measure inputs', () => {
+      const lineMeasures = [makeMeasure('orders', { useSecondaryAxis: true })];
+      render(<BarLineChartPro {...defaultProps} lineMeasures={lineMeasures} />);
       expect(vi.mocked(getBarLineChartProData)).toHaveBeenCalledWith(
         expect.objectContaining({
           barMeasures: defaultProps.measures,
@@ -133,10 +134,11 @@ describe('BarLineChartPro', () => {
 
   describe('getBarLineChartProOptions', () => {
     it('is called with secondary axis props', () => {
+      const lineMeasures = [makeMeasure('orders', { useSecondaryAxis: true })];
       render(
         <BarLineChartPro
           {...defaultProps}
-          showSecondaryAxis
+          lineMeasures={lineMeasures}
           yAxisSecondaryLabel="Units"
           yAxisSecondaryMin={0}
           yAxisSecondaryMax={100}

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -31,7 +31,6 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     showLogarithmicScale,
     showValueLabels,
     showValueLabelsLine,
-    showSecondaryAxis = false,
     yAxisSecondaryLabel,
     yAxisSecondaryMin,
     yAxisSecondaryMax,
@@ -45,6 +44,8 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
   } = props;
 
   const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
+  const showSecondaryAxis = lineMeasures.some((m) => Boolean(m.inputs?.['useSecondaryAxis']));
 
   const results = useFillGaps({ results: props.results, dimension });
 

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -52,7 +52,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     {
       data: results.data,
       dimension,
-      measures,
+      barMeasures: measures,
       lineMeasures,
       maxItems: xAxisMaxItems,
       showSecondaryAxis,
@@ -62,7 +62,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
 
   const options = getBarLineChartProOptions(
     {
-      measures,
+      barMeasures: measures,
       lineMeasures,
       dimension,
       data,
@@ -80,7 +80,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     data,
     dimension,
     granularity,
-    measures,
+    barMeasures: measures,
     onBarClicked,
     onLineClicked,
   });

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -1,7 +1,6 @@
 import { Chart as ChartJS, LineController, LineElement, PointElement } from 'chart.js';
 import { useTheme } from '@embeddable.com/react';
 import { BarChart } from '@embeddable.com/remarkable-ui';
-import { mergician } from 'mergician';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard } from '../../shared/ChartCard/ChartCard';
@@ -61,22 +60,20 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     theme,
   );
 
-  const options = mergician(
-    getBarLineChartProOptions(
-      {
-        measures,
-        lineMeasures,
-        dimension,
-        data,
-        showSecondaryAxis,
-        showValueLabels,
-        showValueLabelsLine,
-        yAxisSecondaryLabel,
-        yAxisSecondaryMin,
-        yAxisSecondaryMax,
-      },
-      theme,
-    ),
+  const options = getBarLineChartProOptions(
+    {
+      measures,
+      lineMeasures,
+      dimension,
+      data,
+      showSecondaryAxis,
+      showValueLabels,
+      showValueLabelsLine,
+      yAxisSecondaryLabel,
+      yAxisSecondaryMin,
+      yAxisSecondaryMax,
+    },
+    theme,
   );
 
   const handleClick = createBarLineClickHandler({

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -1,0 +1,129 @@
+import { Chart as ChartJS, LineController, LineElement, PointElement } from 'chart.js';
+import { useTheme } from '@embeddable.com/react';
+import { BarChart } from '@embeddable.com/remarkable-ui';
+import { mergician } from 'mergician';
+import { Theme } from '../../../../theme/theme.types';
+import { i18nSetup } from '../../../../theme/i18n/i18n';
+import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { resolveI18nProps } from '../../../component.utils';
+import { BarLineChartProProps } from '../combo.types';
+import {
+  createBarLineClickHandler,
+  getBarLineChartProData,
+  getBarLineChartProOptions,
+} from './BarLineChartPro.utils';
+
+ChartJS.register(LineController, LineElement, PointElement);
+
+const BarLineChartPro = (props: BarLineChartProProps) => {
+  const theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const {
+    measures,
+    lineMeasures = [],
+    xAxisMaxItems,
+    yAxisRangeMin,
+    yAxisRangeMax,
+    showLegend,
+    showTooltips,
+    showLogarithmicScale,
+    showValueLabels,
+    showValueLabelsLine,
+    showSecondaryAxis = false,
+    yAxisSecondaryLabel,
+    yAxisSecondaryMin,
+    yAxisSecondaryMax,
+    reverseXAxis,
+    hideMenu,
+    dimension,
+    granularity,
+    setGranularity,
+    onBarClicked,
+    onLineClicked,
+  } = props;
+
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+
+  const results = useFillGaps({ results: props.results, dimension });
+
+  const data = getBarLineChartProData(
+    {
+      data: results.data,
+      dimension,
+      measures,
+      lineMeasures,
+      maxItems: xAxisMaxItems,
+      showSecondaryAxis,
+    },
+    theme,
+  );
+
+  const options = mergician(
+    getBarLineChartProOptions(
+      {
+        measures,
+        lineMeasures,
+        dimension,
+        data,
+        showSecondaryAxis,
+        showValueLabels,
+        showValueLabelsLine,
+        yAxisSecondaryLabel,
+        yAxisSecondaryMin,
+        yAxisSecondaryMax,
+      },
+      theme,
+    ),
+  );
+
+  const handleClick = createBarLineClickHandler({
+    data,
+    dimension,
+    granularity,
+    measures,
+    onBarClicked,
+    onLineClicked,
+  });
+
+  const granularitySelectorHasMarginTop = !title && !description && !tooltip;
+
+  return (
+    <ChartCard
+      data={results}
+      dimensionsAndMeasures={[dimension, ...measures, ...lineMeasures]}
+      errorMessage={results.error}
+      description={description}
+      title={title}
+      tooltip={tooltip}
+      hideMenu={hideMenu}
+    >
+      {setGranularity && (
+        <ChartGranularitySelectField
+          hasMarginTop={granularitySelectorHasMarginTop}
+          dimension={dimension}
+          onChange={setGranularity}
+        />
+      )}
+      <BarChart
+        data={data}
+        showLegend={showLegend}
+        showTooltips={showTooltips}
+        showValueLabels={showValueLabels || showValueLabelsLine}
+        showLogarithmicScale={showLogarithmicScale}
+        xAxisLabel={xAxisLabel}
+        yAxisLabel={yAxisLabel}
+        reverseXAxis={reverseXAxis}
+        yAxisRangeMin={yAxisRangeMin}
+        yAxisRangeMax={yAxisRangeMax}
+        options={options}
+        onClick={handleClick}
+      />
+    </ChartCard>
+  );
+};
+
+export default BarLineChartPro;
+export type { BarLineChartProProps };

--- a/src/components/charts/combo/combo.types.ts
+++ b/src/components/charts/combo/combo.types.ts
@@ -1,0 +1,33 @@
+import { DataResponse, Dimension, Granularity, Measure, TimeRange } from '@embeddable.com/core';
+import { ChartCardHeaderProps } from '../shared/ChartCard/ChartCard';
+
+export type BarLineChartProClickArg = {
+  dimensionValue: string | undefined;
+  dimensionTimeRange: TimeRange | undefined;
+};
+
+export type BarLineChartProProps = {
+  dimension: Dimension;
+  measures: Measure[];
+  lineMeasures?: Measure[];
+  results: DataResponse;
+  showLegend?: boolean;
+  showLogarithmicScale?: boolean;
+  showTooltips?: boolean;
+  showValueLabels?: boolean;
+  showValueLabelsLine?: boolean;
+  xAxisLabel?: string;
+  yAxisLabel?: string;
+  yAxisRangeMin?: number;
+  yAxisRangeMax?: number;
+  reverseXAxis?: boolean;
+  xAxisMaxItems?: number;
+  showSecondaryAxis?: boolean;
+  yAxisSecondaryLabel?: string;
+  yAxisSecondaryMin?: number;
+  yAxisSecondaryMax?: number;
+  granularity?: Granularity;
+  setGranularity?: (granularity: Granularity) => void;
+  onBarClicked?: (args: BarLineChartProClickArg) => void;
+  onLineClicked?: (args: BarLineChartProClickArg) => void;
+} & ChartCardHeaderProps;

--- a/src/components/charts/combo/combo.types.ts
+++ b/src/components/charts/combo/combo.types.ts
@@ -22,7 +22,6 @@ export type BarLineChartProProps = {
   yAxisRangeMax?: number;
   reverseXAxis?: boolean;
   xAxisMaxItems?: number;
-  showSecondaryAxis?: boolean;
   yAxisSecondaryLabel?: string;
   yAxisSecondaryMin?: number;
   yAxisSecondaryMax?: number;

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -180,7 +180,7 @@ const props = (
     state: mergedState,
     setState,
     results: loadDataResults(inputs, mergedState.page, orderBy, dimensionsAndMeasuresToLoad),
-    // allResults: loadDataAllResults(inputs, orderBy, mergedState),
+    allResults: loadDataAllResults(inputs, orderBy, mergedState),
   };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,12 @@ export * as LineChartComparisonWithKpiTabsPro from './components/charts/lines/Li
 export * from './components/charts/lines/LineChartComparisonWithKpiTabsPro';
 export * from './components/charts/lines/LineChartComparisonWithKpiTabsPro/definition';
 
+// Charts - Combo
+export * as BarLineChartPro from './components/charts/combo/BarLineChartPro';
+export * from './components/charts/combo/combo.types';
+export * from './components/charts/combo/BarLineChartPro/BarLineChartPro.utils';
+export * from './components/charts/combo/BarLineChartPro/definition';
+
 // Charts - Scatter
 export * as ScatterChartPro from './components/charts/scatter/ScatterChartPro';
 export type { ScatterChartProProps } from './components/charts/scatter/ScatterChartPro';

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -44,6 +44,7 @@ export type ThemeCharts = {
   lineChartDefaultPro?: { options: Partial<ChartOptions<'line'>> };
   lineChartGroupedPro?: { options: Partial<ChartOptions<'line'>> };
   lineChartComparisonDefaultPro?: { options: Partial<ChartOptions<'line'>> };
+  barLineChartPro?: { options: Partial<ChartOptions<'bar'>> };
   scatterChartPro?: { options: Partial<ChartOptions<'scatter'>> };
   bubbleChartPro?: { options: Partial<ChartOptions<'bubble'>> };
 };


### PR DESCRIPTION
# Why is this pull-request needed?
We need chart type that supports multiple bar measures and multiple line measures plotted against a single shared dimension, with optional secondary Y-axis for line series.

# Main changes

Added BarLineChartPro component

# Test evidence

https://github.com/user-attachments/assets/700be596-e7b9-4a48-b8ab-0c0091ebd559




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bar + Line Chart component for visualizing multiple measures as bars and lines simultaneously on the same chart.
  * Support for secondary y-axis with customizable labels and ranges.
  * Customizable line styling including dashed lines and fill-under-line options.
  * Click event handlers for bar and line interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->