### PR TITLE
[RUI-273] Add default width and height values to component meta

### DIFF
--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
@@ -22,6 +22,8 @@ const meta = {
   description:
     'Same as BarChartDefaultPro but with horizontal bars. Pick when category labels are long or numerous.',
   category: 'Bar Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/bars/BarChartDefaultPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/definition.ts
@@ -22,6 +22,8 @@ const meta = {
   description:
     'Vertical bar chart with one categorical x-axis dimension and one or more measures. Use to compare values across discrete categories.',
   category: 'Bar Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -20,6 +20,8 @@ const meta = {
   description:
     'Same as BarChartGroupedPro but with horizontal bars. Pick when category labels are long or numerous.',
   category: 'Bar Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.measure,

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -20,6 +20,8 @@ const meta = {
   description:
     'Vertical bar chart with side-by-side bars — one x-axis dimension, one grouping dimension, one measure. Use to compare sub-categories at each x value.',
   category: 'Bar Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.measure,

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -20,6 +20,8 @@ const meta = {
   description:
     'Same as BarChartStackedPro but with horizontal bars. Pick when category labels are long or numerous.',
   category: 'Bar Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.measure,

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -20,6 +20,8 @@ const meta = {
   description:
     'Vertical bar chart with stacked segments — two dimensions (x-axis + stack) and one measure. Use for parts-of-whole across categories.',
   category: 'Bar Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.measure,

--- a/src/components/charts/combo/BarLineChartPro/definition.ts
+++ b/src/components/charts/combo/BarLineChartPro/definition.ts
@@ -20,6 +20,8 @@ const meta = {
   name: 'BarLineChartPro',
   label: 'Bar + Line Chart',
   category: 'Combo Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
@@ -24,6 +24,8 @@ const meta = {
   description:
     'Line chart overlaying the current period and a comparison period. Pairs with a comparisonPeriod variable and a timeRange variable.',
   category: 'Line Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/lines/LineChartDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/definition.ts
@@ -22,6 +22,8 @@ const meta = {
   description:
     'Line chart with one time dimension on the x-axis and one or more measures. Use for time-series trends.',
   category: 'Line Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/lines/LineChartGroupedPro/definition.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/definition.ts
@@ -21,6 +21,8 @@ const meta = {
   description:
     'Line chart split into multiple lines by a grouping dimension — one time dim + one grouping dim + one measure.',
   category: 'Line Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/scatter/BubbleChartPro/definition.ts
+++ b/src/components/charts/scatter/BubbleChartPro/definition.ts
@@ -12,6 +12,8 @@ const meta = {
   name: 'BubbleChartPro',
   label: 'Bubble Chart',
   category: 'Scatter Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.xMeasure,

--- a/src/components/charts/scatter/ScatterChartPro/definition.ts
+++ b/src/components/charts/scatter/ScatterChartPro/definition.ts
@@ -14,6 +14,8 @@ const meta = {
   description:
     'Scatter plot showing the relationship between two measures across a grouping dimension. Use to spot correlations.',
   category: 'Scatter Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.xMeasure,

--- a/src/components/charts/tables/HeatMapPro/definition.ts
+++ b/src/components/charts/tables/HeatMapPro/definition.ts
@@ -12,6 +12,8 @@ const meta = {
   description:
     'Heat map of one measure over two dimensions (rows × columns). Use to spot density or correlation patterns.',
   category: 'Table Charts',
+  defaultWidth: 630,
+  defaultHeight: 442,
   inputs: [
     inputs.dataset,
     inputs.measure,

--- a/src/components/charts/tables/PivotTablePro/definition.ts
+++ b/src/components/charts/tables/PivotTablePro/definition.ts
@@ -13,6 +13,8 @@ const meta = {
   description:
     'Cross-tabulated table — row and column dimensions intersected by one or more measures.',
   category: 'Table Charts',
+  defaultWidth: 800,
+  defaultHeight: 500,
   inputs: [
     inputs.dataset,
     {

--- a/src/components/charts/tables/TableChartPaginated/definition.ts
+++ b/src/components/charts/tables/TableChartPaginated/definition.ts
@@ -21,6 +21,8 @@ const meta = {
   label: 'Table Chart - Paginated',
   description: 'Server-side paginated table. Pick over TableScrollable for large datasets.',
   category: 'Table Charts',
+  defaultWidth: 800,
+  defaultHeight: 500,
   inputs: [
     { ...inputs.dataset, config: { hideSort: true } },
     {

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -22,6 +22,8 @@ const meta = {
   label: 'Table Chart - Scrollable',
   description: 'Scrollable table that loads all rows at once. Pick for small or medium datasets.',
   category: 'Table Charts',
+  defaultWidth: 800,
+  defaultHeight: 500,
   inputs: [
     { ...inputs.dataset, config: { hideSort: true } },
     {


### PR DESCRIPTION
## Summary

Closes RUI-273

Adds missing `defaultWidth` and `defaultHeight` fields to the `meta` object in 16 chart component `definition.ts` files, so the AI builder and no-code builder can place components on the canvas at sensible default sizes.

## Changes

**Bar charts** (630×442): `BarChartDefaultPro`, `BarChartDefaultHorizontalPro`, `BarChartGroupedPro`, `BarChartGroupedHorizontalPro`, `BarChartStackedPro`, `BarChartStackedHorizontalPro`

**Line charts** (630×442): `LineChartDefaultPro`, `LineChartGroupedPro`, `LineChartComparisonDefaultPro`

**Scatter charts** (630×442): `BubbleChartPro`, `ScatterChartPro`

**Combo charts** (630×442): `BarLineChartPro`

**Table/heatmap charts**: `HeatMapPro` (630×442), `PivotTablePro` (800×500), `TableChartPaginated` (800×500), `TableScrollable` (800×500)

**Note:** `AreaChartPro` was not modified — it spreads `...lineChartGroupedPro.meta` and will inherit the new values automatically.

## Size conventions used

- Standard charts: `defaultWidth: 630, defaultHeight: 442`
- Table components: `defaultWidth: 800, defaultHeight: 500`

These match existing patterns in the codebase (e.g. `DateRangePickerPresetsPro`, `KpiChartNumberPro`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized default dimensions across all chart and table components. Bar charts, line charts, combo charts, scatter charts, and table variants now have consistent default sizing (630 x 442 pixels for charts, 800 x 500 pixels for tables), ensuring improved visual consistency and better user experience during component placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->