### PR TITLE
Guard click handlers against empty elementAtEvent

### DIFF
--- a/src/components/charts/charts.utils.ts
+++ b/src/components/charts/charts.utils.ts
@@ -54,8 +54,9 @@ export const createSimpleClickHandler = ({
   onClicked?: (args: SimpleClickArg) => void;
 }): ((args: ChartClickArgs) => void) => {
   return ({ elementAtEvent }) => {
-    const element = elementAtEvent[0]!;
-    const dimensionValue = data?.labels?.[element?.index] as string | undefined;
+    const element = elementAtEvent[0];
+    if (!element) return;
+    const dimensionValue = data?.labels?.[element.index] as string | undefined;
     const dimensionTimeRange = getTimeRangeFromDimensionValue({
       value: dimensionValue,
       stateGranularity: granularity,
@@ -79,10 +80,11 @@ export const createGroupedClickHandler = ({
   onClicked?: (args: GroupedClickArg) => void;
 }): ((args: ChartClickArgs) => void) => {
   return ({ elementAtEvent }) => {
-    const element = elementAtEvent[0]!;
-    const dimensionValue = data?.labels?.[element?.index] as string | undefined;
+    const element = elementAtEvent[0];
+    if (!element) return;
+    const dimensionValue = data?.labels?.[element.index] as string | undefined;
     const groupingDimensionValue = (
-      data?.datasets?.[element?.datasetIndex] as { rawLabel?: string } | undefined
+      data?.datasets?.[element.datasetIndex] as { rawLabel?: string } | undefined
     )?.rawLabel;
     const dimensionTimeRange = getTimeRangeFromDimensionValue({
       value: dimensionValue,


### PR DESCRIPTION
## What changed

In `createSimpleClickHandler` and `createGroupedClickHandler` (`charts.utils.ts`), replaced the non-null assertion (`elementAtEvent[0]!`) with an early return guard (`if (!element) return`).

## Why

The pie chart's `createPieClickHandler` already used this pattern — only triggering the callback when an element is actually clicked. The bar and line chart handlers were using a non-null assertion instead, which would throw at runtime if a click landed on empty chart space.

This makes all handlers consistent: `createScatterClickHandler`, `createBubbleClickHandler`, and `createComparisonClickHandler` already had the early return guard.

## Reviewer notes

No behaviour change for normal clicks. The difference is that clicking on empty chart space no longer risks a runtime error — it silently no-ops instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chart click interactions now handle edge cases more gracefully without crashing.
  * Improved defensive handling in click event processing for both simple and grouped charts.
  * User interactions on chart elements are now more reliable and stable.
  * Enhanced robustness when working with charts containing missing or incomplete data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->