### PR TITLE
[RUI-285] Minor pie chart bug: %s decimal places not respected

### DIFF
--- a/.changeset/hungry-corners-stop.md
+++ b/.changeset/hungry-corners-stop.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Consider decimal places in the percentage values

--- a/src/components/charts/bars/bars.utils.test.ts
+++ b/src/components/charts/bars/bars.utils.test.ts
@@ -505,7 +505,7 @@ describe('getBarChartProOptions', () => {
       const context = { datasetIndex: 0, dataset: { data: [50] } } as never;
       const result = options.plugins!.datalabels!.labels!.value!.formatter!(50, context);
 
-      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
+      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50], undefined);
       expect(result).toBe('50%');
     });
   });
@@ -567,7 +567,7 @@ describe('getBarChartProOptions', () => {
       } as never;
       const result = options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
 
-      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
+      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50], undefined);
       expect(result).toBe('Revenue: fmt:50 (50%)');
     });
   });
@@ -724,7 +724,7 @@ describe('getBarStackedChartProOptions', () => {
       } as never;
       const result = options.plugins!.tooltip!.callbacks!.label!.call({} as never, context);
 
-      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50]);
+      expect(getDatalabelPercentage).toHaveBeenCalledWith(50, [50], undefined);
       expect(result).toBe('fmt:North: fmt:50 (33%)');
     });
 

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -169,7 +169,11 @@ export const getBarChartProOptions = (
               const measure = measures[context.datasetIndex % measures.length]!;
 
               if (measure.inputs?.showValueAsPercentage) {
-                return getDatalabelPercentage(Number(value), context.dataset.data);
+                return getDatalabelPercentage(
+                  Number(value),
+                  context.dataset.data,
+                  measure.inputs?.decimalPlaces as number | undefined,
+                );
               }
               return themeFormatter.data(measure, value);
             },
@@ -191,7 +195,7 @@ export const getBarChartProOptions = (
 
             let percentage = '';
             if (measure.inputs?.showValueAsPercentage) {
-              percentage = `(${getDatalabelPercentage(raw, context.dataset.data)})`;
+              percentage = `(${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces as number | undefined)})`;
             }
 
             return `${context.dataset.label}: ${measureValue} ${percentage}`;
@@ -255,7 +259,7 @@ export const getBarStackedChartProOptions = (
 
         let percentage = '';
         if (measure.inputs?.showValueAsPercentage) {
-          percentage = `(${getDatalabelPercentage(raw, context.dataset.data)})`;
+          percentage = `(${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces as number | undefined)})`;
         }
 
         const label = themeFormatter.data(

--- a/src/components/charts/bars/bars.utils.ts
+++ b/src/components/charts/bars/bars.utils.ts
@@ -172,7 +172,7 @@ export const getBarChartProOptions = (
                 return getDatalabelPercentage(
                   Number(value),
                   context.dataset.data,
-                  measure.inputs?.decimalPlaces as number | undefined,
+                  measure.inputs?.decimalPlaces,
                 );
               }
               return themeFormatter.data(measure, value);
@@ -195,7 +195,7 @@ export const getBarChartProOptions = (
 
             let percentage = '';
             if (measure.inputs?.showValueAsPercentage) {
-              percentage = `(${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces as number | undefined)})`;
+              percentage = `(${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces)})`;
             }
 
             return `${context.dataset.label}: ${measureValue} ${percentage}`;
@@ -259,7 +259,7 @@ export const getBarStackedChartProOptions = (
 
         let percentage = '';
         if (measure.inputs?.showValueAsPercentage) {
-          percentage = `(${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces as number | undefined)})`;
+          percentage = `(${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces)})`;
         }
 
         const label = themeFormatter.data(

--- a/src/components/charts/charts.utils.test.ts
+++ b/src/components/charts/charts.utils.test.ts
@@ -64,6 +64,22 @@ describe('getDatalabelPercentage', () => {
     // data is unknown[], so strings are valid — parseFloat handles them
     expect(getDatalabelPercentage(50, ['50', '50'] as unknown[])).toBe('50%');
   });
+
+  it('respects decimalPlaces=0 (rounds to integer)', () => {
+    expect(getDatalabelPercentage(1, [1, 1, 1], 0)).toBe('33%');
+  });
+
+  it('respects decimalPlaces=1', () => {
+    expect(getDatalabelPercentage(1, [1, 1, 1], 1)).toBe('33.3%');
+  });
+
+  it('respects decimalPlaces=4', () => {
+    expect(getDatalabelPercentage(1, [1, 1, 1], 4)).toBe('33.3333%');
+  });
+
+  it('defaults to 2 decimal places when decimalPlaces is undefined', () => {
+    expect(getDatalabelPercentage(1, [1, 1, 1], undefined)).toBe('33.33%');
+  });
 });
 
 describe('getDimensionWithoutTruncation', () => {

--- a/src/components/charts/charts.utils.ts
+++ b/src/components/charts/charts.utils.ts
@@ -47,11 +47,16 @@ export const groupTailAsOther = (
   return [...head, aggregatedRow];
 };
 
-export const getDatalabelPercentage = (value: number, data: unknown[]): string => {
+export const getDatalabelPercentage = (
+  value: number,
+  data: unknown[],
+  decimalPlaces?: number,
+): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const total = data.reduce((sum: number, v: any) => sum + Number.parseFloat(v), 0);
   if (total === 0) return '0%';
-  return `${Number.parseFloat(((value / total) * 100).toFixed(2))}%`;
+  const places = decimalPlaces ?? 2;
+  return `${Number.parseFloat(((value / total) * 100).toFixed(places))}%`;
 };
 
 export const createSimpleClickHandler = ({

--- a/src/components/charts/charts.utils.ts
+++ b/src/components/charts/charts.utils.ts
@@ -50,13 +50,12 @@ export const groupTailAsOther = (
 export const getDatalabelPercentage = (
   value: number,
   data: unknown[],
-  decimalPlaces?: number,
+  decimalPlaces = 2,
 ): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const total = data.reduce((sum: number, v: any) => sum + Number.parseFloat(v), 0);
   if (total === 0) return '0%';
-  const places = decimalPlaces ?? 2;
-  return `${Number.parseFloat(((value / total) * 100).toFixed(places))}%`;
+  return `${Number.parseFloat(((value / total) * 100).toFixed(decimalPlaces))}%`;
 };
 
 export const createSimpleClickHandler = ({

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
@@ -163,7 +163,11 @@ export const getBarLineChartProOptions = (
               const measure = measures[context.datasetIndex];
               if (!measure) return value;
               if (measure.inputs?.showValueAsPercentage) {
-                return getDatalabelPercentage(Number(value), context.dataset.data);
+                return getDatalabelPercentage(
+                  Number(value),
+                  context.dataset.data,
+                  measure.inputs?.decimalPlaces as number | undefined,
+                );
               }
               return themeFormatter.data(measure, value);
             },
@@ -187,7 +191,7 @@ export const getBarLineChartProOptions = (
             const raw = context.raw as number;
             const formatted = themeFormatter.data(measure, raw);
             const percentage = measure.inputs?.showValueAsPercentage
-              ? ` (${getDatalabelPercentage(raw, context.dataset.data)})`
+              ? ` (${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces as number | undefined)})`
               : '';
             return `${context.dataset.label}: ${formatted}${percentage}`;
           },

--- a/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
+++ b/src/components/charts/combo/BarLineChartPro/BarLineChartPro.utils.ts
@@ -166,7 +166,7 @@ export const getBarLineChartProOptions = (
                 return getDatalabelPercentage(
                   Number(value),
                   context.dataset.data,
-                  measure.inputs?.decimalPlaces as number | undefined,
+                  measure.inputs?.decimalPlaces,
                 );
               }
               return themeFormatter.data(measure, value);
@@ -191,7 +191,7 @@ export const getBarLineChartProOptions = (
             const raw = context.raw as number;
             const formatted = themeFormatter.data(measure, raw);
             const percentage = measure.inputs?.showValueAsPercentage
-              ? ` (${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces as number | undefined)})`
+              ? ` (${getDatalabelPercentage(raw, context.dataset.data, measure.inputs?.decimalPlaces)})`
               : '';
             return `${context.dataset.label}: ${formatted}${percentage}`;
           },

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -109,6 +109,7 @@ export const getPieChartProOptions = (
 ): Partial<ChartOptions<'pie'>> => {
   const { dimension, measure } = props;
   const themeFormatter = getThemeFormatter(theme);
+  const decimalPlaces = measure.inputs?.decimalPlaces as number | undefined;
 
   return {
     plugins: {
@@ -135,7 +136,7 @@ export const getPieChartProOptions = (
       datalabels: {
         formatter: (value: string | number, context) => {
           if (measure.inputs?.showValueAsPercentage) {
-            return getDatalabelPercentage(Number(value), context.dataset.data);
+            return getDatalabelPercentage(Number(value), context.dataset.data, decimalPlaces);
           }
           return themeFormatter.data(measure, value);
         },
@@ -148,7 +149,7 @@ export const getPieChartProOptions = (
           },
           label(context) {
             const raw = context.raw as number;
-            return `${themeFormatter.data(measure, raw)} (${getDatalabelPercentage(raw, context.dataset.data)})`;
+            return `${themeFormatter.data(measure, raw)} (${getDatalabelPercentage(raw, context.dataset.data, decimalPlaces)})`;
           },
         },
       },

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -109,7 +109,7 @@ export const getPieChartProOptions = (
 ): Partial<ChartOptions<'pie'>> => {
   const { dimension, measure } = props;
   const themeFormatter = getThemeFormatter(theme);
-  const decimalPlaces = measure.inputs?.decimalPlaces as number | undefined;
+  const decimalPlaces = measure.inputs?.decimalPlaces;
 
   return {
     plugins: {


### PR DESCRIPTION
## Problem

When `showValueAsPercentage` is enabled on a measure, the number of decimal places shown was hardcoded to `2` in `getDatalabelPercentage`, ignoring the `decimalPlaces` subinput. This affected pie/donut charts, bar charts, and the bar+line combo chart — both datalabels and tooltip percentages.

## Root cause

`getDatalabelPercentage` always called `.toFixed(2)`, and none of its callers passed the measure's `decimalPlaces` input.

## Fix

- **`charts.utils.ts`** — use a default parameter (`decimalPlaces = 2`) instead of hardcoding `2` inside the function body
- **`pies.utils.ts`** — pass `measure.inputs?.decimalPlaces` in the datalabels formatter and tooltip label callback
- **`bars.utils.ts`** — pass `measure.inputs?.decimalPlaces` in the datalabels formatter (`getBarChartProOptions`) and tooltip label callbacks in both `getBarChartProOptions` and `getBarStackedChartProOptions`
- **`BarLineChartPro.utils.ts`** — pass `measure.inputs?.decimalPlaces` in the datalabels formatter and tooltip label callback
- **`charts.utils.test.ts`** — added tests covering `decimalPlaces` 0, 1, 4, and `undefined`

Fixes [RUI-285](https://trevorio.atlassian.net/browse/RUI-285)

## Evidence


https://github.com/user-attachments/assets/903faaa9-58d4-4db6-a69b-adb2d5131b23



[RUI-285]: https://trevorio.atlassian.net/browse/RUI-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ