### PR TITLE
RUI-281 | Filter builder improvements

### DIFF
--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderTextValueField.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderTextValueField.tsx
@@ -24,6 +24,9 @@ const FilterBuilderTextValueField = ({
   }, [value, debouncedSelectValue]);
 
   useEffect(() => {
+    // Don't auto-focus if the field already has a value — this means it was restored
+    // from saved state (e.g. page reload), not freshly selected by the user.
+    if (filter.value != null) return;
     setTimeout(() => {
       inputRef.current?.focus();
     }, 100);

--- a/src/components/editors/FilterBuilderPro/index.tsx
+++ b/src/components/editors/FilterBuilderPro/index.tsx
@@ -102,7 +102,12 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
     ro.observe(el);
     el.addEventListener('scroll', updateScrollState);
     updateScrollState();
+    // Run again after a short delay to catch layout updates that haven't settled yet
+    // (e.g. when filters reload from saved state, item widths may not be fully computed
+    // by the time the synchronous call above executes).
+    const timeoutId = setTimeout(updateScrollState, 50);
     return () => {
+      clearTimeout(timeoutId);
       ro.disconnect();
       el.removeEventListener('scroll', updateScrollState);
     };


### PR DESCRIPTION
## Summary

Fixes two bugs in `FilterBuilderPro` reported by Casino Cash Trac.

---

### Bug 1 — Right edge cut off after filters reload

**Root cause:** When saved filters are restored via `defaultFilters`, `updateScrollState()` was being called synchronously inside a `useEffect`. In some cases the browser hadn't finished laying out the newly-rendered filter items at that point, so `scrollWidth` read as equal to (or less than) `clientWidth`. This caused `canScrollRight` to stay `false` — no scroll indicator was rendered and the rightmost filter was silently clipped by `overflow: hidden`.

**Fix (`index.tsx`):** Added a `setTimeout(updateScrollState, 50)` alongside the existing immediate call, so the scroll state is re-evaluated once layout has fully settled. The timeout is properly cleaned up in the effect's return function.

---

### Bug 2 — "Contains" filter text input auto-focuses on page load

**Root cause:** `FilterBuilderTextValueField` calls `inputRef.current?.focus()` inside a `useEffect` that fires on every mount. Because the component only exists when `operator === 'contains'`, mounting is equivalent to the operator becoming "contains" — which happens both when the user actively selects it **and** when saved state is restored on page load.

**Fix (`FilterBuilderTextValueField.tsx`):** Added an early return when `filter.value != null`. When a filter is restored from saved state it always carries a value, so the focus is skipped. When the user freshly selects "contains" the value is `null` (cleared by `handleSelectOperator`), so the focus still fires as intended.

---

### Files changed

| File | Change |
|------|--------|
| `src/components/editors/FilterBuilderPro/index.tsx` | Add `setTimeout(updateScrollState, 50)` in scroll effect |
| `src/components/editors/FilterBuilderPro/components/FilterBuilderTextValueField.tsx` | Skip auto-focus when `filter.value != null` |

Closes [RUI-281](https://trevorio.atlassian.net/browse/RUI-281)

[RUI-281]: https://trevorio.atlassian.net/browse/RUI-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unwanted focus behavior when restoring previously saved filter selections
  * Improved scroll position handling to account for layout changes during component updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->