### PR TITLE
[RUI-275] Add AreaChartPro component

### DIFF
--- a/.changeset/major-donuts-heal.md
+++ b/.changeset/major-donuts-heal.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Add AreaChartPro chart

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -6130,9 +6130,9 @@
       }
     },
     "node_modules/cssstyle/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.emb.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.emb.ts
@@ -1,0 +1,8 @@
+import { defineComponent } from '@embeddable.com/react';
+import { areaChartPro } from './definition';
+
+export const preview = areaChartPro.preview;
+
+export const meta = areaChartPro.meta;
+
+export default defineComponent(areaChartPro.Component, meta, areaChartPro.config);

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
@@ -1,28 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Dimension, Measure } from '@embeddable.com/core';
 import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
-import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
-import { getDimensionWithoutTruncation } from '../../charts.utils';
 
 vi.mock('../LineChartGroupedPro/LineChartGroupedPro.utils', () => ({
   getLineChartGroupedProData: vi.fn(),
   getLineChartGroupedProOptions: vi.fn(),
-}));
-vi.mock('../../../../theme/formatter/formatter.utils', () => ({ getThemeFormatter: vi.fn() }));
-vi.mock('@embeddable.com/remarkable-ui', () => ({
-  getChartColors: vi.fn(() => []),
-  getStyleNumber: vi.fn(() => 5),
-}));
-vi.mock('../../charts.utils', () => ({ getDimensionWithoutTruncation: vi.fn((d) => d) }));
-vi.mock('../../../../theme/styles/styles.utils', () => ({
-  getDimensionMeasureColor: vi.fn(() => '#000'),
-}));
-vi.mock('../../../../utils/color.utils', () => ({
-  isColorValid: vi.fn(() => false),
-  setColorAlpha: vi.fn((c: string) => c),
-}));
-vi.mock('mergician', () => ({
-  mergician: vi.fn((...args: object[]) => Object.assign({}, ...args)),
 }));
 
 import {
@@ -54,11 +36,6 @@ const makeMeasure = (overrides: Record<string, any> = {}): Measure =>
 
 const makeTheme = (overrides = {}) => ({ charts: {}, ...overrides }) as never;
 
-const makeMockFormatter = () => ({
-  data: vi.fn((_: unknown, value: unknown) => `fmt:${value}`),
-  dimensionOrMeasureTitle: vi.fn((m: { title: string }) => m.title),
-});
-
 const makeChartData = (labels: string[], datasets: { data: number[] }[] = []) => ({
   labels,
   datasets,
@@ -67,11 +44,6 @@ const makeChartData = (labels: string[], datasets: { data: number[] }[] = []) =>
 // ----------------------------------------------------------------------------
 
 describe('getAreaChartProData', () => {
-  beforeEach(() => {
-    const mockFormatter = makeMockFormatter();
-    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
-  });
-
   it('sets fill: true on every dataset', () => {
     vi.mocked(getLineChartGroupedProData).mockReturnValue({
       labels: ['Jan', 'Feb'],
@@ -165,9 +137,6 @@ describe('getAreaChartProData', () => {
 
 describe('getAreaChartProOptions', () => {
   beforeEach(() => {
-    const mockFormatter = makeMockFormatter();
-    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
-    vi.mocked(getDimensionWithoutTruncation).mockImplementation((d) => d);
     vi.mocked(getLineChartGroupedProOptions).mockReturnValue({ scales: { x: {}, y: {} } } as never);
   });
 

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
@@ -4,9 +4,9 @@ import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.util
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { getDimensionWithoutTruncation } from '../../charts.utils';
 
-vi.mock('../LineChartDefaultPro/LineChartDefaultPro.utils', () => ({
-  getLineChartProData: vi.fn(),
-  getLineChartProOptions: vi.fn(),
+vi.mock('../LineChartGroupedPro/LineChartGroupedPro.utils', () => ({
+  getLineChartGroupedProData: vi.fn(),
+  getLineChartGroupedProOptions: vi.fn(),
 }));
 vi.mock('../../../../theme/formatter/formatter.utils', () => ({ getThemeFormatter: vi.fn() }));
 vi.mock('@embeddable.com/remarkable-ui', () => ({
@@ -26,9 +26,9 @@ vi.mock('mergician', () => ({
 }));
 
 import {
-  getLineChartProData,
-  getLineChartProOptions,
-} from '../LineChartDefaultPro/LineChartDefaultPro.utils';
+  getLineChartGroupedProData,
+  getLineChartGroupedProOptions,
+} from '../LineChartGroupedPro/LineChartGroupedPro.utils';
 
 // -- helpers -----------------------------------------------------------------
 
@@ -73,11 +73,11 @@ describe('getAreaChartProData', () => {
   });
 
   it('sets fill: true on every dataset', () => {
-    vi.mocked(getLineChartProData).mockReturnValue({
+    vi.mocked(getLineChartGroupedProData).mockReturnValue({
       labels: ['Jan', 'Feb'],
       datasets: [
-        { data: [100, 200], label: 'Revenue', fill: false },
-        { data: [50, 75], label: 'Costs', fill: false },
+        { data: [100, 200], label: 'Group A', fill: false },
+        { data: [50, 75], label: 'Group B', fill: false },
       ],
     } as never);
 
@@ -88,7 +88,8 @@ describe('getAreaChartProData', () => {
           { date: 'Feb', revenue: 200 },
         ],
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
         hasMinMaxYAxisRange: false,
       },
       makeTheme(),
@@ -98,16 +99,17 @@ describe('getAreaChartProData', () => {
   });
 
   it('preserves all other dataset properties when setting fill', () => {
-    vi.mocked(getLineChartProData).mockReturnValue({
+    vi.mocked(getLineChartGroupedProData).mockReturnValue({
       labels: ['Jan'],
-      datasets: [{ data: [100], label: 'Revenue', borderColor: '#ff0000' }],
+      datasets: [{ data: [100], label: 'Group A', borderColor: '#ff0000' }],
     } as never);
 
     const result = getAreaChartProData(
       {
         data: [{ date: 'Jan', revenue: 100 }],
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
         hasMinMaxYAxisRange: false,
       },
       makeTheme(),
@@ -115,14 +117,14 @@ describe('getAreaChartProData', () => {
 
     expect(result.datasets[0]).toMatchObject({
       data: [100],
-      label: 'Revenue',
+      label: 'Group A',
       borderColor: '#ff0000',
       fill: true,
     });
   });
 
-  it('preserves labels from the underlying line chart data', () => {
-    vi.mocked(getLineChartProData).mockReturnValue({
+  it('preserves labels from the underlying grouped line chart data', () => {
+    vi.mocked(getLineChartGroupedProData).mockReturnValue({
       labels: ['Jan', 'Feb', 'Mar'],
       datasets: [{ data: [1, 2, 3] }],
     } as never);
@@ -131,7 +133,8 @@ describe('getAreaChartProData', () => {
       {
         data: [],
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
         hasMinMaxYAxisRange: false,
       },
       makeTheme(),
@@ -140,20 +143,21 @@ describe('getAreaChartProData', () => {
     expect(result.labels).toEqual(['Jan', 'Feb', 'Mar']);
   });
 
-  it('delegates to getLineChartProData with the same props and theme', () => {
-    vi.mocked(getLineChartProData).mockReturnValue({ labels: [], datasets: [] } as never);
+  it('delegates to getLineChartGroupedProData with the same props and theme', () => {
+    vi.mocked(getLineChartGroupedProData).mockReturnValue({ labels: [], datasets: [] } as never);
 
     const props = {
       data: [{ date: 'Jan', revenue: 42 }],
       dimension: makeDimension(),
-      measures: [makeMeasure()],
+      groupDimension: makeDimension({ name: 'category' }),
+      measure: makeMeasure(),
       hasMinMaxYAxisRange: true,
     };
     const theme = makeTheme();
 
     getAreaChartProData(props, theme);
 
-    expect(getLineChartProData).toHaveBeenCalledWith(props, theme);
+    expect(getLineChartGroupedProData).toHaveBeenCalledWith(props, theme);
   });
 });
 
@@ -164,14 +168,15 @@ describe('getAreaChartProOptions', () => {
     const mockFormatter = makeMockFormatter();
     vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
     vi.mocked(getDimensionWithoutTruncation).mockImplementation((d) => d);
-    vi.mocked(getLineChartProOptions).mockReturnValue({ scales: { x: {}, y: {} } } as never);
+    vi.mocked(getLineChartGroupedProOptions).mockReturnValue({ scales: { x: {}, y: {} } } as never);
   });
 
   it('sets scales.y.stacked to true', () => {
     const result = getAreaChartProOptions(
       {
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
         data: makeChartData([]) as never,
       },
       makeTheme(),
@@ -180,30 +185,32 @@ describe('getAreaChartProOptions', () => {
     expect(result.scales?.y?.stacked).toBe(true);
   });
 
-  it('delegates to getLineChartProOptions with the same options and theme', () => {
+  it('delegates to getLineChartGroupedProOptions with the same options and theme', () => {
     const options = {
       dimension: makeDimension(),
-      measures: [makeMeasure()],
+      groupDimension: makeDimension({ name: 'category' }),
+      measure: makeMeasure(),
       data: makeChartData([]) as never,
     };
     const theme = makeTheme();
 
     getAreaChartProOptions(options, theme);
 
-    expect(getLineChartProOptions).toHaveBeenCalledWith(options, theme);
+    expect(getLineChartGroupedProOptions).toHaveBeenCalledWith(options, theme);
   });
 
-  it('merges areaChartDefaultPro theme options when provided', () => {
+  it('merges areaChartPro theme options when provided', () => {
     const theme = {
       charts: {
-        areaChartDefaultPro: { options: { animation: false } },
+        areaChartPro: { options: { animation: false } },
       },
     } as never;
 
     const result = getAreaChartProOptions(
       {
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
         data: makeChartData([]) as never,
       },
       theme,
@@ -212,11 +219,12 @@ describe('getAreaChartProOptions', () => {
     expect((result as { animation?: unknown }).animation).toBe(false);
   });
 
-  it('works without areaChartDefaultPro theme options defined', () => {
+  it('works without areaChartPro theme options defined', () => {
     const result = getAreaChartProOptions(
       {
         dimension: makeDimension(),
-        measures: [makeMeasure()],
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
         data: makeChartData([]) as never,
       },
       makeTheme(),

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Dimension, Measure } from '@embeddable.com/core';
+import { Chart } from 'chart.js';
 import {
   createAreaClickHandler,
   getAreaChartProData,
@@ -252,28 +253,31 @@ describe('createAreaClickHandler', () => {
     ],
   };
 
-  const makeEvent = (y: number | null, x: number | null = 100) => ({
-    x,
-    y,
-    native: {},
-  });
-
-  const makeChart = (
-    pointElements: { index: number; datasetIndex: number }[] = [],
+  const makeChartInstance = (
     datasetPoints: Record<number, { x: number; y: number }[]> = {},
-    chartAreaBottom = 500,
+    chartAreaBottom: number | undefined = 500,
   ) => {
     const keys = Object.keys(datasetPoints).map(Number);
     const numDatasets = keys.length > 0 ? Math.max(...keys) + 1 : 0;
     return {
-      getElementsAtEventForMode: vi.fn(() => pointElements),
       getDatasetMeta: vi.fn((datasetIndex: number) => ({
         data: datasetPoints[datasetIndex] ?? [],
       })),
-      chartArea: { bottom: chartAreaBottom },
+      chartArea: chartAreaBottom != null ? { bottom: chartAreaBottom } : undefined,
       data: { datasets: Array.from({ length: numDatasets }) },
     };
   };
+
+  const makeArgs = (
+    offsetX: number,
+    offsetY: number,
+    elementAtEvent: { index: number; datasetIndex: number }[] = [],
+  ) => ({
+    event: { target: {}, nativeEvent: { offsetX, offsetY } },
+    elementAtEvent,
+    elementsAtEvent: [],
+    datasetAtEvent: [],
+  });
 
   const defaultHandlerProps = {
     data: chartData as never,
@@ -281,42 +285,38 @@ describe('createAreaClickHandler', () => {
     groupBy: makeDimension({ name: 'category' }),
   };
 
+  let mockChartInstance: ReturnType<typeof makeChartInstance>;
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(getTimeRangeFromDimensionValue).mockReturnValue(undefined);
+    mockChartInstance = makeChartInstance({ 0: [{ x: 100, y: 300 }] });
+    vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
   });
 
   describe('onAreaClicked', () => {
     it('does not throw when onAreaClicked is not provided', () => {
       const handler = createAreaClickHandler(defaultHandlerProps);
-      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
-      expect(() => handler(makeEvent(350) as never, [] as never, chart as never)).not.toThrow();
+      expect(() => handler(makeArgs(100, 350) as never)).not.toThrow();
     });
 
-    it('does not call onAreaClicked when clickX is null', () => {
+    it('does not call onAreaClicked when Chart.getChart returns null', () => {
       const onAreaClicked = vi.fn();
+      vi.spyOn(Chart, 'getChart').mockReturnValue(undefined as never);
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
-      handler({ x: null, y: 350, native: {} } as never, [] as never, chart as never);
-      expect(onAreaClicked).not.toHaveBeenCalled();
-    });
-
-    it('does not call onAreaClicked when clickY is null', () => {
-      const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
-      handler({ x: 100, y: null, native: {} } as never, [] as never, chart as never);
+      handler(makeArgs(100, 350) as never);
       expect(onAreaClicked).not.toHaveBeenCalled();
     });
 
     it('selects the dataset whose interpolated area contains the click', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      handler(makeEvent(250) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(100, 250) as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group B' }),
       );
@@ -324,8 +324,7 @@ describe('createAreaClickHandler', () => {
 
     it('interpolates the line y-value between two data points', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [
           { x: 0, y: 400 },
           { x: 200, y: 200 },
@@ -335,7 +334,9 @@ describe('createAreaClickHandler', () => {
           { x: 200, y: 100 },
         ],
       });
-      handler(makeEvent(250, 100) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(100, 250) as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group B' }),
       );
@@ -343,12 +344,13 @@ describe('createAreaClickHandler', () => {
 
     it('selects the lower segment when clicking just below the shared boundary', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      handler(makeEvent(305) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(100, 305) as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group A' }),
       );
@@ -356,12 +358,13 @@ describe('createAreaClickHandler', () => {
 
     it('selects the upper segment when clicking just above the shared boundary', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      handler(makeEvent(295) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(100, 295) as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group B' }),
       );
@@ -369,20 +372,20 @@ describe('createAreaClickHandler', () => {
 
     it('does not call onAreaClicked when click is outside all filled areas', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      handler(makeEvent(50) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(100, 50) as never);
       expect(onAreaClicked).not.toHaveBeenCalled();
     });
 
     it('passes groupingDimensionValue from dataset rawLabel', () => {
       const onAreaClicked = vi.fn();
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
-      handler(makeEvent(350) as never, [] as never, chart as never);
+      handler(makeArgs(100, 350) as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group A' }),
       );
@@ -391,8 +394,7 @@ describe('createAreaClickHandler', () => {
     it('calls getTimeRangeFromDimensionValue for the grouping dimension', () => {
       const onAreaClicked = vi.fn();
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
-      handler(makeEvent(350) as never, [] as never, chart as never);
+      handler(makeArgs(100, 350) as never);
       expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(1);
     });
   });
@@ -401,16 +403,14 @@ describe('createAreaClickHandler', () => {
     it('calls onPointClicked instead of onAreaClicked when a point is hit', () => {
       const onPointClicked = vi.fn();
       const onAreaClicked = vi.fn();
+      mockChartInstance = makeChartInstance({ 0: [{ x: 100, y: 50 }] });
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({
         ...defaultHandlerProps,
         onPointClicked,
         onAreaClicked,
       });
-      handler(
-        makeEvent(50) as never,
-        [] as never,
-        makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 50 }] }) as never,
-      );
+      handler(makeArgs(100, 50, [{ index: 0, datasetIndex: 0 }]) as never);
       expect(onPointClicked).toHaveBeenCalled();
       expect(onAreaClicked).not.toHaveBeenCalled();
     });
@@ -418,16 +418,17 @@ describe('createAreaClickHandler', () => {
     it('falls through to onAreaClicked when click is far from the detected point', () => {
       const onPointClicked = vi.fn();
       const onAreaClicked = vi.fn();
+      mockChartInstance = makeChartInstance({
+        0: [{ x: 100, y: 300 }],
+        1: [{ x: 100, y: 200 }],
+      });
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({
         ...defaultHandlerProps,
         onPointClicked,
         onAreaClicked,
       });
-      const chart = makeChart([{ index: 0, datasetIndex: 0 }], {
-        0: [{ x: 100, y: 300 }],
-        1: [{ x: 100, y: 200 }],
-      });
-      handler(makeEvent(200) as never, [] as never, chart as never);
+      handler(makeArgs(100, 200, [{ index: 0, datasetIndex: 0 }]) as never);
       expect(onPointClicked).not.toHaveBeenCalled();
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group B' }),
@@ -436,17 +437,15 @@ describe('createAreaClickHandler', () => {
 
     it('passes dimensionValue from labels at the clicked element index', () => {
       const onPointClicked = vi.fn();
+      mockChartInstance = makeChartInstance({
+        0: [
+          { x: 100, y: 0 },
+          { x: 100, y: 50 },
+        ],
+      });
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
-      handler(
-        makeEvent(50) as never,
-        [] as never,
-        makeChart([{ index: 1, datasetIndex: 0 }], {
-          0: [
-            { x: 100, y: 0 },
-            { x: 100, y: 50 },
-          ],
-        }) as never,
-      );
+      handler(makeArgs(100, 50, [{ index: 1, datasetIndex: 0 }]) as never);
       expect(onPointClicked).toHaveBeenCalledWith(
         expect.objectContaining({ dimensionValue: 'Feb' }),
       );
@@ -454,29 +453,25 @@ describe('createAreaClickHandler', () => {
 
     it('passes measureValue from the dataset at the clicked element index', () => {
       const onPointClicked = vi.fn();
+      mockChartInstance = makeChartInstance({
+        1: [
+          { x: 100, y: 0 },
+          { x: 100, y: 0 },
+          { x: 100, y: 50 },
+        ],
+      });
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
-      handler(
-        makeEvent(50) as never,
-        [] as never,
-        makeChart([{ index: 2, datasetIndex: 1 }], {
-          1: [
-            { x: 100, y: 0 },
-            { x: 100, y: 0 },
-            { x: 100, y: 50 },
-          ],
-        }) as never,
-      );
+      handler(makeArgs(100, 50, [{ index: 2, datasetIndex: 1 }]) as never);
       expect(onPointClicked).toHaveBeenCalledWith(expect.objectContaining({ measureValue: 90 }));
     });
 
     it('calls getTimeRangeFromDimensionValue for the x dimension', () => {
       const onPointClicked = vi.fn();
+      mockChartInstance = makeChartInstance({ 0: [{ x: 100, y: 50 }] });
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
-      handler(
-        makeEvent(50) as never,
-        [] as never,
-        makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 50 }] }) as never,
-      );
+      handler(makeArgs(100, 50, [{ index: 0, datasetIndex: 0 }]) as never);
       expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(1);
     });
 
@@ -488,40 +483,28 @@ describe('createAreaClickHandler', () => {
         onPointClicked,
         onAreaClicked,
       });
-      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
-      handler(makeEvent(350) as never, [] as never, chart as never);
+      handler(makeArgs(100, 350) as never);
       expect(onPointClicked).not.toHaveBeenCalled();
       expect(onAreaClicked).toHaveBeenCalled();
     });
 
     it('does not call onPointClicked when pointY pixel is not available', () => {
       const onPointClicked = vi.fn();
+      mockChartInstance = makeChartInstance({});
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
-      const chart = makeChart([{ index: 5, datasetIndex: 0 }], {});
-      handler(makeEvent(50) as never, [] as never, chart as never);
+      handler(makeArgs(100, 50, [{ index: 5, datasetIndex: 0 }]) as never);
       expect(onPointClicked).not.toHaveBeenCalled();
-    });
-
-    it('treats event.y=null as on-point (proximity check skipped)', () => {
-      const onPointClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
-      const chart = makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 300 }] });
-      handler({ x: 100, y: null, native: {} } as never, [] as never, chart as never);
-      expect(onPointClicked).toHaveBeenCalled();
     });
   });
 
   describe('edge cases', () => {
     it('uses Infinity as chartBottom when chart.chartArea is undefined', () => {
       const onAreaClicked = vi.fn();
+      mockChartInstance = makeChartInstance({ 0: [{ x: 100, y: 300 }] }, undefined);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = {
-        getElementsAtEventForMode: vi.fn(() => []),
-        getDatasetMeta: vi.fn(() => ({ data: [{ x: 100, y: 300 }] })),
-        chartArea: undefined,
-        data: { datasets: [{}] },
-      };
-      handler(makeEvent(400) as never, [] as never, chart as never);
+      handler(makeArgs(100, 400) as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group A' }),
       );
@@ -529,8 +512,7 @@ describe('createAreaClickHandler', () => {
 
     it('skips a dataset when interpolated lineY is null (clickX outside all segments)', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [
           { x: 0, y: 400 },
           { x: 50, y: 300 },
@@ -540,18 +522,21 @@ describe('createAreaClickHandler', () => {
           { x: 50, y: 150 },
         ],
       });
-      handler(makeEvent(250, 200) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(200, 250) as never);
       expect(onAreaClicked).not.toHaveBeenCalled();
     });
 
     it('skips a dataset when its previous line interpolation returns null', () => {
       const onAreaClicked = vi.fn();
-      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      const chart = makeChart([], {
+      mockChartInstance = makeChartInstance({
         0: [],
         1: [{ x: 100, y: 200 }],
       });
-      handler(makeEvent(300) as never, [] as never, chart as never);
+      vi.spyOn(Chart, 'getChart').mockReturnValue(mockChartInstance as never);
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      handler(makeArgs(100, 300) as never);
       expect(onAreaClicked).not.toHaveBeenCalled();
     });
   });

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
@@ -252,15 +252,12 @@ describe('createAreaClickHandler', () => {
     ],
   };
 
-  // x defaults to 100 so most tests don't need to specify it
   const makeEvent = (y: number | null, x: number | null = 100) => ({
     x,
     y,
     native: {},
   });
 
-  // datasetPoints: datasetIndex → pixel-space points [{x, y}]
-  // numDatasets in chart.data.datasets is derived from max key + 1
   const makeChart = (
     pointElements: { index: number; datasetIndex: number }[] = [],
     datasetPoints: Record<number, { x: number; y: number }[]> = {},
@@ -313,9 +310,6 @@ describe('createAreaClickHandler', () => {
     });
 
     it('selects the dataset whose interpolated area contains the click', () => {
-      // ds=0 (Group A, bottom): line y=300, fills [300, chartBottom=500]
-      // ds=1 (Group B, top):    line y=200, fills [200, 300]
-      // click y=250 → Group B
       const onAreaClicked = vi.fn();
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
       const chart = makeChart([], {
@@ -329,9 +323,6 @@ describe('createAreaClickHandler', () => {
     });
 
     it('interpolates the line y-value between two data points', () => {
-      // ds=0: x=[0,200] y=[400,200] → at x=100: y=300
-      // ds=1: x=[0,200] y=[300,100] → at x=100: y=200
-      // Group B fills [200, 300], click y=250 → Group B
       const onAreaClicked = vi.fn();
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
       const chart = makeChart([], {
@@ -357,7 +348,6 @@ describe('createAreaClickHandler', () => {
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      // y=305 → inside Group A [300, 500], outside Group B [200, 300]
       handler(makeEvent(305) as never, [] as never, chart as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group A' }),
@@ -371,7 +361,6 @@ describe('createAreaClickHandler', () => {
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      // y=295 → inside Group B [200, 300]
       handler(makeEvent(295) as never, [] as never, chart as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
         expect.objectContaining({ groupingDimensionValue: 'Group B' }),
@@ -385,7 +374,6 @@ describe('createAreaClickHandler', () => {
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
       });
-      // y=50 → above all areas (topmost starts at y=200)
       handler(makeEvent(50) as never, [] as never, chart as never);
       expect(onAreaClicked).not.toHaveBeenCalled();
     });
@@ -393,7 +381,6 @@ describe('createAreaClickHandler', () => {
     it('passes groupingDimensionValue from dataset rawLabel', () => {
       const onAreaClicked = vi.fn();
       const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
-      // ds=0 only: fills [300, 500], click y=350 → Group A
       const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
       handler(makeEvent(350) as never, [] as never, chart as never);
       expect(onAreaClicked).toHaveBeenCalledWith(
@@ -436,8 +423,6 @@ describe('createAreaClickHandler', () => {
         onPointClicked,
         onAreaClicked,
       });
-      // click y=200, point at y=300 — 100px apart, well beyond 8px threshold
-      // Group B fills [200, 300], so area click should fire for Group B
       const chart = makeChart([{ index: 0, datasetIndex: 0 }], {
         0: [{ x: 100, y: 300 }],
         1: [{ x: 100, y: 200 }],
@@ -493,6 +478,81 @@ describe('createAreaClickHandler', () => {
         makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 50 }] }) as never,
       );
       expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls through to onAreaClicked when no point element is under the cursor', () => {
+      const onPointClicked = vi.fn();
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({
+        ...defaultHandlerProps,
+        onPointClicked,
+        onAreaClicked,
+      });
+      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
+      handler(makeEvent(350) as never, [] as never, chart as never);
+      expect(onPointClicked).not.toHaveBeenCalled();
+      expect(onAreaClicked).toHaveBeenCalled();
+    });
+
+    it('does not call onPointClicked when pointY pixel is not available', () => {
+      const onPointClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
+      const chart = makeChart([{ index: 5, datasetIndex: 0 }], {});
+      handler(makeEvent(50) as never, [] as never, chart as never);
+      expect(onPointClicked).not.toHaveBeenCalled();
+    });
+
+    it('treats event.y=null as on-point (proximity check skipped)', () => {
+      const onPointClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
+      const chart = makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 300 }] });
+      handler({ x: 100, y: null, native: {} } as never, [] as never, chart as never);
+      expect(onPointClicked).toHaveBeenCalled();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('uses Infinity as chartBottom when chart.chartArea is undefined', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = {
+        getElementsAtEventForMode: vi.fn(() => []),
+        getDatasetMeta: vi.fn(() => ({ data: [{ x: 100, y: 300 }] })),
+        chartArea: undefined,
+        data: { datasets: [{}] },
+      };
+      handler(makeEvent(400) as never, [] as never, chart as never);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group A' }),
+      );
+    });
+
+    it('skips a dataset when interpolated lineY is null (clickX outside all segments)', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [
+          { x: 0, y: 400 },
+          { x: 50, y: 300 },
+        ],
+        1: [
+          { x: 0, y: 200 },
+          { x: 50, y: 150 },
+        ],
+      });
+      handler(makeEvent(250, 200) as never, [] as never, chart as never);
+      expect(onAreaClicked).not.toHaveBeenCalled();
+    });
+
+    it('skips a dataset when its previous line interpolation returns null', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [],
+        1: [{ x: 100, y: 200 }],
+      });
+      handler(makeEvent(300) as never, [] as never, chart as never);
+      expect(onAreaClicked).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Dimension, Measure } from '@embeddable.com/core';
+import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
+import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
+import { getDimensionWithoutTruncation } from '../../charts.utils';
+
+vi.mock('../LineChartDefaultPro/LineChartDefaultPro.utils', () => ({
+  getLineChartProData: vi.fn(),
+  getLineChartProOptions: vi.fn(),
+}));
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({ getThemeFormatter: vi.fn() }));
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  getChartColors: vi.fn(() => []),
+  getStyleNumber: vi.fn(() => 5),
+}));
+vi.mock('../../charts.utils', () => ({ getDimensionWithoutTruncation: vi.fn((d) => d) }));
+vi.mock('../../../../theme/styles/styles.utils', () => ({
+  getDimensionMeasureColor: vi.fn(() => '#000'),
+}));
+vi.mock('../../../../utils/color.utils', () => ({
+  isColorValid: vi.fn(() => false),
+  setColorAlpha: vi.fn((c: string) => c),
+}));
+vi.mock('mergician', () => ({
+  mergician: vi.fn((...args: object[]) => Object.assign({}, ...args)),
+}));
+
+import {
+  getLineChartProData,
+  getLineChartProOptions,
+} from '../LineChartDefaultPro/LineChartDefaultPro.utils';
+
+// -- helpers -----------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeDimension = (overrides: Record<string, any> = {}): Dimension =>
+  ({
+    name: 'date',
+    title: 'Date',
+    nativeType: 'string',
+    inputs: {},
+    ...overrides,
+  }) as unknown as Dimension;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const makeMeasure = (overrides: Record<string, any> = {}): Measure =>
+  ({
+    name: 'revenue',
+    title: 'Revenue',
+    nativeType: 'number',
+    inputs: {},
+    ...overrides,
+  }) as unknown as Measure;
+
+const makeTheme = (overrides = {}) => ({ charts: {}, ...overrides }) as never;
+
+const makeMockFormatter = () => ({
+  data: vi.fn((_: unknown, value: unknown) => `fmt:${value}`),
+  dimensionOrMeasureTitle: vi.fn((m: { title: string }) => m.title),
+});
+
+const makeChartData = (labels: string[], datasets: { data: number[] }[] = []) => ({
+  labels,
+  datasets,
+});
+
+// ----------------------------------------------------------------------------
+
+describe('getAreaChartProData', () => {
+  beforeEach(() => {
+    const mockFormatter = makeMockFormatter();
+    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
+  });
+
+  it('sets fill: true on every dataset', () => {
+    vi.mocked(getLineChartProData).mockReturnValue({
+      labels: ['Jan', 'Feb'],
+      datasets: [
+        { data: [100, 200], label: 'Revenue', fill: false },
+        { data: [50, 75], label: 'Costs', fill: false },
+      ],
+    } as never);
+
+    const result = getAreaChartProData(
+      {
+        data: [
+          { date: 'Jan', revenue: 100 },
+          { date: 'Feb', revenue: 200 },
+        ],
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        hasMinMaxYAxisRange: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.datasets.every((ds) => ds.fill === true)).toBe(true);
+  });
+
+  it('preserves all other dataset properties when setting fill', () => {
+    vi.mocked(getLineChartProData).mockReturnValue({
+      labels: ['Jan'],
+      datasets: [{ data: [100], label: 'Revenue', borderColor: '#ff0000' }],
+    } as never);
+
+    const result = getAreaChartProData(
+      {
+        data: [{ date: 'Jan', revenue: 100 }],
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        hasMinMaxYAxisRange: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.datasets[0]).toMatchObject({
+      data: [100],
+      label: 'Revenue',
+      borderColor: '#ff0000',
+      fill: true,
+    });
+  });
+
+  it('preserves labels from the underlying line chart data', () => {
+    vi.mocked(getLineChartProData).mockReturnValue({
+      labels: ['Jan', 'Feb', 'Mar'],
+      datasets: [{ data: [1, 2, 3] }],
+    } as never);
+
+    const result = getAreaChartProData(
+      {
+        data: [],
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        hasMinMaxYAxisRange: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.labels).toEqual(['Jan', 'Feb', 'Mar']);
+  });
+
+  it('delegates to getLineChartProData with the same props and theme', () => {
+    vi.mocked(getLineChartProData).mockReturnValue({ labels: [], datasets: [] } as never);
+
+    const props = {
+      data: [{ date: 'Jan', revenue: 42 }],
+      dimension: makeDimension(),
+      measures: [makeMeasure()],
+      hasMinMaxYAxisRange: true,
+    };
+    const theme = makeTheme();
+
+    getAreaChartProData(props, theme);
+
+    expect(getLineChartProData).toHaveBeenCalledWith(props, theme);
+  });
+});
+
+// ----------------------------------------------------------------------------
+
+describe('getAreaChartProOptions', () => {
+  beforeEach(() => {
+    const mockFormatter = makeMockFormatter();
+    vi.mocked(getThemeFormatter).mockReturnValue(mockFormatter as never);
+    vi.mocked(getDimensionWithoutTruncation).mockImplementation((d) => d);
+    vi.mocked(getLineChartProOptions).mockReturnValue({ scales: { x: {}, y: {} } } as never);
+  });
+
+  it('sets scales.y.stacked to true', () => {
+    const result = getAreaChartProOptions(
+      {
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        data: makeChartData([]) as never,
+      },
+      makeTheme(),
+    );
+
+    expect(result.scales?.y?.stacked).toBe(true);
+  });
+
+  it('delegates to getLineChartProOptions with the same options and theme', () => {
+    const options = {
+      dimension: makeDimension(),
+      measures: [makeMeasure()],
+      data: makeChartData([]) as never,
+    };
+    const theme = makeTheme();
+
+    getAreaChartProOptions(options, theme);
+
+    expect(getLineChartProOptions).toHaveBeenCalledWith(options, theme);
+  });
+
+  it('merges areaChartDefaultPro theme options when provided', () => {
+    const theme = {
+      charts: {
+        areaChartDefaultPro: { options: { animation: false } },
+      },
+    } as never;
+
+    const result = getAreaChartProOptions(
+      {
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        data: makeChartData([]) as never,
+      },
+      theme,
+    );
+
+    expect((result as { animation?: unknown }).animation).toBe(false);
+  });
+
+  it('works without areaChartDefaultPro theme options defined', () => {
+    const result = getAreaChartProOptions(
+      {
+        dimension: makeDimension(),
+        measures: [makeMeasure()],
+        data: makeChartData([]) as never,
+      },
+      makeTheme(),
+    );
+
+    expect(result.scales).toBeDefined();
+  });
+});

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.test.ts
@@ -1,16 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Dimension, Measure } from '@embeddable.com/core';
-import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
+import {
+  createAreaClickHandler,
+  getAreaChartProData,
+  getAreaChartProOptions,
+} from './AreaChartPro.utils';
 
 vi.mock('../LineChartGroupedPro/LineChartGroupedPro.utils', () => ({
   getLineChartGroupedProData: vi.fn(),
   getLineChartGroupedProOptions: vi.fn(),
 }));
 
+vi.mock('../../../../utils/color.utils', () => ({
+  setColorAlpha: vi.fn((color: string, alpha: number) => `${color}@${alpha}`),
+}));
+
+vi.mock('../../../utils/dimension.utils', () => ({
+  getTimeRangeFromDimensionValue: vi.fn(() => undefined),
+}));
+
 import {
   getLineChartGroupedProData,
   getLineChartGroupedProOptions,
 } from '../LineChartGroupedPro/LineChartGroupedPro.utils';
+import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
 
 // -- helpers -----------------------------------------------------------------
 
@@ -44,6 +57,31 @@ const makeChartData = (labels: string[], datasets: { data: number[] }[] = []) =>
 // ----------------------------------------------------------------------------
 
 describe('getAreaChartProData', () => {
+  it('sets backgroundColor to 0.9 opacity on every dataset', () => {
+    vi.mocked(getLineChartGroupedProData).mockReturnValue({
+      labels: ['Jan'],
+      datasets: [
+        { data: [100], backgroundColor: 'rgba(255,0,0,0.5)' },
+        { data: [50], backgroundColor: 'rgba(0,255,0,0.5)' },
+      ],
+    } as never);
+
+    const result = getAreaChartProData(
+      {
+        data: [],
+        dimension: makeDimension(),
+        groupDimension: makeDimension({ name: 'category' }),
+        measure: makeMeasure(),
+        hasMinMaxYAxisRange: false,
+      },
+      makeTheme(),
+    );
+
+    expect(result.datasets.every((ds) => (ds.backgroundColor as string).endsWith('@0.9'))).toBe(
+      true,
+    );
+  });
+
   it('sets fill: true on every dataset', () => {
     vi.mocked(getLineChartGroupedProData).mockReturnValue({
       labels: ['Jan', 'Feb'],
@@ -200,5 +238,261 @@ describe('getAreaChartProOptions', () => {
     );
 
     expect(result.scales).toBeDefined();
+  });
+});
+
+// ----------------------------------------------------------------------------
+
+describe('createAreaClickHandler', () => {
+  const chartData = {
+    labels: ['Jan', 'Feb', 'Mar'],
+    datasets: [
+      { rawLabel: 'Group A', data: [100, 200, 300] },
+      { rawLabel: 'Group B', data: [50, 75, 90] },
+    ],
+  };
+
+  // x defaults to 100 so most tests don't need to specify it
+  const makeEvent = (y: number | null, x: number | null = 100) => ({
+    x,
+    y,
+    native: {},
+  });
+
+  // datasetPoints: datasetIndex → pixel-space points [{x, y}]
+  // numDatasets in chart.data.datasets is derived from max key + 1
+  const makeChart = (
+    pointElements: { index: number; datasetIndex: number }[] = [],
+    datasetPoints: Record<number, { x: number; y: number }[]> = {},
+    chartAreaBottom = 500,
+  ) => {
+    const keys = Object.keys(datasetPoints).map(Number);
+    const numDatasets = keys.length > 0 ? Math.max(...keys) + 1 : 0;
+    return {
+      getElementsAtEventForMode: vi.fn(() => pointElements),
+      getDatasetMeta: vi.fn((datasetIndex: number) => ({
+        data: datasetPoints[datasetIndex] ?? [],
+      })),
+      chartArea: { bottom: chartAreaBottom },
+      data: { datasets: Array.from({ length: numDatasets }) },
+    };
+  };
+
+  const defaultHandlerProps = {
+    data: chartData as never,
+    dimension: makeDimension(),
+    groupBy: makeDimension({ name: 'category' }),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTimeRangeFromDimensionValue).mockReturnValue(undefined);
+  });
+
+  describe('onAreaClicked', () => {
+    it('does not throw when onAreaClicked is not provided', () => {
+      const handler = createAreaClickHandler(defaultHandlerProps);
+      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
+      expect(() => handler(makeEvent(350) as never, [] as never, chart as never)).not.toThrow();
+    });
+
+    it('does not call onAreaClicked when clickX is null', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
+      handler({ x: null, y: 350, native: {} } as never, [] as never, chart as never);
+      expect(onAreaClicked).not.toHaveBeenCalled();
+    });
+
+    it('does not call onAreaClicked when clickY is null', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
+      handler({ x: 100, y: null, native: {} } as never, [] as never, chart as never);
+      expect(onAreaClicked).not.toHaveBeenCalled();
+    });
+
+    it('selects the dataset whose interpolated area contains the click', () => {
+      // ds=0 (Group A, bottom): line y=300, fills [300, chartBottom=500]
+      // ds=1 (Group B, top):    line y=200, fills [200, 300]
+      // click y=250 → Group B
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [{ x: 100, y: 300 }],
+        1: [{ x: 100, y: 200 }],
+      });
+      handler(makeEvent(250) as never, [] as never, chart as never);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('interpolates the line y-value between two data points', () => {
+      // ds=0: x=[0,200] y=[400,200] → at x=100: y=300
+      // ds=1: x=[0,200] y=[300,100] → at x=100: y=200
+      // Group B fills [200, 300], click y=250 → Group B
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [
+          { x: 0, y: 400 },
+          { x: 200, y: 200 },
+        ],
+        1: [
+          { x: 0, y: 300 },
+          { x: 200, y: 100 },
+        ],
+      });
+      handler(makeEvent(250, 100) as never, [] as never, chart as never);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('selects the lower segment when clicking just below the shared boundary', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [{ x: 100, y: 300 }],
+        1: [{ x: 100, y: 200 }],
+      });
+      // y=305 → inside Group A [300, 500], outside Group B [200, 300]
+      handler(makeEvent(305) as never, [] as never, chart as never);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group A' }),
+      );
+    });
+
+    it('selects the upper segment when clicking just above the shared boundary', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [{ x: 100, y: 300 }],
+        1: [{ x: 100, y: 200 }],
+      });
+      // y=295 → inside Group B [200, 300]
+      handler(makeEvent(295) as never, [] as never, chart as never);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('does not call onAreaClicked when click is outside all filled areas', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], {
+        0: [{ x: 100, y: 300 }],
+        1: [{ x: 100, y: 200 }],
+      });
+      // y=50 → above all areas (topmost starts at y=200)
+      handler(makeEvent(50) as never, [] as never, chart as never);
+      expect(onAreaClicked).not.toHaveBeenCalled();
+    });
+
+    it('passes groupingDimensionValue from dataset rawLabel', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      // ds=0 only: fills [300, 500], click y=350 → Group A
+      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
+      handler(makeEvent(350) as never, [] as never, chart as never);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group A' }),
+      );
+    });
+
+    it('calls getTimeRangeFromDimensionValue for the grouping dimension', () => {
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onAreaClicked });
+      const chart = makeChart([], { 0: [{ x: 100, y: 300 }] });
+      handler(makeEvent(350) as never, [] as never, chart as never);
+      expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('onPointClicked', () => {
+    it('calls onPointClicked instead of onAreaClicked when a point is hit', () => {
+      const onPointClicked = vi.fn();
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({
+        ...defaultHandlerProps,
+        onPointClicked,
+        onAreaClicked,
+      });
+      handler(
+        makeEvent(50) as never,
+        [] as never,
+        makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 50 }] }) as never,
+      );
+      expect(onPointClicked).toHaveBeenCalled();
+      expect(onAreaClicked).not.toHaveBeenCalled();
+    });
+
+    it('falls through to onAreaClicked when click is far from the detected point', () => {
+      const onPointClicked = vi.fn();
+      const onAreaClicked = vi.fn();
+      const handler = createAreaClickHandler({
+        ...defaultHandlerProps,
+        onPointClicked,
+        onAreaClicked,
+      });
+      // click y=200, point at y=300 — 100px apart, well beyond 8px threshold
+      // Group B fills [200, 300], so area click should fire for Group B
+      const chart = makeChart([{ index: 0, datasetIndex: 0 }], {
+        0: [{ x: 100, y: 300 }],
+        1: [{ x: 100, y: 200 }],
+      });
+      handler(makeEvent(200) as never, [] as never, chart as never);
+      expect(onPointClicked).not.toHaveBeenCalled();
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('passes dimensionValue from labels at the clicked element index', () => {
+      const onPointClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
+      handler(
+        makeEvent(50) as never,
+        [] as never,
+        makeChart([{ index: 1, datasetIndex: 0 }], {
+          0: [
+            { x: 100, y: 0 },
+            { x: 100, y: 50 },
+          ],
+        }) as never,
+      );
+      expect(onPointClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ dimensionValue: 'Feb' }),
+      );
+    });
+
+    it('passes measureValue from the dataset at the clicked element index', () => {
+      const onPointClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
+      handler(
+        makeEvent(50) as never,
+        [] as never,
+        makeChart([{ index: 2, datasetIndex: 1 }], {
+          1: [
+            { x: 100, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 50 },
+          ],
+        }) as never,
+      );
+      expect(onPointClicked).toHaveBeenCalledWith(expect.objectContaining({ measureValue: 90 }));
+    });
+
+    it('calls getTimeRangeFromDimensionValue for the x dimension', () => {
+      const onPointClicked = vi.fn();
+      const handler = createAreaClickHandler({ ...defaultHandlerProps, onPointClicked });
+      handler(
+        makeEvent(50) as never,
+        [] as never,
+        makeChart([{ index: 0, datasetIndex: 0 }], { 0: [{ x: 100, y: 50 }] }) as never,
+      );
+      expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
@@ -1,0 +1,41 @@
+import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { Theme } from '../../../../theme/theme.types';
+import { ChartData, ChartOptions } from 'chart.js';
+import { mergician } from 'mergician';
+import {
+  getLineChartProData,
+  getLineChartProOptions,
+} from '../LineChartDefaultPro/LineChartDefaultPro.utils';
+
+export const getAreaChartProData = (
+  props: {
+    data: DataResponse['data'];
+    dimension: Dimension;
+    measures: Measure[];
+    hasMinMaxYAxisRange: boolean;
+  },
+  theme: Theme,
+): ChartData<'line'> => {
+  const data = getLineChartProData(props, theme);
+
+  return {
+    ...data,
+    datasets: data.datasets.map((dataset) => ({ ...dataset, fill: true })),
+  };
+};
+
+export const getAreaChartProOptions = (
+  options: {
+    dimension: Dimension;
+    measures: Measure[];
+    data: ChartData<'line'>;
+  },
+  theme: Theme,
+): ChartOptions<'line'> => {
+  const lineOptions = getLineChartProOptions(options, theme);
+
+  return mergician(lineOptions, {
+    scales: { y: { stacked: true } },
+    ...(theme.charts?.areaChartDefaultPro?.options || {}),
+  });
+};

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
@@ -3,20 +3,21 @@ import { Theme } from '../../../../theme/theme.types';
 import { ChartData, ChartOptions } from 'chart.js';
 import { mergician } from 'mergician';
 import {
-  getLineChartProData,
-  getLineChartProOptions,
-} from '../LineChartDefaultPro/LineChartDefaultPro.utils';
+  getLineChartGroupedProData,
+  getLineChartGroupedProOptions,
+} from '../LineChartGroupedPro/LineChartGroupedPro.utils';
 
 export const getAreaChartProData = (
   props: {
     data: DataResponse['data'];
     dimension: Dimension;
-    measures: Measure[];
+    groupDimension: Dimension;
+    measure: Measure;
     hasMinMaxYAxisRange: boolean;
   },
   theme: Theme,
 ): ChartData<'line'> => {
-  const data = getLineChartProData(props, theme);
+  const data = getLineChartGroupedProData(props, theme);
 
   return {
     ...data,
@@ -27,15 +28,16 @@ export const getAreaChartProData = (
 export const getAreaChartProOptions = (
   options: {
     dimension: Dimension;
-    measures: Measure[];
+    groupDimension: Dimension;
+    measure: Measure;
     data: ChartData<'line'>;
   },
   theme: Theme,
 ): ChartOptions<'line'> => {
-  const lineOptions = getLineChartProOptions(options, theme);
+  const lineOptions = getLineChartGroupedProOptions(options, theme);
 
   return mergician(lineOptions, {
     scales: { y: { stacked: true } },
-    ...(theme.charts?.areaChartDefaultPro?.options || {}),
+    ...(theme.charts?.areaChartPro?.options || {}),
   });
 };

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
@@ -1,6 +1,6 @@
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { Theme } from '../../../../theme/theme.types';
-import { ActiveElement, Chart, ChartData, ChartEvent, ChartOptions } from 'chart.js';
+import { Chart, ChartData, ChartOptions } from 'chart.js';
 import { mergician } from 'mergician';
 import {
   getLineChartGroupedProData,
@@ -9,6 +9,7 @@ import {
 import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
 import { setColorAlpha } from '../../../../utils/color.utils';
 import { AreaChartProAreaClickArg, AreaChartProPointClickArg } from '../lines.types';
+import { ChartClickArgs } from '@embeddable.com/remarkable-ui';
 
 export const getAreaChartProData = (
   props: {
@@ -53,26 +54,20 @@ const interpolateLineY = (chart: Chart, datasetIndex: number, clickX: number): n
 
 const handlePointClick = (
   chart: Chart,
-  event: ChartEvent,
+  elementAtEvent: ChartClickArgs['elementAtEvent'],
+  clickY: number,
   data: ChartData<'line'>,
   dimension: Dimension,
   granularity: Granularity | undefined,
   onPointClicked: (arg: AreaChartProPointClickArg) => void,
 ): boolean => {
-  const pointElements = chart.getElementsAtEventForMode(
-    event.native as Event,
-    'nearest',
-    { intersect: true },
-    false,
-  );
-  if (!pointElements.length) return false;
+  if (!elementAtEvent.length) return false;
 
-  const clicked = pointElements[0]!;
+  const clicked = elementAtEvent[0]!;
   const pointY = getPixelPoints(chart, clicked.datasetIndex)[clicked.index]?.y;
   if (pointY == null) return false;
 
-  const isOnPoint = event.y == null || Math.abs(event.y - pointY) <= 8;
-  if (!isOnPoint) return false;
+  if (Math.abs(clickY - pointY) > 8) return false;
 
   const dimensionValue = data?.labels?.[clicked.index] as string | undefined;
   const measureValue = (data?.datasets?.[clicked.datasetIndex] as { data?: unknown[] })?.data?.[
@@ -93,14 +88,12 @@ const handlePointClick = (
 
 const handleAreaClick = (
   chart: Chart,
-  event: ChartEvent,
+  clickX: number,
+  clickY: number,
   data: ChartData<'line'>,
   groupBy: Dimension,
   onAreaClicked: (arg: AreaChartProAreaClickArg) => void,
 ): void => {
-  const { x: clickX, y: clickY } = event;
-  if (clickX == null || clickY == null) return;
-
   const chartBottom = chart.chartArea?.bottom ?? Infinity;
 
   for (let i = chart.data.datasets.length - 1; i >= 0; i--) {
@@ -137,13 +130,19 @@ export const createAreaClickHandler =
     onPointClicked?: (arg: AreaChartProPointClickArg) => void;
     onAreaClicked?: (arg: AreaChartProAreaClickArg) => void;
   }) =>
-  (event: ChartEvent, _elements: ActiveElement[], chart: Chart): void => {
+  ({ event, elementAtEvent }: ChartClickArgs): void => {
+    const chart = Chart.getChart(event.target as HTMLCanvasElement);
+    if (!chart) return;
+
+    const clickX = event.nativeEvent.offsetX;
+    const clickY = event.nativeEvent.offsetY;
+
     if (
       onPointClicked &&
-      handlePointClick(chart, event, data, dimension, granularity, onPointClicked)
+      handlePointClick(chart, elementAtEvent, clickY, data, dimension, granularity, onPointClicked)
     )
       return;
-    if (onAreaClicked) handleAreaClick(chart, event, data, groupBy, onAreaClicked);
+    if (onAreaClicked) handleAreaClick(chart, clickX, clickY, data, groupBy, onAreaClicked);
   };
 
 export const getAreaChartProOptions = (

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
@@ -159,6 +159,7 @@ export const getAreaChartProOptions = (
 
   return mergician(lineOptions, {
     scales: { y: { stacked: true } },
+    interaction: { mode: 'index' as const, intersect: false },
     ...(theme.charts?.areaChartPro?.options || {}),
   });
 };

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
@@ -1,11 +1,14 @@
-import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { Theme } from '../../../../theme/theme.types';
-import { ChartData, ChartOptions } from 'chart.js';
+import { ActiveElement, Chart, ChartData, ChartEvent, ChartOptions } from 'chart.js';
 import { mergician } from 'mergician';
 import {
   getLineChartGroupedProData,
   getLineChartGroupedProOptions,
 } from '../LineChartGroupedPro/LineChartGroupedPro.utils';
+import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
+import { setColorAlpha } from '../../../../utils/color.utils';
+import { AreaChartProAreaClickArg, AreaChartProPointClickArg } from '../lines.types';
 
 export const getAreaChartProData = (
   props: {
@@ -21,9 +24,117 @@ export const getAreaChartProData = (
 
   return {
     ...data,
-    datasets: data.datasets.map((dataset) => ({ ...dataset, fill: true })),
+    datasets: data.datasets.map((dataset) => ({
+      ...dataset,
+      fill: true,
+      backgroundColor: setColorAlpha(dataset.backgroundColor as string, 0.9),
+    })),
   };
 };
+
+export const createAreaClickHandler =
+  ({
+    data,
+    dimension,
+    groupBy,
+    granularity,
+    onPointClicked,
+    onAreaClicked,
+  }: {
+    data: ChartData<'line'>;
+    dimension: Dimension;
+    groupBy: Dimension;
+    granularity?: Granularity;
+    onPointClicked?: (arg: AreaChartProPointClickArg) => void;
+    onAreaClicked?: (arg: AreaChartProAreaClickArg) => void;
+  }) =>
+  (event: ChartEvent, _elements: ActiveElement[], chart: Chart): void => {
+    if (!onPointClicked && !onAreaClicked) return;
+
+    const clickY = event.y;
+
+    const pointElements = chart.getElementsAtEventForMode(
+      event.native as Event,
+      'nearest',
+      { intersect: true },
+      false,
+    );
+
+    if (pointElements.length && onPointClicked) {
+      const clickedElement = pointElements[0]!;
+      const pointY = (
+        chart.getDatasetMeta(clickedElement.datasetIndex).data[clickedElement.index] as unknown as {
+          y: number;
+        }
+      ).y;
+
+      const isOnPoint = clickY == null || Math.abs(clickY - pointY) <= 8;
+
+      if (isOnPoint) {
+        const dimensionValue = data?.labels?.[clickedElement.index] as string | undefined;
+        const measureValue = (
+          data?.datasets?.[clickedElement.datasetIndex] as { data?: unknown[] } | undefined
+        )?.data?.[clickedElement.index] as number | undefined;
+
+        onPointClicked({
+          dimensionValue,
+          dimensionTimeRange: getTimeRangeFromDimensionValue({
+            value: dimensionValue,
+            stateGranularity: granularity,
+            dimension,
+          }),
+          measureValue,
+        });
+        return;
+      }
+    }
+
+    if (!onAreaClicked) return;
+
+    const clickX = event.x;
+    if (clickX == null || clickY == null) return;
+
+    const chartBottom =
+      (chart.chartArea as { bottom: number } | undefined)?.bottom ?? Number.MAX_VALUE;
+
+    const interpolateLineY = (datasetIndex: number): number | null => {
+      const points = chart.getDatasetMeta(datasetIndex).data as unknown as {
+        x: number;
+        y: number;
+      }[];
+      for (let j = 0; j < points.length - 1; j++) {
+        const p1 = points[j]!;
+        const p2 = points[j + 1]!;
+        if (p1.x <= clickX && p2.x >= clickX) {
+          const t = (clickX - p1.x) / (p2.x - p1.x);
+          return p1.y + t * (p2.y - p1.y);
+        }
+      }
+      const last = points[points.length - 1];
+      return last && last.x === clickX ? last.y : null;
+    };
+
+    const numDatasets = chart.data.datasets.length;
+    for (let i = numDatasets - 1; i >= 0; i--) {
+      const lineY = interpolateLineY(i);
+      const baseY = i > 0 ? interpolateLineY(i - 1) : chartBottom;
+      if (lineY == null || baseY == null) continue;
+      const top = Math.min(lineY, baseY);
+      const bottom = Math.max(lineY, baseY);
+      if (clickY >= top && clickY <= bottom) {
+        const groupingDimensionValue = (data?.datasets?.[i] as { rawLabel?: string } | undefined)
+          ?.rawLabel;
+        onAreaClicked({
+          groupingDimensionValue,
+          groupingDimensionTimeRange: getTimeRangeFromDimensionValue({
+            value: groupingDimensionValue,
+            dimension: groupBy,
+          }),
+        });
+        return;
+      }
+    }
+  };
 
 export const getAreaChartProOptions = (
   options: {

--- a/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
+++ b/src/components/charts/lines/AreaChartPro/AreaChartPro.utils.ts
@@ -32,6 +32,95 @@ export const getAreaChartProData = (
   };
 };
 
+type PixelPoint = { x: number; y: number };
+
+const getPixelPoints = (chart: Chart, datasetIndex: number): PixelPoint[] =>
+  chart.getDatasetMeta(datasetIndex).data;
+
+const interpolateLineY = (chart: Chart, datasetIndex: number, clickX: number): number | null => {
+  const points = getPixelPoints(chart, datasetIndex);
+  for (let i = 0; i < points.length - 1; i++) {
+    const left = points[i]!;
+    const right = points[i + 1]!;
+    if (left.x <= clickX && right.x >= clickX) {
+      const t = (clickX - left.x) / (right.x - left.x);
+      return left.y + t * (right.y - left.y);
+    }
+  }
+  const last = points.at(-1);
+  return last?.x === clickX ? last.y : null;
+};
+
+const handlePointClick = (
+  chart: Chart,
+  event: ChartEvent,
+  data: ChartData<'line'>,
+  dimension: Dimension,
+  granularity: Granularity | undefined,
+  onPointClicked: (arg: AreaChartProPointClickArg) => void,
+): boolean => {
+  const pointElements = chart.getElementsAtEventForMode(
+    event.native as Event,
+    'nearest',
+    { intersect: true },
+    false,
+  );
+  if (!pointElements.length) return false;
+
+  const clicked = pointElements[0]!;
+  const pointY = getPixelPoints(chart, clicked.datasetIndex)[clicked.index]?.y;
+  if (pointY == null) return false;
+
+  const isOnPoint = event.y == null || Math.abs(event.y - pointY) <= 8;
+  if (!isOnPoint) return false;
+
+  const dimensionValue = data?.labels?.[clicked.index] as string | undefined;
+  const measureValue = (data?.datasets?.[clicked.datasetIndex] as { data?: unknown[] })?.data?.[
+    clicked.index
+  ] as number | undefined;
+
+  onPointClicked({
+    dimensionValue,
+    dimensionTimeRange: getTimeRangeFromDimensionValue({
+      value: dimensionValue,
+      stateGranularity: granularity,
+      dimension,
+    }),
+    measureValue,
+  });
+  return true;
+};
+
+const handleAreaClick = (
+  chart: Chart,
+  event: ChartEvent,
+  data: ChartData<'line'>,
+  groupBy: Dimension,
+  onAreaClicked: (arg: AreaChartProAreaClickArg) => void,
+): void => {
+  const { x: clickX, y: clickY } = event;
+  if (clickX == null || clickY == null) return;
+
+  const chartBottom = chart.chartArea?.bottom ?? Infinity;
+
+  for (let i = chart.data.datasets.length - 1; i >= 0; i--) {
+    const lineY = interpolateLineY(chart, i, clickX);
+    const baseY = i > 0 ? interpolateLineY(chart, i - 1, clickX) : chartBottom;
+    if (lineY == null || baseY == null) continue;
+    if (clickY < Math.min(lineY, baseY) || clickY > Math.max(lineY, baseY)) continue;
+
+    const groupingDimensionValue = (data?.datasets?.[i] as { rawLabel?: string })?.rawLabel;
+    onAreaClicked({
+      groupingDimensionValue,
+      groupingDimensionTimeRange: getTimeRangeFromDimensionValue({
+        value: groupingDimensionValue,
+        dimension: groupBy,
+      }),
+    });
+    return;
+  }
+};
+
 export const createAreaClickHandler =
   ({
     data,
@@ -49,91 +138,12 @@ export const createAreaClickHandler =
     onAreaClicked?: (arg: AreaChartProAreaClickArg) => void;
   }) =>
   (event: ChartEvent, _elements: ActiveElement[], chart: Chart): void => {
-    if (!onPointClicked && !onAreaClicked) return;
-
-    const clickY = event.y;
-
-    const pointElements = chart.getElementsAtEventForMode(
-      event.native as Event,
-      'nearest',
-      { intersect: true },
-      false,
-    );
-
-    if (pointElements.length && onPointClicked) {
-      const clickedElement = pointElements[0]!;
-      const pointY = (
-        chart.getDatasetMeta(clickedElement.datasetIndex).data[clickedElement.index] as unknown as {
-          y: number;
-        }
-      ).y;
-
-      const isOnPoint = clickY == null || Math.abs(clickY - pointY) <= 8;
-
-      if (isOnPoint) {
-        const dimensionValue = data?.labels?.[clickedElement.index] as string | undefined;
-        const measureValue = (
-          data?.datasets?.[clickedElement.datasetIndex] as { data?: unknown[] } | undefined
-        )?.data?.[clickedElement.index] as number | undefined;
-
-        onPointClicked({
-          dimensionValue,
-          dimensionTimeRange: getTimeRangeFromDimensionValue({
-            value: dimensionValue,
-            stateGranularity: granularity,
-            dimension,
-          }),
-          measureValue,
-        });
-        return;
-      }
-    }
-
-    if (!onAreaClicked) return;
-
-    const clickX = event.x;
-    if (clickX == null || clickY == null) return;
-
-    const chartBottom =
-      (chart.chartArea as { bottom: number } | undefined)?.bottom ?? Number.MAX_VALUE;
-
-    const interpolateLineY = (datasetIndex: number): number | null => {
-      const points = chart.getDatasetMeta(datasetIndex).data as unknown as {
-        x: number;
-        y: number;
-      }[];
-      for (let j = 0; j < points.length - 1; j++) {
-        const p1 = points[j]!;
-        const p2 = points[j + 1]!;
-        if (p1.x <= clickX && p2.x >= clickX) {
-          const t = (clickX - p1.x) / (p2.x - p1.x);
-          return p1.y + t * (p2.y - p1.y);
-        }
-      }
-      const last = points[points.length - 1];
-      return last && last.x === clickX ? last.y : null;
-    };
-
-    const numDatasets = chart.data.datasets.length;
-    for (let i = numDatasets - 1; i >= 0; i--) {
-      const lineY = interpolateLineY(i);
-      const baseY = i > 0 ? interpolateLineY(i - 1) : chartBottom;
-      if (lineY == null || baseY == null) continue;
-      const top = Math.min(lineY, baseY);
-      const bottom = Math.max(lineY, baseY);
-      if (clickY >= top && clickY <= bottom) {
-        const groupingDimensionValue = (data?.datasets?.[i] as { rawLabel?: string } | undefined)
-          ?.rawLabel;
-        onAreaClicked({
-          groupingDimensionValue,
-          groupingDimensionTimeRange: getTimeRangeFromDimensionValue({
-            value: groupingDimensionValue,
-            dimension: groupBy,
-          }),
-        });
-        return;
-      }
-    }
+    if (
+      onPointClicked &&
+      handlePointClick(chart, event, data, dimension, granularity, onPointClicked)
+    )
+      return;
+    if (onAreaClicked) handleAreaClick(chart, event, data, groupBy, onAreaClicked);
   };
 
 export const getAreaChartProOptions = (

--- a/src/components/charts/lines/AreaChartPro/definition.ts
+++ b/src/components/charts/lines/AreaChartPro/definition.ts
@@ -1,4 +1,11 @@
-import { Granularity, Value } from '@embeddable.com/core';
+import {
+  DataResponse,
+  Dimension,
+  Granularity,
+  LoadDataRequest,
+  Value,
+  loadData,
+} from '@embeddable.com/core';
 import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 import Component from './index';
 import { LineChartGroupedProOptionsClickArg } from '../lines.types';
@@ -6,11 +13,40 @@ import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 import { ThemeClientContext } from '../../../../theme/theme.types';
 import { lineChartGroupedPro, LineChartGroupedProState } from '../LineChartGroupedPro/definition';
+import { getClientContextTimezone } from '../../../../theme/utils/clientContext.utils';
 
 const meta = {
   ...lineChartGroupedPro.meta,
   name: 'AreaChartPro',
   label: 'Area Chart',
+  events: [
+    {
+      name: 'onAreaClicked',
+      label: 'An area is clicked',
+      properties: [
+        {
+          name: 'axisDimensionValue',
+          label: 'Clicked axis dimension value',
+          type: 'string',
+        },
+        {
+          name: 'axisDimensionTimeRange',
+          label: 'Clicked axis dimension time range',
+          type: 'timeRange',
+        },
+        {
+          name: 'segmentDimensionValue',
+          label: 'Clicked segment dimension value',
+          type: 'string',
+        },
+        {
+          name: 'segmentDimensionTimeRange',
+          label: 'Clicked segment dimension time range',
+          type: 'timeRange',
+        },
+      ],
+    },
+  ],
 } as const satisfies EmbeddedComponentMeta;
 
 export type AreaChartProState = LineChartGroupedProState;
@@ -25,15 +61,29 @@ const previewConfig = {
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = lineChartGroupedPro.results.loadDataArgs;
-const loadDataResults = lineChartGroupedPro.results.loadData;
+const loadDataResultsArgs = (
+  inputs: Inputs<typeof meta>,
+  xAxis?: Dimension,
+  clientContext?: ThemeClientContext,
+): LoadDataRequest => ({
+  limit: inputs.maxResults,
+  from: inputs.dataset,
+  select: [xAxis ?? inputs.xAxis, inputs.groupBy, inputs.measure],
+  timezone: getClientContextTimezone(clientContext?.timezone),
+});
+
+const loadDataResults = (
+  inputs: Inputs<typeof meta>,
+  xAxis: Dimension,
+  clientContext: ThemeClientContext,
+): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, clientContext));
 
 const events = {
-  onLineClicked: (value: LineChartGroupedProOptionsClickArg) => ({
+  onAreaClicked: (value: LineChartGroupedProOptionsClickArg) => ({
     axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
     axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
-    groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
-    groupingDimensionTimeRange: value.groupingDimensionTimeRange ?? Value.noFilter(),
+    segmentDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
+    segmentDimensionTimeRange: value.groupingDimensionTimeRange ?? Value.noFilter(),
   }),
 };
 

--- a/src/components/charts/lines/AreaChartPro/definition.ts
+++ b/src/components/charts/lines/AreaChartPro/definition.ts
@@ -11,7 +11,6 @@ const meta = {
   ...lineChartDefaultPro.meta,
   name: 'AreaChartPro',
   label: 'Area Chart',
-  category: 'Line Charts',
 } as const satisfies EmbeddedComponentMeta;
 
 export type AreaChartProState = LineChartDefaultProState;

--- a/src/components/charts/lines/AreaChartPro/definition.ts
+++ b/src/components/charts/lines/AreaChartPro/definition.ts
@@ -12,8 +12,6 @@ const meta = {
   name: 'AreaChartPro',
   label: 'Area Chart',
   category: 'Line Charts',
-  inputs: [...lineChartDefaultPro.meta.inputs],
-  events: [...lineChartDefaultPro.meta.events],
 } as const satisfies EmbeddedComponentMeta;
 
 export type AreaChartProState = LineChartDefaultProState;

--- a/src/components/charts/lines/AreaChartPro/definition.ts
+++ b/src/components/charts/lines/AreaChartPro/definition.ts
@@ -1,0 +1,68 @@
+import { Granularity, Value } from '@embeddable.com/core';
+import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
+import Component from './index';
+import { LineChartProOptionsClickArg } from '../lines.types';
+import { previewData } from '../../../preview.data.constants';
+import { getDimensionWithGranularity } from '../../utils/granularity.utils';
+import { ThemeClientContext } from '../../../../theme/theme.types';
+import { lineChartDefaultPro, LineChartDefaultProState } from '../LineChartDefaultPro/definition';
+
+const meta = {
+  ...lineChartDefaultPro.meta,
+  name: 'AreaChartPro',
+  label: 'Area Chart',
+  category: 'Line Charts',
+  inputs: [...lineChartDefaultPro.meta.inputs],
+  events: [...lineChartDefaultPro.meta.events],
+} as const satisfies EmbeddedComponentMeta;
+
+export type AreaChartProState = LineChartDefaultProState;
+
+const previewConfig = {
+  xAxis: previewData.dimension,
+  measures: [previewData.measure],
+  results: previewData.results1Measure1Dimension,
+  hideMenu: true,
+};
+
+const preview = definePreview(Component, previewConfig);
+
+const loadDataResultsArgs = lineChartDefaultPro.results.loadDataArgs;
+const loadDataResults = lineChartDefaultPro.results.loadData;
+
+const events = {
+  onLineClicked: (value: LineChartProOptionsClickArg) => ({
+    axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
+    axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
+  }),
+};
+
+const props = (
+  inputs: Inputs<typeof meta>,
+  [state, setState]: [AreaChartProState, (state: AreaChartProState) => void],
+  clientContext: ThemeClientContext,
+) => {
+  const xAxisWithGranularity = getDimensionWithGranularity(inputs.xAxis, state?.granularity);
+
+  return {
+    ...inputs,
+    xAxis: xAxisWithGranularity,
+    setGranularity: (granularity: Granularity) => setState({ granularity }),
+    results: loadDataResults(inputs, xAxisWithGranularity, clientContext),
+  };
+};
+
+export const areaChartPro = {
+  Component,
+  meta,
+  preview,
+  previewConfig,
+  config: {
+    props,
+    events,
+  },
+  results: {
+    loadDataArgs: loadDataResultsArgs,
+    loadData: loadDataResults,
+  },
+} as const;

--- a/src/components/charts/lines/AreaChartPro/definition.ts
+++ b/src/components/charts/lines/AreaChartPro/definition.ts
@@ -8,7 +8,7 @@ import {
 } from '@embeddable.com/core';
 import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 import Component from './index';
-import { LineChartGroupedProOptionsClickArg } from '../lines.types';
+import { AreaChartProAreaClickArg, AreaChartProPointClickArg } from '../lines.types';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 import { ThemeClientContext } from '../../../../theme/theme.types';
@@ -25,6 +25,22 @@ const meta = {
       label: 'An area is clicked',
       properties: [
         {
+          name: 'segmentDimensionValue',
+          label: 'Clicked segment dimension value',
+          type: 'string',
+        },
+        {
+          name: 'segmentDimensionTimeRange',
+          label: 'Clicked segment dimension time range',
+          type: 'timeRange',
+        },
+      ],
+    },
+    {
+      name: 'onPointClicked',
+      label: 'A point is clicked',
+      properties: [
+        {
           name: 'axisDimensionValue',
           label: 'Clicked axis dimension value',
           type: 'string',
@@ -35,14 +51,9 @@ const meta = {
           type: 'timeRange',
         },
         {
-          name: 'segmentDimensionValue',
-          label: 'Clicked segment dimension value',
-          type: 'string',
-        },
-        {
-          name: 'segmentDimensionTimeRange',
-          label: 'Clicked segment dimension time range',
-          type: 'timeRange',
+          name: 'measureValue',
+          label: 'Clicked measure value',
+          type: 'number',
         },
       ],
     },
@@ -79,11 +90,14 @@ const loadDataResults = (
 ): DataResponse => loadData(loadDataResultsArgs(inputs, xAxis, clientContext));
 
 const events = {
-  onAreaClicked: (value: LineChartGroupedProOptionsClickArg) => ({
-    axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
-    axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
+  onAreaClicked: (value: AreaChartProAreaClickArg) => ({
     segmentDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
     segmentDimensionTimeRange: value.groupingDimensionTimeRange ?? Value.noFilter(),
+  }),
+  onPointClicked: (value: AreaChartProPointClickArg) => ({
+    axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
+    axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
+    measureValue: value.measureValue ?? Value.noFilter(),
   }),
 };
 

--- a/src/components/charts/lines/AreaChartPro/definition.ts
+++ b/src/components/charts/lines/AreaChartPro/definition.ts
@@ -1,36 +1,39 @@
 import { Granularity, Value } from '@embeddable.com/core';
 import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/react';
 import Component from './index';
-import { LineChartProOptionsClickArg } from '../lines.types';
+import { LineChartGroupedProOptionsClickArg } from '../lines.types';
 import { previewData } from '../../../preview.data.constants';
 import { getDimensionWithGranularity } from '../../utils/granularity.utils';
 import { ThemeClientContext } from '../../../../theme/theme.types';
-import { lineChartDefaultPro, LineChartDefaultProState } from '../LineChartDefaultPro/definition';
+import { lineChartGroupedPro, LineChartGroupedProState } from '../LineChartGroupedPro/definition';
 
 const meta = {
-  ...lineChartDefaultPro.meta,
+  ...lineChartGroupedPro.meta,
   name: 'AreaChartPro',
   label: 'Area Chart',
 } as const satisfies EmbeddedComponentMeta;
 
-export type AreaChartProState = LineChartDefaultProState;
+export type AreaChartProState = LineChartGroupedProState;
 
 const previewConfig = {
   xAxis: previewData.dimension,
-  measures: [previewData.measure],
-  results: previewData.results1Measure1Dimension,
+  groupBy: previewData.dimensionGroup,
+  measure: previewData.measure,
+  results: previewData.results1Measure2Dimensions,
   hideMenu: true,
 };
 
 const preview = definePreview(Component, previewConfig);
 
-const loadDataResultsArgs = lineChartDefaultPro.results.loadDataArgs;
-const loadDataResults = lineChartDefaultPro.results.loadData;
+const loadDataResultsArgs = lineChartGroupedPro.results.loadDataArgs;
+const loadDataResults = lineChartGroupedPro.results.loadData;
 
 const events = {
-  onLineClicked: (value: LineChartProOptionsClickArg) => ({
+  onLineClicked: (value: LineChartGroupedProOptionsClickArg) => ({
     axisDimensionValue: value.dimensionValue ?? Value.noFilter(),
     axisDimensionTimeRange: value.dimensionTimeRange ?? Value.noFilter(),
+    groupingDimensionValue: value.groupingDimensionValue ?? Value.noFilter(),
+    groupingDimensionTimeRange: value.groupingDimensionTimeRange ?? Value.noFilter(),
   }),
 };
 
@@ -44,6 +47,7 @@ const props = (
   return {
     ...inputs,
     xAxis: xAxisWithGranularity,
+    granularity: state?.granularity,
     setGranularity: (granularity: Granularity) => setState({ granularity }),
     results: loadDataResults(inputs, xAxisWithGranularity, clientContext),
   };

--- a/src/components/charts/lines/AreaChartPro/index.test.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.test.tsx
@@ -4,8 +4,11 @@ import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import AreaChartPro from './index';
 import type { AreaChartProProps } from './index';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
-import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
-import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
+import {
+  createAreaClickHandler,
+  getAreaChartProData,
+  getAreaChartProOptions,
+} from './AreaChartPro.utils';
 
 vi.mock('@embeddable.com/react', () => ({
   useTheme: vi.fn(() => ({})),
@@ -29,12 +32,8 @@ vi.mock('../../charts.fillGaps.hooks', () => ({
   useFillGaps: vi.fn(),
 }));
 
-let capturedLineChartProps: Record<string, unknown> = {};
 vi.mock('@embeddable.com/remarkable-ui', () => ({
-  LineChart: (props: Record<string, unknown>) => {
-    capturedLineChartProps = props;
-    return <div data-testid="line-chart" />;
-  },
+  LineChart: () => <div data-testid="line-chart" />,
 }));
 
 vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
@@ -46,10 +45,7 @@ vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', 
 vi.mock('./AreaChartPro.utils', () => ({
   getAreaChartProData: vi.fn(() => ({ datasets: [], labels: [] })),
   getAreaChartProOptions: vi.fn(() => ({})),
-}));
-
-vi.mock('../../../utils/dimension.utils', () => ({
-  getTimeRangeFromDimensionValue: vi.fn(() => undefined),
+  createAreaClickHandler: vi.fn(() => vi.fn()),
 }));
 
 const makeMeasure = (name = 'revenue'): Measure => ({ name, inputs: {} }) as unknown as Measure;
@@ -64,26 +60,13 @@ const defaultProps: AreaChartProProps = {
   results: emptyResults,
 };
 
-const makeElement = (index: number, datasetIndex: number, y: number) => ({
-  index,
-  datasetIndex,
-  element: { y },
-});
-
-const makeEvent = (offsetY: number | null) => ({
-  native: offsetY != null ? { offsetY } : null,
-});
-
-const getOnClick = () =>
-  (capturedLineChartProps.options as { onClick: (...args: unknown[]) => void }).onClick;
-
 describe('AreaChartPro', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    capturedLineChartProps = {};
     vi.mocked(useFillGaps).mockReturnValue(emptyResults);
     vi.mocked(getAreaChartProData).mockReturnValue({ datasets: [], labels: [] } as never);
     vi.mocked(getAreaChartProOptions).mockReturnValue({} as never);
+    vi.mocked(createAreaClickHandler).mockReturnValue(vi.fn());
   });
 
   describe('rendering', () => {
@@ -162,6 +145,30 @@ describe('AreaChartPro', () => {
     });
   });
 
+  describe('createAreaClickHandler', () => {
+    it('is called with dimension, groupBy, granularity, onPointClicked, and onAreaClicked', () => {
+      const onPointClicked = vi.fn();
+      const onAreaClicked = vi.fn();
+      render(
+        <AreaChartPro
+          {...defaultProps}
+          granularity="month"
+          onPointClicked={onPointClicked}
+          onAreaClicked={onAreaClicked}
+        />,
+      );
+      expect(vi.mocked(createAreaClickHandler)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dimension: defaultProps.xAxis,
+          groupBy: defaultProps.groupBy,
+          granularity: 'month',
+          onPointClicked,
+          onAreaClicked,
+        }),
+      );
+    });
+  });
+
   describe('granularity selector', () => {
     it('renders ChartGranularitySelectField when setGranularity is provided', () => {
       render(<AreaChartPro {...defaultProps} setGranularity={vi.fn()} />);
@@ -203,84 +210,6 @@ describe('AreaChartPro', () => {
         'data-has-margin-top',
         'false',
       );
-    });
-  });
-
-  describe('handleAreaClick', () => {
-    const chartData = {
-      labels: ['Jan', 'Feb', 'Mar'],
-      datasets: [
-        { rawLabel: 'Group A', data: [100, 200, 300] },
-        { rawLabel: 'Group B', data: [50, 75, 90] },
-      ],
-    };
-
-    beforeEach(() => {
-      vi.mocked(getAreaChartProData).mockReturnValue(chartData as never);
-    });
-
-    it('does not call onAreaClicked when elements is empty', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()(makeEvent(100), []);
-      expect(onAreaClicked).not.toHaveBeenCalled();
-    });
-
-    it('does not call onAreaClicked when it is not provided', () => {
-      render(<AreaChartPro {...defaultProps} />);
-      expect(() => getOnClick()(makeEvent(100), [makeElement(0, 0, 50)])).not.toThrow();
-    });
-
-    it('selects the element with the highest y at or below clickY', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()(makeEvent(70), [makeElement(0, 0, 30), makeElement(0, 1, 60)]);
-      expect(onAreaClicked).toHaveBeenCalledWith(
-        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
-      );
-    });
-
-    it('falls back to elements[0] when no element is at or below clickY', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()(makeEvent(10), [makeElement(1, 0, 50), makeElement(1, 1, 70)]);
-      expect(onAreaClicked).toHaveBeenCalledWith(
-        expect.objectContaining({ groupingDimensionValue: 'Group A' }),
-      );
-    });
-
-    it('uses all elements when clickY is null', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()({ native: null }, [makeElement(0, 0, 30), makeElement(0, 1, 80)]);
-      expect(onAreaClicked).toHaveBeenCalledWith(
-        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
-      );
-    });
-
-    it('passes dimensionValue from labels at element.index', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()(makeEvent(100), [makeElement(1, 0, 50)]);
-      expect(onAreaClicked).toHaveBeenCalledWith(
-        expect.objectContaining({ dimensionValue: 'Feb' }),
-      );
-    });
-
-    it('passes groupingDimensionValue from dataset.rawLabel at element.datasetIndex', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()(makeEvent(100), [makeElement(0, 1, 50)]);
-      expect(onAreaClicked).toHaveBeenCalledWith(
-        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
-      );
-    });
-
-    it('calls getTimeRangeFromDimensionValue for both dimension and grouping dimension', () => {
-      const onAreaClicked = vi.fn();
-      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
-      getOnClick()(makeEvent(100), [makeElement(0, 0, 50)]);
-      expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/components/charts/lines/AreaChartPro/index.test.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.test.tsx
@@ -1,0 +1,286 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import AreaChartPro from './index';
+import type { AreaChartProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
+import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart-card">{children}</div>
+  ),
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+let capturedLineChartProps: Record<string, unknown> = {};
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  LineChart: (props: Record<string, unknown>) => {
+    capturedLineChartProps = props;
+    return <div data-testid="line-chart" />;
+  },
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: ({ hasMarginTop }: { hasMarginTop?: boolean }) => (
+    <div data-testid="granularity-select-field" data-has-margin-top={String(hasMarginTop)} />
+  ),
+}));
+
+vi.mock('./AreaChartPro.utils', () => ({
+  getAreaChartProData: vi.fn(() => ({ datasets: [], labels: [] })),
+  getAreaChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../utils/dimension.utils', () => ({
+  getTimeRangeFromDimensionValue: vi.fn(() => undefined),
+}));
+
+const makeMeasure = (name = 'revenue'): Measure => ({ name, inputs: {} }) as unknown as Measure;
+const makeDimension = (name = 'date'): Dimension => ({ name, inputs: {} }) as unknown as Dimension;
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+
+const defaultProps: AreaChartProProps = {
+  xAxis: makeDimension(),
+  groupBy: makeDimension('category'),
+  measure: makeMeasure(),
+  results: emptyResults,
+};
+
+const makeElement = (index: number, datasetIndex: number, y: number) => ({
+  index,
+  datasetIndex,
+  element: { y },
+});
+
+const makeEvent = (offsetY: number | null) => ({
+  native: offsetY != null ? { offsetY } : null,
+});
+
+const getOnClick = () =>
+  (capturedLineChartProps.options as { onClick: (...args: unknown[]) => void }).onClick;
+
+describe('AreaChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedLineChartProps = {};
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+    vi.mocked(getAreaChartProData).mockReturnValue({ datasets: [], labels: [] } as never);
+    vi.mocked(getAreaChartProOptions).mockReturnValue({} as never);
+  });
+
+  describe('rendering', () => {
+    it('renders ChartCard and LineChart', () => {
+      render(<AreaChartPro {...defaultProps} />);
+      expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+      expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+    });
+  });
+
+  describe('useFillGaps', () => {
+    it('is called with results and xAxis', () => {
+      render(<AreaChartPro {...defaultProps} />);
+      expect(useFillGaps).toHaveBeenCalledWith({
+        results: defaultProps.results,
+        dimension: defaultProps.xAxis,
+      });
+    });
+  });
+
+  describe('getAreaChartProData', () => {
+    it('is called with xAxis, groupBy, measure, and data from useFillGaps', () => {
+      const filledResults = { ...emptyResults, data: [{ date: 'Jan' }] };
+      vi.mocked(useFillGaps).mockReturnValue(filledResults as never);
+      render(<AreaChartPro {...defaultProps} />);
+      expect(vi.mocked(getAreaChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dimension: defaultProps.xAxis,
+          groupDimension: defaultProps.groupBy,
+          measure: defaultProps.measure,
+          data: filledResults.data,
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('passes hasMinMaxYAxisRange=true when yAxisRangeMin is provided', () => {
+      render(<AreaChartPro {...defaultProps} yAxisRangeMin={0} />);
+      expect(vi.mocked(getAreaChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({ hasMinMaxYAxisRange: true }),
+        expect.anything(),
+      );
+    });
+
+    it('passes hasMinMaxYAxisRange=true when yAxisRangeMax is provided', () => {
+      render(<AreaChartPro {...defaultProps} yAxisRangeMax={100} />);
+      expect(vi.mocked(getAreaChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({ hasMinMaxYAxisRange: true }),
+        expect.anything(),
+      );
+    });
+
+    it('passes hasMinMaxYAxisRange=false when neither range prop is provided', () => {
+      render(<AreaChartPro {...defaultProps} />);
+      expect(vi.mocked(getAreaChartProData)).toHaveBeenCalledWith(
+        expect.objectContaining({ hasMinMaxYAxisRange: false }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('getAreaChartProOptions', () => {
+    it('is called with xAxis, groupBy, measure, and chart data', () => {
+      const chartData = { datasets: [{ data: [1] }], labels: ['Jan'] };
+      vi.mocked(getAreaChartProData).mockReturnValue(chartData as never);
+      render(<AreaChartPro {...defaultProps} />);
+      expect(vi.mocked(getAreaChartProOptions)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dimension: defaultProps.xAxis,
+          groupDimension: defaultProps.groupBy,
+          measure: defaultProps.measure,
+          data: chartData,
+        }),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('granularity selector', () => {
+    it('renders ChartGranularitySelectField when setGranularity is provided', () => {
+      render(<AreaChartPro {...defaultProps} setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toBeInTheDocument();
+    });
+
+    it('does not render ChartGranularitySelectField when setGranularity is not provided', () => {
+      render(<AreaChartPro {...defaultProps} />);
+      expect(screen.queryByTestId('granularity-select-field')).not.toBeInTheDocument();
+    });
+
+    it('passes hasMarginTop=true when title, description, and tooltip are all absent', () => {
+      render(<AreaChartPro {...defaultProps} setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'true',
+      );
+    });
+
+    it('passes hasMarginTop=false when title is present', () => {
+      render(<AreaChartPro {...defaultProps} title="My Chart" setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'false',
+      );
+    });
+
+    it('passes hasMarginTop=false when description is present', () => {
+      render(<AreaChartPro {...defaultProps} description="Some desc" setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'false',
+      );
+    });
+
+    it('passes hasMarginTop=false when tooltip is present', () => {
+      render(<AreaChartPro {...defaultProps} tooltip="Tip" setGranularity={vi.fn()} />);
+      expect(screen.getByTestId('granularity-select-field')).toHaveAttribute(
+        'data-has-margin-top',
+        'false',
+      );
+    });
+  });
+
+  describe('handleAreaClick', () => {
+    const chartData = {
+      labels: ['Jan', 'Feb', 'Mar'],
+      datasets: [
+        { rawLabel: 'Group A', data: [100, 200, 300] },
+        { rawLabel: 'Group B', data: [50, 75, 90] },
+      ],
+    };
+
+    beforeEach(() => {
+      vi.mocked(getAreaChartProData).mockReturnValue(chartData as never);
+    });
+
+    it('does not call onAreaClicked when elements is empty', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()(makeEvent(100), []);
+      expect(onAreaClicked).not.toHaveBeenCalled();
+    });
+
+    it('does not call onAreaClicked when it is not provided', () => {
+      render(<AreaChartPro {...defaultProps} />);
+      expect(() => getOnClick()(makeEvent(100), [makeElement(0, 0, 50)])).not.toThrow();
+    });
+
+    it('selects the element with the highest y at or below clickY', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()(makeEvent(70), [makeElement(0, 0, 30), makeElement(0, 1, 60)]);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('falls back to elements[0] when no element is at or below clickY', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()(makeEvent(10), [makeElement(1, 0, 50), makeElement(1, 1, 70)]);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group A' }),
+      );
+    });
+
+    it('uses all elements when clickY is null', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()({ native: null }, [makeElement(0, 0, 30), makeElement(0, 1, 80)]);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('passes dimensionValue from labels at element.index', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()(makeEvent(100), [makeElement(1, 0, 50)]);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ dimensionValue: 'Feb' }),
+      );
+    });
+
+    it('passes groupingDimensionValue from dataset.rawLabel at element.datasetIndex', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()(makeEvent(100), [makeElement(0, 1, 50)]);
+      expect(onAreaClicked).toHaveBeenCalledWith(
+        expect.objectContaining({ groupingDimensionValue: 'Group B' }),
+      );
+    });
+
+    it('calls getTimeRangeFromDimensionValue for both dimension and grouping dimension', () => {
+      const onAreaClicked = vi.fn();
+      render(<AreaChartPro {...defaultProps} onAreaClicked={onAreaClicked} />);
+      getOnClick()(makeEvent(100), [makeElement(0, 0, 50)]);
+      expect(getTimeRangeFromDimensionValue).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -67,10 +67,10 @@ const AreaChartPro = (props: AreaChartProProps) => {
     onAreaClicked,
   });
 
-  const options = {
-    ...getAreaChartProOptions({ data, dimension: xAxis, groupDimension: groupBy, measure }, theme),
-    onClick: handleClick,
-  };
+  const options = getAreaChartProOptions(
+    { data, dimension: xAxis, groupDimension: groupBy, measure },
+    theme,
+  );
 
   const granularitySelectorHasMarginTop = !title && !description && !tooltip;
 
@@ -103,6 +103,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
         yAxisRangeMax={yAxisRangeMax}
         yAxisRangeMin={yAxisRangeMin}
         options={options}
+        onClick={handleClick}
       />
     </ChartCard>
   );

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -4,16 +4,19 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
 import { ChartCard } from '../../shared/ChartCard/ChartCard';
 import { LineChartGroupedProProp } from '../LineChartGroupedPro';
-import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
+import {
+  createAreaClickHandler,
+  getAreaChartProData,
+  getAreaChartProOptions,
+} from './AreaChartPro.utils';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
-import { LineChartGroupedProOptionsClickArg } from '../lines.types';
+import { AreaChartProAreaClickArg, AreaChartProPointClickArg } from '../lines.types';
 import { LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
-import { ActiveElement, ChartEvent } from 'chart.js';
 
 export type AreaChartProProps = Omit<LineChartGroupedProProp, 'onLineClicked'> & {
-  onAreaClicked?: (arg: LineChartGroupedProOptionsClickArg) => void;
+  onPointClicked?: (arg: AreaChartProPointClickArg) => void;
+  onAreaClicked?: (arg: AreaChartProAreaClickArg) => void;
 };
 
 const AreaChartPro = (props: AreaChartProProps) => {
@@ -35,6 +38,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
     yAxisRangeMin,
     granularity,
     setGranularity,
+    onPointClicked,
     onAreaClicked,
   } = props;
 
@@ -54,42 +58,17 @@ const AreaChartPro = (props: AreaChartProProps) => {
     theme,
   );
 
-  const handleAreaClick = (event: ChartEvent, elements: ActiveElement[]) => {
-    if (!elements.length || !onAreaClicked) return;
-    const clickY = (event.native as MouseEvent | null)?.offsetY;
-
-    const qualifying = clickY != null ? elements.filter((el) => el.element.y <= clickY) : elements;
-    const element =
-      qualifying.reduce<ActiveElement | undefined>(
-        (max, el) => (!max || el.element.y > max.element.y ? el : max),
-        undefined,
-      ) ?? elements[0]!;
-
-    const dimensionValue = data?.labels?.[element.index] as string | undefined;
-    const groupingDimensionValue = (
-      data?.datasets?.[element.datasetIndex] as { rawLabel?: string } | undefined
-    )?.rawLabel;
-
-    const clickArg: LineChartGroupedProOptionsClickArg = {
-      dimensionValue,
-      dimensionTimeRange: getTimeRangeFromDimensionValue({
-        value: dimensionValue,
-        stateGranularity: granularity,
-        dimension: xAxis,
-      }),
-      groupingDimensionValue,
-      groupingDimensionTimeRange: getTimeRangeFromDimensionValue({
-        value: groupingDimensionValue,
-        dimension: groupBy,
-      }),
-    };
-    onAreaClicked(clickArg);
-  };
-
   const options = {
     ...getAreaChartProOptions({ data, dimension: xAxis, groupDimension: groupBy, measure }, theme),
     interaction: { mode: 'index' as const, intersect: false },
-    onClick: handleAreaClick,
+    onClick: createAreaClickHandler({
+      data,
+      dimension: xAxis,
+      groupBy,
+      granularity,
+      onPointClicked,
+      onAreaClicked,
+    }),
   };
 
   const granularitySelectorHasMarginTop = !title && !description && !tooltip;

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -58,17 +58,18 @@ const AreaChartPro = (props: AreaChartProProps) => {
     theme,
   );
 
+  const handleClick = createAreaClickHandler({
+    data,
+    dimension: xAxis,
+    groupBy,
+    granularity,
+    onPointClicked,
+    onAreaClicked,
+  });
+
   const options = {
     ...getAreaChartProOptions({ data, dimension: xAxis, groupDimension: groupBy, measure }, theme),
-    interaction: { mode: 'index' as const, intersect: false },
-    onClick: createAreaClickHandler({
-      data,
-      dimension: xAxis,
-      groupBy,
-      granularity,
-      onPointClicked,
-      onAreaClicked,
-    }),
+    onClick: handleClick,
   };
 
   const granularitySelectorHasMarginTop = !title && !description && !tooltip;

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -27,7 +27,7 @@ export type AreaChartProProps = {
   yAxisRangeMin?: number;
   granularity?: Granularity;
   setGranularity?: (granularity: Granularity) => void;
-  onLineClicked?: (arg: LineChartGroupedProOptionsClickArg) => void;
+  onAreaClicked?: (arg: LineChartGroupedProOptionsClickArg) => void;
 } & ChartCardHeaderProps;
 
 const AreaChartPro = (props: AreaChartProProps) => {
@@ -49,7 +49,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
     yAxisRangeMin,
     granularity,
     setGranularity,
-    onLineClicked,
+    onAreaClicked,
   } = props;
 
   const results = useFillGaps({
@@ -74,13 +74,22 @@ const AreaChartPro = (props: AreaChartProProps) => {
 
   const granularitySelectorHasMarginTop = !title && !description && !tooltip;
 
-  const handleClick = createGroupedClickHandler({
+  const groupedClickHandler = createGroupedClickHandler({
     data,
     dimension: xAxis,
     groupBy,
     granularity,
-    onClicked: onLineClicked,
+    onClicked: (value) => {
+      console.log('[AreaChartPro] onAreaClicked', value);
+      onAreaClicked?.(value);
+    },
   });
+
+  const handleClick: typeof groupedClickHandler = (args) =>
+    groupedClickHandler({
+      ...args,
+      elementAtEvent: args.elementAtEvent.length ? args.elementAtEvent : args.elementsAtEvent,
+    });
 
   return (
     <ChartCard

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -6,14 +6,15 @@ import { resolveI18nProps } from '../../../component.utils';
 import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
-import { LineChartProOptionsClick } from '../lines.types';
+import { LineChartGroupedProOptionsClickArg } from '../lines.types';
 import { LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { createSimpleClickHandler } from '../../charts.utils';
+import { createGroupedClickHandler } from '../../charts.utils';
 
 export type AreaChartProProps = {
   xAxis: Dimension;
-  measures: Measure[];
+  groupBy: Dimension;
+  measure: Measure;
   results: DataResponse;
   reverseXAxis?: boolean;
   showLegend?: boolean;
@@ -26,7 +27,7 @@ export type AreaChartProProps = {
   yAxisRangeMin?: number;
   granularity?: Granularity;
   setGranularity?: (granularity: Granularity) => void;
-  onLineClicked?: LineChartProOptionsClick;
+  onLineClicked?: (arg: LineChartGroupedProOptionsClickArg) => void;
 } & ChartCardHeaderProps;
 
 const AreaChartPro = (props: AreaChartProProps) => {
@@ -36,9 +37,9 @@ const AreaChartPro = (props: AreaChartProProps) => {
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
-    measures,
-    granularity,
+    measure,
     xAxis,
+    groupBy,
     reverseXAxis,
     showLegend,
     showLogarithmicScale,
@@ -46,6 +47,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
     showValueLabels,
     yAxisRangeMax,
     yAxisRangeMin,
+    granularity,
     setGranularity,
     onLineClicked,
   } = props;
@@ -59,18 +61,23 @@ const AreaChartPro = (props: AreaChartProProps) => {
     {
       data: results.data,
       dimension: xAxis,
-      measures,
+      groupDimension: groupBy,
+      measure,
       hasMinMaxYAxisRange: Boolean(yAxisRangeMin != null || yAxisRangeMax != null),
     },
     theme,
   );
-  const options = getAreaChartProOptions({ data, dimension: xAxis, measures }, theme);
+  const options = getAreaChartProOptions(
+    { data, dimension: xAxis, groupDimension: groupBy, measure },
+    theme,
+  );
 
   const granularitySelectorHasMarginTop = !title && !description && !tooltip;
 
-  const handleClick = createSimpleClickHandler({
+  const handleClick = createGroupedClickHandler({
     data,
     dimension: xAxis,
+    groupBy,
     granularity,
     onClicked: onLineClicked,
   });
@@ -78,7 +85,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
   return (
     <ChartCard
       data={results}
-      dimensionsAndMeasures={[...measures, xAxis]}
+      dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
       description={description}
       title={title}

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -1,0 +1,113 @@
+import { useTheme } from '@embeddable.com/react';
+import { Theme } from '../../../../theme/theme.types';
+import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
+import { i18nSetup } from '../../../../theme/i18n/i18n';
+import { resolveI18nProps } from '../../../component.utils';
+import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+import { LineChartProOptionsClick } from '../lines.types';
+import { LineChart } from '@embeddable.com/remarkable-ui';
+import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
+import { createSimpleClickHandler } from '../../charts.utils';
+
+export type AreaChartProProps = {
+  xAxis: Dimension;
+  measures: Measure[];
+  results: DataResponse;
+  reverseXAxis?: boolean;
+  showLegend?: boolean;
+  showLogarithmicScale?: boolean;
+  showTooltips?: boolean;
+  showValueLabels?: boolean;
+  xAxisLabel?: string;
+  yAxisLabel?: string;
+  yAxisRangeMax?: number;
+  yAxisRangeMin?: number;
+  granularity?: Granularity;
+  setGranularity?: (granularity: Granularity) => void;
+  onLineClicked?: LineChartProOptionsClick;
+} & ChartCardHeaderProps;
+
+const AreaChartPro = (props: AreaChartProProps) => {
+  const theme: Theme = useTheme() as Theme;
+  i18nSetup(theme);
+
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const {
+    hideMenu,
+    measures,
+    granularity,
+    xAxis,
+    reverseXAxis,
+    showLegend,
+    showLogarithmicScale,
+    showTooltips,
+    showValueLabels,
+    yAxisRangeMax,
+    yAxisRangeMin,
+    setGranularity,
+    onLineClicked,
+  } = props;
+
+  const results = useFillGaps({
+    results: props.results,
+    dimension: xAxis,
+  });
+
+  const data = getAreaChartProData(
+    {
+      data: results.data,
+      dimension: xAxis,
+      measures,
+      hasMinMaxYAxisRange: Boolean(yAxisRangeMin != null || yAxisRangeMax != null),
+    },
+    theme,
+  );
+  const options = getAreaChartProOptions({ data, dimension: xAxis, measures }, theme);
+
+  const granularitySelectorHasMarginTop = !title && !description && !tooltip;
+
+  const handleClick = createSimpleClickHandler({
+    data,
+    dimension: xAxis,
+    granularity,
+    onClicked: onLineClicked,
+  });
+
+  return (
+    <ChartCard
+      data={results}
+      dimensionsAndMeasures={[...measures, xAxis]}
+      errorMessage={results.error}
+      description={description}
+      title={title}
+      tooltip={tooltip}
+      hideMenu={hideMenu}
+    >
+      {setGranularity && (
+        <ChartGranularitySelectField
+          hasMarginTop={granularitySelectorHasMarginTop}
+          dimension={xAxis}
+          onChange={setGranularity}
+        />
+      )}
+      <LineChart
+        data={data}
+        reverseXAxis={reverseXAxis}
+        showLegend={showLegend}
+        showLogarithmicScale={showLogarithmicScale}
+        showTooltips={showTooltips}
+        showValueLabels={showValueLabels}
+        xAxisLabel={xAxisLabel}
+        yAxisLabel={yAxisLabel}
+        yAxisRangeMax={yAxisRangeMax}
+        yAxisRangeMin={yAxisRangeMin}
+        options={options}
+        onClick={handleClick}
+      />
+    </ChartCard>
+  );
+};
+
+export default AreaChartPro;

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -1,9 +1,9 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
-import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { LineChartGroupedProProp } from '../LineChartGroupedPro';
 import { getAreaChartProData, getAreaChartProOptions } from './AreaChartPro.utils';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { LineChartGroupedProOptionsClickArg } from '../lines.types';
@@ -12,24 +12,9 @@ import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelect
 import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
 import { ActiveElement, ChartEvent } from 'chart.js';
 
-export type AreaChartProProps = {
-  xAxis: Dimension;
-  groupBy: Dimension;
-  measure: Measure;
-  results: DataResponse;
-  reverseXAxis?: boolean;
-  showLegend?: boolean;
-  showLogarithmicScale?: boolean;
-  showTooltips?: boolean;
-  showValueLabels?: boolean;
-  xAxisLabel?: string;
-  yAxisLabel?: string;
-  yAxisRangeMax?: number;
-  yAxisRangeMin?: number;
-  granularity?: Granularity;
-  setGranularity?: (granularity: Granularity) => void;
+export type AreaChartProProps = Omit<LineChartGroupedProProp, 'onLineClicked'> & {
   onAreaClicked?: (arg: LineChartGroupedProOptionsClickArg) => void;
-} & ChartCardHeaderProps;
+};
 
 const AreaChartPro = (props: AreaChartProProps) => {
   const theme: Theme = useTheme() as Theme;

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -9,7 +9,8 @@ import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { LineChartGroupedProOptionsClickArg } from '../lines.types';
 import { LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
-import { createGroupedClickHandler } from '../../charts.utils';
+import { getTimeRangeFromDimensionValue } from '../../../utils/dimension.utils';
+import { ActiveElement, ChartEvent } from 'chart.js';
 
 export type AreaChartProProps = {
   xAxis: Dimension;
@@ -67,26 +68,46 @@ const AreaChartPro = (props: AreaChartProProps) => {
     },
     theme,
   );
-  const options = getAreaChartProOptions(
-    { data, dimension: xAxis, groupDimension: groupBy, measure },
-    theme,
-  );
+
+  const handleAreaClick = (event: ChartEvent, elements: ActiveElement[]) => {
+    if (!elements.length || !onAreaClicked) return;
+    const clickY = (event.native as MouseEvent | null)?.offsetY;
+
+    const qualifying = clickY != null ? elements.filter((el) => el.element.y <= clickY) : elements;
+    const element =
+      qualifying.reduce<ActiveElement | undefined>(
+        (max, el) => (!max || el.element.y > max.element.y ? el : max),
+        undefined,
+      ) ?? elements[0]!;
+
+    const dimensionValue = data?.labels?.[element.index] as string | undefined;
+    const groupingDimensionValue = (
+      data?.datasets?.[element.datasetIndex] as { rawLabel?: string } | undefined
+    )?.rawLabel;
+
+    const clickArg: LineChartGroupedProOptionsClickArg = {
+      dimensionValue,
+      dimensionTimeRange: getTimeRangeFromDimensionValue({
+        value: dimensionValue,
+        stateGranularity: granularity,
+        dimension: xAxis,
+      }),
+      groupingDimensionValue,
+      groupingDimensionTimeRange: getTimeRangeFromDimensionValue({
+        value: groupingDimensionValue,
+        dimension: groupBy,
+      }),
+    };
+    onAreaClicked(clickArg);
+  };
+
+  const options = {
+    ...getAreaChartProOptions({ data, dimension: xAxis, groupDimension: groupBy, measure }, theme),
+    interaction: { mode: 'index' as const, intersect: false },
+    onClick: handleAreaClick,
+  };
 
   const granularitySelectorHasMarginTop = !title && !description && !tooltip;
-
-  const groupedClickHandler = createGroupedClickHandler({
-    data,
-    dimension: xAxis,
-    groupBy,
-    granularity,
-    onClicked: onAreaClicked,
-  });
-
-  const handleClick: typeof groupedClickHandler = (args) =>
-    groupedClickHandler({
-      ...args,
-      elementAtEvent: args.elementAtEvent.length ? args.elementAtEvent : args.elementsAtEvent,
-    });
 
   return (
     <ChartCard
@@ -117,7 +138,6 @@ const AreaChartPro = (props: AreaChartProProps) => {
         yAxisRangeMax={yAxisRangeMax}
         yAxisRangeMin={yAxisRangeMin}
         options={options}
-        onClick={handleClick}
       />
     </ChartCard>
   );

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -79,10 +79,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
     dimension: xAxis,
     groupBy,
     granularity,
-    onClicked: (value) => {
-      console.log('[AreaChartPro] onAreaClicked', value);
-      onAreaClicked?.(value);
-    },
+    onClicked: onAreaClicked,
   });
 
   const handleClick: typeof groupedClickHandler = (args) =>

--- a/src/components/charts/lines/lines.types.ts
+++ b/src/components/charts/lines/lines.types.ts
@@ -12,4 +12,15 @@ export type LineChartGroupedProOptionsClickArg = {
   groupingDimensionTimeRange: TimeRange | undefined;
 };
 
+export type AreaChartProPointClickArg = {
+  dimensionValue: string | number | undefined;
+  dimensionTimeRange: TimeRange | undefined;
+  measureValue: number | undefined;
+};
+
+export type AreaChartProAreaClickArg = {
+  groupingDimensionValue: string | boolean | undefined;
+  groupingDimensionTimeRange: TimeRange | undefined;
+};
+
 export type LineChartProOptionsClick = (arg: LineChartProOptionsClickArg) => void;

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,10 @@ export * from './components/charts/kpis/KpiChartNumberPro/definition';
 export * from './components/charts/kpis/KpiChartNumberComparisonPro/definition';
 
 // Charts - Lines
+export * as AreaChartPro from './components/charts/lines/AreaChartPro';
+export type { AreaChartProProps } from './components/charts/lines/AreaChartPro';
+export * from './components/charts/lines/AreaChartPro/AreaChartPro.utils';
+export * from './components/charts/lines/AreaChartPro/definition';
 export * as LineChartDefaultPro from './components/charts/lines/LineChartDefaultPro';
 export type {
   LineChartProProps,

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -45,6 +45,7 @@ export type ThemeCharts = {
   lineChartGroupedPro?: { options: Partial<ChartOptions<'line'>> };
   lineChartComparisonDefaultPro?: { options: Partial<ChartOptions<'line'>> };
   barLineChartPro?: { options: Partial<ChartOptions<'bar'>> };
+  areaChartDefaultPro?: { options: Partial<ChartOptions<'line'>> };
   scatterChartPro?: { options: Partial<ChartOptions<'scatter'>> };
   bubbleChartPro?: { options: Partial<ChartOptions<'bubble'>> };
 };

--- a/src/theme/theme.types.ts
+++ b/src/theme/theme.types.ts
@@ -45,7 +45,7 @@ export type ThemeCharts = {
   lineChartGroupedPro?: { options: Partial<ChartOptions<'line'>> };
   lineChartComparisonDefaultPro?: { options: Partial<ChartOptions<'line'>> };
   barLineChartPro?: { options: Partial<ChartOptions<'bar'>> };
-  areaChartDefaultPro?: { options: Partial<ChartOptions<'line'>> };
+  areaChartPro?: { options: Partial<ChartOptions<'line'>> };
   scatterChartPro?: { options: Partial<ChartOptions<'scatter'>> };
   bubbleChartPro?: { options: Partial<ChartOptions<'bubble'>> };
 };


### PR DESCRIPTION
# Why is this pull-request needed?
We need AreaChart component.

# Main changes
Added AreaChart component.

# Test evidence


https://github.com/user-attachments/assets/3b36c0a1-ed71-42dd-9171-423ba0d680b5



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced AreaChartPro, a new area-based chart visualization component that displays data as stacked areas, providing clear insights into composition and trends over time
  * Enables interactive click handling for filtering and exploring specific dimension values within the visualization
  * Supports dynamic granularity adjustments to customize time-based data aggregation and visualization detail levels
  * Includes comprehensive theme customization options for styling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->