### PR TITLE
[RUI-280]: Add export options to component settings in builder

### DIFF
--- a/.changeset/loose-kiwis-search.md
+++ b/.changeset/loose-kiwis-search.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Add export options input to component builder settings

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",
@@ -25,8 +25,9 @@
         "xlsx": "npm:@e965/xlsx@^0.20.3"
       },
       "devDependencies": {
-        "@embeddable.com/sdk-core": "4.7.2",
-        "@embeddable.com/sdk-react": "4.3.12",
+        "@embeddable.com/sdk-core": "^4.8.0",
+        "@embeddable.com/sdk-react": "^4.3.13",
+        "@embeddable.com/sdk-utils": "^0.9.1",
         "@eslint/css": "^0.13.0",
         "@testing-library/react": "^16.3.2",
         "@types/chroma-js": "^3.1.1",
@@ -768,9 +769,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.7.tgz",
+      "integrity": "sha512-CmjJFQTFQx/U/xNJhSjCQ0ilpesPmNQ8+eOUeM/+kDOVW33qsIjeOXc27vrQDdWVkf83ZSWwtg7kXSUvKDJ8cQ==",
       "dev": true,
       "funding": [
         {
@@ -894,21 +895,21 @@
       }
     },
     "node_modules/@embeddable.com/core": {
-      "version": "2.13.7",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/core/-/core-2.13.7.tgz",
-      "integrity": "sha512-3ODHfzosDHjICQs2v832sg6b0uBEzP6Kw35HHCIHVxg+oQ4stD5U/jaVicOX6mzCDs9XZcM9UYEqwt49L0RCcw==",
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/core/-/core-2.13.8.tgz",
+      "integrity": "sha512-1qoGjcuOd11/CD4oe+GLRVj7YfxQYBE1V8nWMP55oTHcDq36EDRU0NmGYtUdFIjjDW+DA4p9q3glGKSfyeuLrQ==",
       "license": "MIT",
       "dependencies": {
         "mergician": "^2.0.2"
       }
     },
     "node_modules/@embeddable.com/react": {
-      "version": "2.13.7",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.13.7.tgz",
-      "integrity": "sha512-LyeFoucnq5WbDEbB97meqw5XFuVcSsWlNOElObIA+LZiy4XXmR1NMRHd8bRAmgloqp0jLNzoH1Ajixlefo5MyQ==",
+      "version": "2.13.8",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/react/-/react-2.13.8.tgz",
+      "integrity": "sha512-HyNKyEGy1HDvJ6vnztDRoStYFMJFhr11HemtLr5LXsWxQ0fOhOdBLedm+34/JjKiLvYwt0OxRsv8y7oe4JIErw==",
       "license": "MIT",
       "dependencies": {
-        "@embeddable.com/core": "2.13.7"
+        "@embeddable.com/core": "2.13.8"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -945,13 +946,13 @@
       }
     },
     "node_modules/@embeddable.com/sdk-core": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.7.2.tgz",
-      "integrity": "sha512-kYI+HEaIn7SQeMYhZqhqwPBl1b96Wn674oTMOT2SUPftbZuRzRZEJGaS+ZtWTrZEZzTMbUWRLglBQlRen1V5Rw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-core/-/sdk-core-4.8.0.tgz",
+      "integrity": "sha512-xFe0RSCBlEffbSxJS8UyTn/TYWThrVtJBlmoLhggZNhsyskZQzzPsXGm2BLc2w9FlARqtW85B02tWmpmkJVGvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@embeddable.com/core": "2.13.7",
+        "@embeddable.com/core": "2.13.8",
         "@embeddable.com/sdk-utils": "0.9.1",
         "@inquirer/prompts": "^7.2.1",
         "@stencil/core": "^4.23.0",
@@ -989,16 +990,16 @@
       }
     },
     "node_modules/@embeddable.com/sdk-react": {
-      "version": "4.3.12",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.3.12.tgz",
-      "integrity": "sha512-vWiQL7jPTPzQOSy2iGFfA26+G4nFCRT3ckUcWlBorp4FnV7W8qitOpQ12AkaJqOLBWCBV6lOFzYxm7YJtlVZQg==",
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/sdk-react/-/sdk-react-4.3.13.tgz",
+      "integrity": "sha512-Cp32/vH7GD61XymNLDRX++riK89qn07DTl4weKg6SDn4IzInfHnIwRjM5Da4XDAeYfDFqSVvO9L0QNVpjt+VvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.23.0",
         "@babel/parser": "^7.26.2",
         "@babel/traverse": "^7.24.7",
-        "@embeddable.com/sdk-core": "4.7.2",
+        "@embeddable.com/sdk-core": "4.8.0",
         "@embeddable.com/sdk-utils": "0.9.1",
         "@happy-dom/global-registrator": "^20.3.7",
         "@vitejs/plugin-react": "^4.3.2",
@@ -1054,9 +1055,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1072,9 +1073,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -1090,9 +1091,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -1108,9 +1109,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -1126,9 +1127,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -1144,9 +1145,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -1162,9 +1163,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -1180,9 +1181,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -1198,9 +1199,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -1216,9 +1217,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -1234,9 +1235,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -1252,9 +1253,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -1270,9 +1271,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -1288,9 +1289,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1306,9 +1307,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1324,9 +1325,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -1342,9 +1343,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -1360,9 +1361,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -1378,9 +1379,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -1396,9 +1397,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1414,9 +1415,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1432,9 +1433,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1450,9 +1451,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1468,9 +1469,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1486,9 +1487,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1504,9 +1505,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1790,14 +1791,14 @@
       "license": "MIT"
     },
     "node_modules/@happy-dom/global-registrator": {
-      "version": "20.10.1",
-      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.10.1.tgz",
-      "integrity": "sha512-nIT1Jdsar1KnLuqX+q3oMKwUIDcSJ4GnGMBnCtXLLL+lIpqaBBACPIo9By3NeF15XDPLDLIou8aQd3/xqZoSkQ==",
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.10.5.tgz",
+      "integrity": "sha512-U64VYxPsoO4RxNHzzp7N+sMHmXaY+GDzcc272mTfZFt0LKuuf7hoNCxna4+T472p+GRKUOtYlLLnVlxCWAcobw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
-        "happy-dom": "^20.10.1"
+        "happy-dom": "^20.10.5"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -2341,14 +2342,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -2679,18 +2680,18 @@
       }
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
-      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-arrow": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
-      "integrity": "sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.10.tgz",
+      "integrity": "sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2708,15 +2709,15 @@
       }
     },
     "node_modules/@radix-ui/react-collection": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
-      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2734,9 +2735,9 @@
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
-      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2749,9 +2750,9 @@
       }
     },
     "node_modules/@radix-ui/react-context": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
-      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2764,9 +2765,9 @@
       }
     },
     "node_modules/@radix-ui/react-direction": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
-      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2779,16 +2780,16 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
-      "integrity": "sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.13.tgz",
+      "integrity": "sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-escape-keydown": "1.1.1"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2806,18 +2807,18 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
-      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.18.tgz",
+      "integrity": "sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-menu": "2.1.16",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.18",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2835,9 +2836,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-guards": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
-      "integrity": "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -2850,14 +2851,14 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
-      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.10.tgz",
+      "integrity": "sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2875,12 +2876,12 @@
       }
     },
     "node_modules/@radix-ui/react-id": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
-      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2893,29 +2894,29 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
-      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.18.tgz",
+      "integrity": "sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-focus-guards": "1.1.3",
-        "@radix-ui/react-focus-scope": "1.1.7",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-roving-focus": "1.1.11",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.10",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.1",
+        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
         "aria-hidden": "^1.2.4",
-        "react-remove-scroll": "^2.6.3"
+        "react-remove-scroll": "^2.7.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2933,21 +2934,21 @@
       }
     },
     "node_modules/@radix-ui/react-popper": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
-      "integrity": "sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.1.tgz",
+      "integrity": "sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
-        "@radix-ui/react-arrow": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-layout-effect": "1.1.1",
-        "@radix-ui/react-use-rect": "1.1.1",
-        "@radix-ui/react-use-size": "1.1.1",
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/react-arrow": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2965,13 +2966,13 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
-      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.12.tgz",
+      "integrity": "sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2989,13 +2990,12 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
-      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3013,12 +3013,12 @@
       }
     },
     "node_modules/@radix-ui/react-primitive": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
-      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-slot": "1.2.3"
+        "@radix-ui/react-slot": "1.3.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3036,20 +3036,20 @@
       }
     },
     "node_modules/@radix-ui/react-roving-focus": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
-      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
+      "integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-collection": "1.1.7",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-direction": "1.1.1",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-use-callback-ref": "1.1.1",
-        "@radix-ui/react-use-controllable-state": "1.2.2"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3067,12 +3067,12 @@
       }
     },
     "node_modules/@radix-ui/react-slot": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
-      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-compose-refs": "1.1.2"
+        "@radix-ui/react-compose-refs": "1.1.3"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3085,23 +3085,23 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
-      "integrity": "sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==",
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.10.tgz",
+      "integrity": "sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.3",
-        "@radix-ui/react-compose-refs": "1.1.2",
-        "@radix-ui/react-context": "1.1.2",
-        "@radix-ui/react-dismissable-layer": "1.1.11",
-        "@radix-ui/react-id": "1.1.1",
-        "@radix-ui/react-popper": "1.2.8",
-        "@radix-ui/react-portal": "1.1.9",
-        "@radix-ui/react-presence": "1.1.5",
-        "@radix-ui/react-primitive": "2.1.3",
-        "@radix-ui/react-slot": "1.2.3",
-        "@radix-ui/react-use-controllable-state": "1.2.2",
-        "@radix-ui/react-visually-hidden": "1.2.3"
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.13",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.1",
+        "@radix-ui/react-portal": "1.1.12",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0",
+        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-visually-hidden": "1.2.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3119,9 +3119,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-callback-ref": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
-      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3134,13 +3134,13 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
-      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-effect-event": "0.0.2",
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3153,12 +3153,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-effect-event": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
-      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3171,12 +3171,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-escape-keydown": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
-      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-callback-ref": "1.1.1"
+        "@radix-ui/react-use-callback-ref": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3189,9 +3189,9 @@
       }
     },
     "node_modules/@radix-ui/react-use-layout-effect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -3204,12 +3204,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
-      "integrity": "sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/rect": "1.1.1"
+        "@radix-ui/rect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3222,12 +3222,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-size": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
-      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-use-layout-effect": "1.1.1"
+        "@radix-ui/react-use-layout-effect": "1.1.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3240,12 +3240,12 @@
       }
     },
     "node_modules/@radix-ui/react-visually-hidden": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
-      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.6.tgz",
+      "integrity": "sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/react-primitive": "2.1.3"
+        "@radix-ui/react-primitive": "2.1.6"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3263,9 +3263,9 @@
       }
     },
     "node_modules/@radix-ui/rect": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
-      "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3276,9 +3276,9 @@
       "license": "MIT"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.61.1.tgz",
-      "integrity": "sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.0.tgz",
+      "integrity": "sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==",
       "cpu": [
         "arm"
       ],
@@ -3290,9 +3290,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.61.1.tgz",
-      "integrity": "sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.0.tgz",
+      "integrity": "sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==",
       "cpu": [
         "arm64"
       ],
@@ -3332,9 +3332,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.61.1.tgz",
-      "integrity": "sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.0.tgz",
+      "integrity": "sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==",
       "cpu": [
         "arm64"
       ],
@@ -3346,9 +3346,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.61.1.tgz",
-      "integrity": "sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.0.tgz",
+      "integrity": "sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==",
       "cpu": [
         "x64"
       ],
@@ -3360,9 +3360,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.61.1.tgz",
-      "integrity": "sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.0.tgz",
+      "integrity": "sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==",
       "cpu": [
         "arm"
       ],
@@ -3374,9 +3374,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.61.1.tgz",
-      "integrity": "sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.0.tgz",
+      "integrity": "sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==",
       "cpu": [
         "arm"
       ],
@@ -3416,9 +3416,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.61.1.tgz",
-      "integrity": "sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.0.tgz",
+      "integrity": "sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==",
       "cpu": [
         "loong64"
       ],
@@ -3430,9 +3430,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.61.1.tgz",
-      "integrity": "sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.0.tgz",
+      "integrity": "sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==",
       "cpu": [
         "loong64"
       ],
@@ -3444,9 +3444,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.61.1.tgz",
-      "integrity": "sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.0.tgz",
+      "integrity": "sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==",
       "cpu": [
         "ppc64"
       ],
@@ -3458,9 +3458,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.61.1.tgz",
-      "integrity": "sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.0.tgz",
+      "integrity": "sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==",
       "cpu": [
         "ppc64"
       ],
@@ -3472,9 +3472,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.61.1.tgz",
-      "integrity": "sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.0.tgz",
+      "integrity": "sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==",
       "cpu": [
         "riscv64"
       ],
@@ -3486,9 +3486,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.61.1.tgz",
-      "integrity": "sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.0.tgz",
+      "integrity": "sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==",
       "cpu": [
         "riscv64"
       ],
@@ -3500,9 +3500,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.61.1.tgz",
-      "integrity": "sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.0.tgz",
+      "integrity": "sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==",
       "cpu": [
         "s390x"
       ],
@@ -3542,9 +3542,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.61.1.tgz",
-      "integrity": "sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.0.tgz",
+      "integrity": "sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==",
       "cpu": [
         "x64"
       ],
@@ -3556,9 +3556,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.61.1.tgz",
-      "integrity": "sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.0.tgz",
+      "integrity": "sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==",
       "cpu": [
         "arm64"
       ],
@@ -3584,9 +3584,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.61.1.tgz",
-      "integrity": "sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.0.tgz",
+      "integrity": "sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==",
       "cpu": [
         "ia32"
       ],
@@ -3598,9 +3598,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.61.1.tgz",
-      "integrity": "sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==",
       "cpu": [
         "x64"
       ],
@@ -3718,9 +3718,9 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
-      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
+      "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -3737,18 +3737,18 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.40",
-        "@swc/core-darwin-x64": "1.15.40",
-        "@swc/core-linux-arm-gnueabihf": "1.15.40",
-        "@swc/core-linux-arm64-gnu": "1.15.40",
-        "@swc/core-linux-arm64-musl": "1.15.40",
-        "@swc/core-linux-ppc64-gnu": "1.15.40",
-        "@swc/core-linux-s390x-gnu": "1.15.40",
-        "@swc/core-linux-x64-gnu": "1.15.40",
-        "@swc/core-linux-x64-musl": "1.15.40",
-        "@swc/core-win32-arm64-msvc": "1.15.40",
-        "@swc/core-win32-ia32-msvc": "1.15.40",
-        "@swc/core-win32-x64-msvc": "1.15.40"
+        "@swc/core-darwin-arm64": "1.15.41",
+        "@swc/core-darwin-x64": "1.15.41",
+        "@swc/core-linux-arm-gnueabihf": "1.15.41",
+        "@swc/core-linux-arm64-gnu": "1.15.41",
+        "@swc/core-linux-arm64-musl": "1.15.41",
+        "@swc/core-linux-ppc64-gnu": "1.15.41",
+        "@swc/core-linux-s390x-gnu": "1.15.41",
+        "@swc/core-linux-x64-gnu": "1.15.41",
+        "@swc/core-linux-x64-musl": "1.15.41",
+        "@swc/core-win32-arm64-msvc": "1.15.41",
+        "@swc/core-win32-ia32-msvc": "1.15.41",
+        "@swc/core-win32-x64-msvc": "1.15.41"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -3760,9 +3760,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
-      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.41.tgz",
+      "integrity": "sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==",
       "cpu": [
         "arm64"
       ],
@@ -3778,9 +3778,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
-      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.41.tgz",
+      "integrity": "sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==",
       "cpu": [
         "x64"
       ],
@@ -3796,9 +3796,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
-      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.41.tgz",
+      "integrity": "sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==",
       "cpu": [
         "arm"
       ],
@@ -3814,9 +3814,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
-      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.41.tgz",
+      "integrity": "sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==",
       "cpu": [
         "arm64"
       ],
@@ -3832,9 +3832,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
-      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.41.tgz",
+      "integrity": "sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==",
       "cpu": [
         "arm64"
       ],
@@ -3850,9 +3850,9 @@
       }
     },
     "node_modules/@swc/core-linux-ppc64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
-      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.41.tgz",
+      "integrity": "sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==",
       "cpu": [
         "ppc64"
       ],
@@ -3868,9 +3868,9 @@
       }
     },
     "node_modules/@swc/core-linux-s390x-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
-      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.41.tgz",
+      "integrity": "sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==",
       "cpu": [
         "s390x"
       ],
@@ -3886,9 +3886,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
-      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.41.tgz",
+      "integrity": "sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==",
       "cpu": [
         "x64"
       ],
@@ -3904,9 +3904,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
-      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.41.tgz",
+      "integrity": "sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==",
       "cpu": [
         "x64"
       ],
@@ -3922,9 +3922,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
-      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.41.tgz",
+      "integrity": "sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==",
       "cpu": [
         "arm64"
       ],
@@ -3940,9 +3940,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
-      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.41.tgz",
+      "integrity": "sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==",
       "cpu": [
         "ia32"
       ],
@@ -3958,9 +3958,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.40",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
-      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.41.tgz",
+      "integrity": "sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==",
       "cpu": [
         "x64"
       ],
@@ -3984,9 +3984,9 @@
       "peer": true
     },
     "node_modules/@swc/types": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
-      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -4357,9 +4357,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -4367,9 +4367,9 @@
       }
     },
     "node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4409,17 +4409,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.1.tgz",
+      "integrity": "sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/type-utils": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/type-utils": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4432,7 +4432,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.1",
+        "@typescript-eslint/parser": "^8.61.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4448,16 +4448,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
+      "integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4473,14 +4473,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.1.tgz",
+      "integrity": "sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.1",
-        "@typescript-eslint/types": "^8.60.1",
+        "@typescript-eslint/tsconfig-utils": "^8.61.1",
+        "@typescript-eslint/types": "^8.61.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4495,14 +4495,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.1.tgz",
+      "integrity": "sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1"
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4513,9 +4513,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.1.tgz",
+      "integrity": "sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4530,15 +4530,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.1.tgz",
+      "integrity": "sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4555,9 +4555,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.1.tgz",
+      "integrity": "sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4569,16 +4569,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.1.tgz",
+      "integrity": "sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.1",
-        "@typescript-eslint/tsconfig-utils": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/visitor-keys": "8.60.1",
+        "@typescript-eslint/project-service": "8.61.1",
+        "@typescript-eslint/tsconfig-utils": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/visitor-keys": "8.61.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4636,16 +4636,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.1.tgz",
+      "integrity": "sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.1",
-        "@typescript-eslint/types": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1"
+        "@typescript-eslint/scope-manager": "8.61.1",
+        "@typescript-eslint/types": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4660,13 +4660,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.1.tgz",
+      "integrity": "sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/types": "8.61.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4718,14 +4718,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
-      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
+      "integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -4739,8 +4739,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.8",
-        "vitest": "4.1.8"
+        "@vitest/browser": "4.1.9",
+        "vitest": "4.1.9"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -4836,9 +4836,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
-      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4849,13 +4849,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
-      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.8",
+        "@vitest/utils": "4.1.9",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -4863,14 +4863,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
-      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -4893,13 +4893,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
-      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.8",
+        "@vitest/pretty-format": "4.1.9",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -4908,14 +4908,14 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.35",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.35.tgz",
-      "integrity": "sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.38.tgz",
+      "integrity": "sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@vue/shared": "3.5.35",
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.38",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -4929,28 +4929,28 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.35",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.35.tgz",
-      "integrity": "sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.38.tgz",
+      "integrity": "sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.35",
-        "@vue/shared": "3.5.35"
+        "@vue/compiler-core": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.35",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.35.tgz",
-      "integrity": "sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.38.tgz",
+      "integrity": "sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.3",
-        "@vue/compiler-core": "3.5.35",
-        "@vue/compiler-dom": "3.5.35",
-        "@vue/compiler-ssr": "3.5.35",
-        "@vue/shared": "3.5.35",
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.38",
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/compiler-ssr": "3.5.38",
+        "@vue/shared": "3.5.38",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.15",
@@ -4965,27 +4965,27 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.35",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.35.tgz",
-      "integrity": "sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.38.tgz",
+      "integrity": "sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.35",
-        "@vue/shared": "3.5.35"
+        "@vue/compiler-dom": "3.5.38",
+        "@vue/shared": "3.5.38"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.35",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.35.tgz",
-      "integrity": "sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==",
+      "version": "3.5.38",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.38.tgz",
+      "integrity": "sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -5307,9 +5307,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
-      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.4.tgz",
+      "integrity": "sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5428,9 +5428,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.33",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz",
-      "integrity": "sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==",
+      "version": "2.10.37",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+      "integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5738,9 +5738,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -6673,9 +6673,9 @@
       "peer": true
     },
     "node_modules/dom-to-image-more": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/dom-to-image-more/-/dom-to-image-more-3.7.2.tgz",
-      "integrity": "sha512-uQf+pHv6eQhgfI8t2bFuinV0KsPyT8TZgCLwcSU8uBVgN9v6leb0mMpvp6HQAlAcplP3NCcGjxbdqef6pTzvmw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/dom-to-image-more/-/dom-to-image-more-3.10.0.tgz",
+      "integrity": "sha512-APrFEimSmH4phJKs8DlURuSr3BFwDqNi62l14bx73Wrhx0OhE4dd0qzZR+4E3sH8PnHxvax1LOrosC9oXRFA5A==",
       "license": "MIT"
     },
     "node_modules/dotenv": {
@@ -6714,9 +6714,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.368",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz",
-      "integrity": "sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==",
+      "version": "1.5.375",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz",
+      "integrity": "sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -6738,9 +6738,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.22.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.2.tgz",
-      "integrity": "sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6859,6 +6859,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -6880,9 +6899,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.2.tgz",
-      "integrity": "sha512-HVLACW1TppGYjJ8H6/jqH/pqOtKRw6wMlrB23xfExmFWxFquAIWCmwoLsOyN96K4a5KbmOf5At9ZUO3GZbetAw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6957,15 +6976,17 @@
       }
     },
     "node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
-      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.1.tgz",
+      "integrity": "sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-errors": "^1.3.0",
         "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -6975,9 +6996,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6989,32 +7010,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/esbuild-register": {
@@ -7789,17 +7810,17 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -7865,18 +7886,21 @@
       }
     },
     "node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
-      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
         "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -8128,9 +8152,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.10.1",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.1.tgz",
-      "integrity": "sha512-awPoqPjx8CgjapJllyDlgzgVHjBExcitKK5ZJkxwhQJyQpHFkyS2bEcqCm7IeW20cQvuCI0cz2Ifq79CJKqtiw==",
+      "version": "20.10.5",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.5.tgz",
+      "integrity": "sha512-0aA6BQoMnpcRE/c1E8ZyF2jXnET7MJskereWOXher4CJuYjrI5esN0Az/1NPMD4KeWUbampBGw2MGqabMPFIbg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8140,7 +8164,7 @@
         "buffer-image-size": "^0.6.4",
         "entities": "^7.0.1",
         "whatwg-mimetype": "^3.0.0",
-        "ws": "^8.18.3"
+        "ws": "^8.21.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -8727,6 +8751,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-extglob": {
@@ -11210,9 +11250,9 @@
       }
     },
     "node_modules/obug": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.2.tgz",
-      "integrity": "sha512-AWGB9WFcRXOQs48Z/udjI5ZcZMHXwX8XPByNpOydgcGsDLIzjGizhoMWJyKAWze7AVW/2W1i+/gPX4YtKe5cyg==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
       "dev": true,
       "funding": [
         "https://github.com/sponsors/sxzz",
@@ -11786,9 +11826,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -12477,9 +12517,9 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
-      "integrity": "sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
+      "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12493,38 +12533,38 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.61.1",
-        "@rollup/rollup-android-arm64": "4.61.1",
-        "@rollup/rollup-darwin-arm64": "4.61.1",
-        "@rollup/rollup-darwin-x64": "4.61.1",
-        "@rollup/rollup-freebsd-arm64": "4.61.1",
-        "@rollup/rollup-freebsd-x64": "4.61.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.61.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.61.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.61.1",
-        "@rollup/rollup-linux-arm64-musl": "4.61.1",
-        "@rollup/rollup-linux-loong64-gnu": "4.61.1",
-        "@rollup/rollup-linux-loong64-musl": "4.61.1",
-        "@rollup/rollup-linux-ppc64-gnu": "4.61.1",
-        "@rollup/rollup-linux-ppc64-musl": "4.61.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.61.1",
-        "@rollup/rollup-linux-riscv64-musl": "4.61.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.61.1",
-        "@rollup/rollup-linux-x64-gnu": "4.61.1",
-        "@rollup/rollup-linux-x64-musl": "4.61.1",
-        "@rollup/rollup-openbsd-x64": "4.61.1",
-        "@rollup/rollup-openharmony-arm64": "4.61.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.61.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.61.1",
-        "@rollup/rollup-win32-x64-gnu": "4.61.1",
-        "@rollup/rollup-win32-x64-msvc": "4.61.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.0",
+        "@rollup/rollup-android-arm64": "4.62.0",
+        "@rollup/rollup-darwin-arm64": "4.62.0",
+        "@rollup/rollup-darwin-x64": "4.62.0",
+        "@rollup/rollup-freebsd-arm64": "4.62.0",
+        "@rollup/rollup-freebsd-x64": "4.62.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.0",
+        "@rollup/rollup-linux-arm64-musl": "4.62.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.0",
+        "@rollup/rollup-linux-loong64-musl": "4.62.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-gnu": "4.62.0",
+        "@rollup/rollup-linux-x64-musl": "4.62.0",
+        "@rollup/rollup-openbsd-x64": "4.62.0",
+        "@rollup/rollup-openharmony-arm64": "4.62.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.0",
+        "@rollup/rollup-win32-x64-gnu": "4.62.0",
+        "@rollup/rollup-win32-x64-msvc": "4.62.0",
         "fsevents": "~2.3.2"
       }
     },
     "node_modules/rollup/node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.61.1.tgz",
-      "integrity": "sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.0.tgz",
+      "integrity": "sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==",
       "cpu": [
         "arm64"
       ],
@@ -12536,9 +12576,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.61.1.tgz",
-      "integrity": "sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.0.tgz",
+      "integrity": "sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==",
       "cpu": [
         "x64"
       ],
@@ -12550,9 +12590,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.61.1.tgz",
-      "integrity": "sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.0.tgz",
+      "integrity": "sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==",
       "cpu": [
         "arm64"
       ],
@@ -12564,9 +12604,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.61.1.tgz",
-      "integrity": "sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.0.tgz",
+      "integrity": "sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==",
       "cpu": [
         "arm64"
       ],
@@ -12578,9 +12618,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.61.1.tgz",
-      "integrity": "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.0.tgz",
+      "integrity": "sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==",
       "cpu": [
         "x64"
       ],
@@ -12592,9 +12632,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.61.1.tgz",
-      "integrity": "sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.0.tgz",
+      "integrity": "sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==",
       "cpu": [
         "x64"
       ],
@@ -12606,9 +12646,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.61.1.tgz",
-      "integrity": "sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==",
       "cpu": [
         "arm64"
       ],
@@ -12620,9 +12660,9 @@
       ]
     },
     "node_modules/rollup/node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.61.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.61.1.tgz",
-      "integrity": "sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==",
+      "version": "4.62.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.0.tgz",
+      "integrity": "sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==",
       "cpu": [
         "x64"
       ],
@@ -12798,9 +12838,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
-      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -12945,15 +12985,15 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -13865,19 +13905,20 @@
       }
     },
     "node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
-      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-data-property": "^1.1.4",
         "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -13887,16 +13928,16 @@
       }
     },
     "node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
-      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -14194,22 +14235,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.2.tgz",
-      "integrity": "sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.3.tgz",
+      "integrity": "sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.4.2"
+        "tldts-core": "^7.4.3"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.2.tgz",
-      "integrity": "sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.3.tgz",
+      "integrity": "sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==",
       "dev": true,
       "license": "MIT"
     },
@@ -14447,16 +14488,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+      "version": "8.61.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.1.tgz",
+      "integrity": "sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.60.1",
-        "@typescript-eslint/parser": "8.60.1",
-        "@typescript-eslint/typescript-estree": "8.60.1",
-        "@typescript-eslint/utils": "8.60.1"
+        "@typescript-eslint/eslint-plugin": "8.61.1",
+        "@typescript-eslint/parser": "8.61.1",
+        "@typescript-eslint/typescript-estree": "8.61.1",
+        "@typescript-eslint/utils": "8.61.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14490,9 +14531,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.1.tgz",
-      "integrity": "sha512-UDdpiex+mzigiyrXrGbiUaF4HzTNhKbh2vRNFaTMzcqmLIPrZxaCtwo/1TMSuWoM1Xz3WiTo9KdgI3kRqYzJGg==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15291,19 +15332,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
-      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.8",
-        "@vitest/mocker": "4.1.8",
-        "@vitest/pretty-format": "4.1.8",
-        "@vitest/runner": "4.1.8",
-        "@vitest/snapshot": "4.1.8",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -15331,12 +15372,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.8",
-        "@vitest/browser-preview": "4.1.8",
-        "@vitest/browser-webdriverio": "4.1.8",
-        "@vitest/coverage-istanbul": "4.1.8",
-        "@vitest/coverage-v8": "4.1.8",
-        "@vitest/ui": "4.1.8",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -15381,16 +15422,16 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/expect": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
-      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.8",
-        "@vitest/utils": "4.1.8",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -15399,13 +15440,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
-      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.8",
+        "@vitest/spy": "4.1.9",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -15426,9 +15467,9 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/spy": {
-      "version": "4.1.8",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
-      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -15596,9 +15637,9 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.21.tgz",
-      "integrity": "sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -77,8 +77,9 @@
     "xlsx": "npm:@e965/xlsx@^0.20.3"
   },
   "devDependencies": {
-    "@embeddable.com/sdk-core": "4.7.2",
-    "@embeddable.com/sdk-react": "4.3.12",
+    "@embeddable.com/sdk-core": "^4.8.0",
+    "@embeddable.com/sdk-react": "^4.3.13",
+    "@embeddable.com/sdk-utils": "^0.9.1",
     "@eslint/css": "^0.13.0",
     "@testing-library/react": "^16.3.2",
     "@types/chroma-js": "^3.1.1",

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
@@ -43,7 +43,7 @@ const meta = {
     inputs.xAxisRangeMax,
     inputs.yAxisMaxItems,
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/definition.ts
@@ -43,6 +43,7 @@ const meta = {
     inputs.xAxisRangeMax,
     inputs.yAxisMaxItems,
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarChartDefaultHorizontalPro from './index';
+import type { BarChartDefaultHorizontalProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../bars.utils', () => ({
+  getBarChartProData: vi.fn(() => ({})),
+  getBarChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createSimpleClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'date', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: BarChartDefaultHorizontalProProps = {
+  dimension,
+  measures: [measure],
+  results: emptyResults,
+};
+
+describe('BarChartDefaultHorizontalPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<BarChartDefaultHorizontalPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<BarChartDefaultHorizontalPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders BarChart', () => {
+    render(<BarChartDefaultHorizontalPro {...defaultProps} />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -79,10 +79,10 @@ describe('BarChartDefaultHorizontalPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<BarChartDefaultHorizontalPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<BarChartDefaultHorizontalPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders BarChart', () => {

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProData, getBarChartProOptions } from '../bars.utils';
@@ -38,8 +38,8 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
     onBarClicked,
   } = props;
 
-  const resolvedProps = resolveI18nProps(props);
-  const { description, title, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { description, title, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const results = useFillGaps({
     results: props.results,
@@ -70,7 +70,7 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
@@ -24,6 +24,7 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
 
   const {
     hideMenu,
+    exportOptions,
     dimension,
     measures,
     showValueLabels,
@@ -74,6 +75,7 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
@@ -70,7 +70,7 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProData, getBarChartProOptions } from '../bars.utils';
@@ -23,8 +23,6 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
   i18nSetup(theme);
 
   const {
-    hideMenu,
-    exportOptions,
     dimension,
     measures,
     showValueLabels,
@@ -40,7 +38,8 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
     onBarClicked,
   } = props;
 
-  const { description, title, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { description, title, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
 
   const results = useFillGaps({
     results: props.results,
@@ -71,11 +70,7 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultHorizontalPro/index.tsx
@@ -70,7 +70,7 @@ const BarChartDefaultHorizontalPro = (props: BarChartDefaultHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/definition.ts
@@ -46,6 +46,7 @@ const meta = {
     inputs.yAxisRangeMax,
     inputs.xAxisMaxItems,
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartDefaultPro/definition.ts
+++ b/src/components/charts/bars/BarChartDefaultPro/definition.ts
@@ -46,7 +46,7 @@ const meta = {
     inputs.yAxisRangeMax,
     inputs.xAxisMaxItems,
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarChartDefaultPro from './index';
+import type { BarChartDefaultProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../bars.utils', () => ({
+  getBarChartProData: vi.fn(() => ({})),
+  getBarChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createSimpleClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'date', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: BarChartDefaultProProps = {
+  dimension,
+  measures: [measure],
+  results: emptyResults,
+};
+
+describe('BarChartDefaultPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard and BarChart', () => {
+    render(<BarChartDefaultPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard', () => {
+    render(<BarChartDefaultPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('passes no exportOptions to ChartCard when not provided', () => {
+    render(<BarChartDefaultPro {...defaultProps} />);
+    const card = screen.getByTestId('chart-card');
+    // exportOptions is undefined (not set), so JSON.stringify renders 'undefined'
+    expect(card.getAttribute('data-export-options')).toBeNull();
+  });
+
+  it('renders granularity selector when setGranularity is provided', () => {
+    render(<BarChartDefaultPro {...defaultProps} setGranularity={vi.fn()} />);
+    expect(screen.getByTestId('granularity-select')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -80,17 +80,17 @@ describe('BarChartDefaultPro', () => {
     expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard', () => {
-    render(<BarChartDefaultPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard', () => {
+    render(<BarChartDefaultPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
-  it('passes no exportOptions to ChartCard when not provided', () => {
+  it('passes no menuOptions to ChartCard when not provided', () => {
     render(<BarChartDefaultPro {...defaultProps} />);
     const card = screen.getByTestId('chart-card');
-    // exportOptions is undefined (not set), so JSON.stringify renders 'undefined'
-    expect(card.getAttribute('data-export-options')).toBeNull();
+    // menuOptions is undefined (not set), so JSON.stringify renders 'undefined'
+    expect(card.getAttribute('data-menu-options')).toBeNull();
   });
 
   it('renders granularity selector when setGranularity is provided', () => {

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -39,8 +39,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
   } = props;
 
   const resolvedI18nProps = resolveI18nProps(props);
-  const { xAxisLabel, yAxisLabel } = resolvedI18nProps;
-  const { tooltip, description, title } = resolvedI18nProps;
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const results = useFillGaps({
     results: props.results,
@@ -71,7 +70,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -33,6 +33,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
     showValueLabels,
     reverseXAxis,
     hideMenu,
+    exportOptions,
     dimension,
     granularity,
     setGranularity,
@@ -74,6 +75,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -70,7 +70,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProData, getBarChartProOptions } from '../bars.utils';
@@ -32,15 +32,15 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
     showLogarithmicScale,
     showValueLabels,
     reverseXAxis,
-    hideMenu,
-    exportOptions,
     dimension,
     granularity,
     setGranularity,
     onBarClicked,
   } = props;
 
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { xAxisLabel, yAxisLabel } = resolvedProps;
+  const { tooltip, description, title } = resolvedProps;
 
   const results = useFillGaps({
     results: props.results,
@@ -71,11 +71,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartDefaultPro/index.tsx
+++ b/src/components/charts/bars/BarChartDefaultPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarChartProData, getBarChartProOptions } from '../bars.utils';
@@ -38,9 +38,9 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
     onBarClicked,
   } = props;
 
-  const resolvedProps = resolveI18nProps(props);
-  const { xAxisLabel, yAxisLabel } = resolvedProps;
-  const { tooltip, description, title } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { xAxisLabel, yAxisLabel } = resolvedI18nProps;
+  const { tooltip, description, title } = resolvedI18nProps;
 
   const results = useFillGaps({
     results: props.results,
@@ -71,7 +71,7 @@ const BarChartDefaultPro = (props: BarChartDefaultProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -40,7 +40,7 @@ const meta = {
     inputs.reverseYAxis,
     inputs.xAxisRangeMin,
     inputs.xAxisRangeMax,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/definition.ts
@@ -40,6 +40,7 @@ const meta = {
     inputs.reverseYAxis,
     inputs.xAxisRangeMin,
     inputs.xAxisRangeMax,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarChartGroupedHorizontalPro from './index';
+import type { BarChartGroupedHorizontalProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../bars.utils', () => ({
+  getBarStackedChartProData: vi.fn(() => ({ datasets: [] })),
+  getBarStackedChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createGroupedClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../bars.hooks', () => ({
+  useUpdateAxisOrderAndCacheKey: vi.fn(),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const yAxis = { name: 'category', inputs: {} } as unknown as Dimension;
+const groupBy = { name: 'group', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: BarChartGroupedHorizontalProProps = {
+  yAxis,
+  groupBy,
+  measure,
+  results: emptyResults,
+};
+
+describe('BarChartGroupedHorizontalPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<BarChartGroupedHorizontalPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<BarChartGroupedHorizontalPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders BarChart', () => {
+    render(<BarChartGroupedHorizontalPro {...defaultProps} />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -85,10 +85,10 @@ describe('BarChartGroupedHorizontalPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<BarChartGroupedHorizontalPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<BarChartGroupedHorizontalPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders BarChart', () => {

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -28,6 +28,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
 
   const {
     hideMenu,
+    exportOptions,
     yAxis,
     groupBy,
     measure,
@@ -104,6 +105,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,8 +24,8 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const {
     yAxis,
@@ -100,7 +100,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,11 +24,10 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
 
   const {
-    hideMenu,
-    exportOptions,
     yAxis,
     groupBy,
     measure,
@@ -101,11 +100,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedHorizontalPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartGroupedHorizontalPro = (props: BarChartGroupedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -40,7 +40,7 @@ const meta = {
     inputs.reverseXAxis,
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartGroupedPro/definition.ts
+++ b/src/components/charts/bars/BarChartGroupedPro/definition.ts
@@ -40,6 +40,7 @@ const meta = {
     inputs.reverseXAxis,
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartGroupedPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartGroupedPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -85,10 +85,10 @@ describe('BarChartGroupedPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<BarChartGroupedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<BarChartGroupedPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders BarChart', () => {

--- a/src/components/charts/bars/BarChartGroupedPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarChartGroupedPro from './index';
+import type { BarChartGroupedProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../bars.utils', () => ({
+  getBarStackedChartProData: vi.fn(() => ({ datasets: [] })),
+  getBarStackedChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createGroupedClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../bars.hooks', () => ({
+  useUpdateAxisOrderAndCacheKey: vi.fn(),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const xAxis = { name: 'category', inputs: {} } as unknown as Dimension;
+const groupBy = { name: 'group', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: BarChartGroupedProProps = {
+  xAxis,
+  groupBy,
+  measure,
+  results: emptyResults,
+};
+
+describe('BarChartGroupedPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<BarChartGroupedPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<BarChartGroupedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders BarChart', () => {
+    render(<BarChartGroupedPro {...defaultProps} />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,11 +24,10 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
 
   const {
-    hideMenu,
-    exportOptions,
     groupBy,
     measure,
     reverseXAxis,
@@ -101,11 +100,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -28,6 +28,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
 
   const {
     hideMenu,
+    exportOptions,
     groupBy,
     measure,
     reverseXAxis,
@@ -104,6 +105,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartGroupedPro/index.tsx
+++ b/src/components/charts/bars/BarChartGroupedPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,8 +24,8 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const {
     groupBy,
@@ -100,7 +100,7 @@ const BarChartGroupedPro = (props: BarChartGroupedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -41,6 +41,7 @@ const meta = {
     inputs.xAxisRangeMin,
     inputs.xAxisRangeMax,
     inputs.showTotalLabels,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/definition.ts
@@ -41,7 +41,7 @@ const meta = {
     inputs.xAxisRangeMin,
     inputs.xAxisRangeMax,
     inputs.showTotalLabels,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarChartStackedHorizontalPro from './index';
+import type { BarChartStackedHorizontalProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../bars.utils', () => ({
+  getBarStackedChartProData: vi.fn(() => ({ datasets: [] })),
+  getBarStackedChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createGroupedClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../bars.hooks', () => ({
+  useUpdateAxisOrderAndCacheKey: vi.fn(),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const yAxis = { name: 'category', inputs: {} } as unknown as Dimension;
+const groupBy = { name: 'group', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: BarChartStackedHorizontalProProps = {
+  yAxis,
+  groupBy,
+  measure,
+  results: emptyResults,
+};
+
+describe('BarChartStackedHorizontalPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<BarChartStackedHorizontalPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<BarChartStackedHorizontalPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders BarChart', () => {
+    render(<BarChartStackedHorizontalPro {...defaultProps} />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -85,10 +85,10 @@ describe('BarChartStackedHorizontalPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<BarChartStackedHorizontalPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<BarChartStackedHorizontalPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders BarChart', () => {

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -28,6 +28,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
 
   const {
     hideMenu,
+    exportOptions,
     groupBy,
     measure,
     reverseYAxis,
@@ -104,6 +105,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,11 +24,10 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
 
   const {
-    hideMenu,
-    exportOptions,
     groupBy,
     measure,
     reverseYAxis,
@@ -101,11 +100,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedHorizontalPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,8 +24,8 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const {
     groupBy,
@@ -100,7 +100,7 @@ const BarChartStackedHorizontalPro = (props: BarChartStackedHorizontalProProps) 
       data={results}
       dimensionsAndMeasures={[measure, yAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -41,7 +41,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.showTotalLabels,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartStackedPro/definition.ts
+++ b/src/components/charts/bars/BarChartStackedPro/definition.ts
@@ -41,6 +41,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.showTotalLabels,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/bars/BarChartStackedPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BarChartStackedPro from './index';
+import type { BarChartStackedProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BarChart: () => <div data-testid="bar-chart" />,
+}));
+
+vi.mock('../bars.utils', () => ({
+  getBarStackedChartProData: vi.fn(() => ({ datasets: [] })),
+  getBarStackedChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createGroupedClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../bars.hooks', () => ({
+  useUpdateAxisOrderAndCacheKey: vi.fn(),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const xAxis = { name: 'category', inputs: {} } as unknown as Dimension;
+const groupBy = { name: 'group', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: BarChartStackedProProps = {
+  xAxis,
+  groupBy,
+  measure,
+  results: emptyResults,
+};
+
+describe('BarChartStackedPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<BarChartStackedPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<BarChartStackedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders BarChart', () => {
+    render(<BarChartStackedPro {...defaultProps} />);
+    expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/bars/BarChartStackedPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/bars/BarChartStackedPro/index.test.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -85,10 +85,10 @@ describe('BarChartStackedPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<BarChartStackedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<BarChartStackedPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders BarChart', () => {

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -28,6 +28,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
 
   const {
     hideMenu,
+    exportOptions,
     groupBy,
     measure,
     reverseXAxis,
@@ -104,6 +105,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -100,7 +100,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,8 +24,8 @@ export type BarChartStackedProProps = BarChartStackedBaseProps & {
 const BarChartStackedPro = (props: BarChartStackedProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
-  const resolvedProps = resolveI18nProps(props);
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const {
     groupBy,
@@ -100,7 +100,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/bars/BarChartStackedPro/index.tsx
+++ b/src/components/charts/bars/BarChartStackedPro/index.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { getBarStackedChartProData, getBarStackedChartProOptions } from '../bars.utils';
@@ -24,11 +24,10 @@ export type BarChartStackedProProps = BarChartStackedBaseProps & {
 const BarChartStackedPro = (props: BarChartStackedProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
 
   const {
-    hideMenu,
-    exportOptions,
     groupBy,
     measure,
     reverseXAxis,
@@ -101,11 +100,7 @@ const BarChartStackedPro = (props: BarChartStackedProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results?.error || resultsAxisOrder?.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/combo/BarLineChartPro/definition.ts
+++ b/src/components/charts/combo/BarLineChartPro/definition.ts
@@ -75,7 +75,7 @@ const meta = {
       description: 'Maximum value for the right-hand Y-axis used by line series.',
     },
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/combo/BarLineChartPro/definition.ts
+++ b/src/components/charts/combo/BarLineChartPro/definition.ts
@@ -75,6 +75,7 @@ const meta = {
       description: 'Maximum value for the right-hand Y-axis used by line series.',
     },
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/combo/BarLineChartPro/index.test.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.test.tsx
@@ -32,6 +32,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/combo/BarLineChartPro/index.test.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@embeddable.com/react';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { resolveI18nProps } from '../../../component.utils';
@@ -35,8 +35,6 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     yAxisSecondaryMin,
     yAxisSecondaryMax,
     reverseXAxis,
-    hideMenu,
-    exportOptions,
     dimension,
     granularity,
     setGranularity,
@@ -44,7 +42,8 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     onLineClicked,
   } = props;
 
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
 
   const showSecondaryAxis = lineMeasures.some((m) => Boolean(m.inputs?.['useSecondaryAxis']));
 
@@ -94,11 +93,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures, ...lineMeasures]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -36,6 +36,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     yAxisSecondaryMax,
     reverseXAxis,
     hideMenu,
+    exportOptions,
     dimension,
     granularity,
     setGranularity,
@@ -97,6 +98,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -93,7 +93,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures, ...lineMeasures]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -3,7 +3,7 @@ import { useTheme } from '@embeddable.com/react';
 import { BarChart } from '@embeddable.com/remarkable-ui';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { resolveI18nProps } from '../../../component.utils';
@@ -42,8 +42,8 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
     onLineClicked,
   } = props;
 
-  const resolvedProps = resolveI18nProps(props);
-  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { tooltip, description, title, xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const showSecondaryAxis = lineMeasures.some((m) => Boolean(m.inputs?.['useSecondaryAxis']));
 
@@ -93,7 +93,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures, ...lineMeasures]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/combo/BarLineChartPro/index.tsx
+++ b/src/components/charts/combo/BarLineChartPro/index.tsx
@@ -93,7 +93,7 @@ const BarLineChartPro = (props: BarLineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, ...measures, ...lineMeasures]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/definition.ts
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/definition.ts
@@ -62,6 +62,7 @@ const meta = {
       name: 'changeFontSize',
       label: 'Trend font-size',
     },
+    inputs.exportOptions,
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/definition.ts
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/definition.ts
@@ -62,7 +62,7 @@ const meta = {
       name: 'changeFontSize',
       label: 'Trend font-size',
     },
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.test.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -78,10 +78,10 @@ describe('KpiChartNumberComparisonPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<KpiChartNumberComparisonPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<KpiChartNumberComparisonPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders KpiChart', () => {

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.test.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.test.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Measure, TimeRange } from '@embeddable.com/core';
+import KpiChartNumberComparisonPro from './index';
+import type { KpiChartNumberComparisonProProp } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn(() => '') },
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  KpiChart: () => <div data-testid="kpi-chart" />,
+}));
+
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({
+  getThemeFormatter: vi.fn(() => ({
+    data: vi.fn(() => ''),
+  })),
+}));
+
+vi.mock('../kpis.utils', () => ({
+  getKpiResults: vi.fn((results: DataResponse) => results),
+}));
+
+vi.mock('../../../utils/timeRange.utils', () => ({
+  getComparisonPeriodDateRange: vi.fn(() => ({})),
+  getComparisonPeriodLabel: vi.fn(() => ''),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+const dateRange = {} as unknown as TimeRange;
+
+const defaultProps: KpiChartNumberComparisonProProp = {
+  measure,
+  results: emptyResults,
+  resultsComparison: emptyResults,
+  primaryDateRange: dateRange,
+  comparisonDateRange: dateRange,
+};
+
+describe('KpiChartNumberComparisonPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<KpiChartNumberComparisonPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<KpiChartNumberComparisonPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders KpiChart', () => {
+    render(<KpiChartNumberComparisonPro {...defaultProps} />);
+    expect(screen.getByTestId('kpi-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -105,7 +105,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
         measure,
       ]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -105,7 +105,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
         measure,
       ]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -3,7 +3,11 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse, Measure, TimeRange } from '@embeddable.com/core';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { KpiChart } from '@embeddable.com/remarkable-ui';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { useEffect } from 'react';
@@ -33,10 +37,9 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, displayNullAs } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { displayNullAs } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     changeFontSize,
     comparisonPeriod,
     comparisonDateRange,
@@ -102,11 +105,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
         measure,
       ]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -6,7 +6,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { KpiChart } from '@embeddable.com/remarkable-ui';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
@@ -37,8 +37,8 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { displayNullAs } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { displayNullAs } = resolvedI18nProps;
   const {
     changeFontSize,
     comparisonPeriod,
@@ -105,7 +105,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
         measure,
       ]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -36,6 +36,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
   const { title, description, tooltip, displayNullAs } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     changeFontSize,
     comparisonPeriod,
     comparisonDateRange,
@@ -105,6 +106,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberPro/definition.ts
+++ b/src/components/charts/kpis/KpiChartNumberPro/definition.ts
@@ -20,6 +20,7 @@ const meta = {
     inputs.displayNullAs,
     inputs.tooltip,
     inputs.fontSize,
+    inputs.exportOptions,
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/components/charts/kpis/KpiChartNumberPro/definition.ts
+++ b/src/components/charts/kpis/KpiChartNumberPro/definition.ts
@@ -20,7 +20,7 @@ const meta = {
     inputs.displayNullAs,
     inputs.tooltip,
     inputs.fontSize,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/components/charts/kpis/KpiChartNumberPro/index.test.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.test.tsx
@@ -20,14 +20,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -68,10 +68,10 @@ describe('KpiChartNumberPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<KpiChartNumberPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<KpiChartNumberPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders KpiChart', () => {

--- a/src/components/charts/kpis/KpiChartNumberPro/index.test.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Measure } from '@embeddable.com/core';
+import KpiChartNumberPro from './index';
+import type { KpiChartNumberProProp } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  KpiChart: () => <div data-testid="kpi-chart" />,
+}));
+
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({
+  getThemeFormatter: vi.fn(() => ({
+    data: vi.fn(() => ''),
+  })),
+}));
+
+vi.mock('../kpis.utils', () => ({
+  getKpiResults: vi.fn((results: DataResponse) => results),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: KpiChartNumberProProp = {
+  measure,
+  results: emptyResults,
+};
+
+describe('KpiChartNumberPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<KpiChartNumberPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<KpiChartNumberPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders KpiChart', () => {
+    render(<KpiChartNumberPro {...defaultProps} />);
+    expect(screen.getByTestId('kpi-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/kpis/KpiChartNumberPro/index.test.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/kpis/KpiChartNumberPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.tsx
@@ -39,7 +39,7 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
       data={resultsWithNullsHandled}
       dimensionsAndMeasures={[measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.tsx
@@ -20,7 +20,7 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
   i18nSetup(theme);
 
   const { title, description, tooltip, displayNullAs } = resolveI18nProps(props);
-  const { measure, fontSize, hideMenu, results } = props;
+  const { measure, fontSize, hideMenu, exportOptions, results } = props;
 
   const value = results.data?.[0]?.[measure.name];
 
@@ -38,6 +38,7 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.tsx
@@ -6,7 +6,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { KpiChart } from '@embeddable.com/remarkable-ui';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
@@ -23,8 +23,8 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { displayNullAs } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { displayNullAs } = resolvedI18nProps;
   const { measure, fontSize, results } = props;
 
   const value = results.data?.[0]?.[measure.name];
@@ -39,7 +39,7 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
       data={resultsWithNullsHandled}
       dimensionsAndMeasures={[measure]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.tsx
@@ -39,7 +39,7 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
       data={resultsWithNullsHandled}
       dimensionsAndMeasures={[measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/kpis/KpiChartNumberPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberPro/index.tsx
@@ -3,7 +3,11 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse, Measure } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { KpiChart } from '@embeddable.com/remarkable-ui';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { getKpiResults } from '../kpis.utils';
@@ -19,8 +23,9 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, displayNullAs } = resolveI18nProps(props);
-  const { measure, fontSize, hideMenu, exportOptions, results } = props;
+  const resolvedProps = resolveI18nProps(props);
+  const { displayNullAs } = resolvedProps;
+  const { measure, fontSize, results } = props;
 
   const value = results.data?.[0]?.[measure.name];
 
@@ -34,11 +39,7 @@ const KpiChartNumberPro = (props: KpiChartNumberProProp) => {
       data={resultsWithNullsHandled}
       dimensionsAndMeasures={[measure]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <KpiChart
         displayNullAs={displayNullAs}

--- a/src/components/charts/lines/AreaChartPro/index.test.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/AreaChartPro/index.test.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.test.tsx
@@ -26,7 +26,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { LineChartGroupedProProp } from '../LineChartGroupedPro';
 import {
   createAreaClickHandler,
@@ -23,8 +23,8 @@ const AreaChartPro = (props: AreaChartProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
   const {
     measure,
     xAxis,
@@ -79,7 +79,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -79,7 +79,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -2,7 +2,7 @@ import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { LineChartGroupedProProp } from '../LineChartGroupedPro';
 import {
   createAreaClickHandler,
@@ -23,10 +23,9 @@ const AreaChartPro = (props: AreaChartProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     measure,
     xAxis,
     groupBy,
@@ -80,11 +79,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -26,6 +26,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     measure,
     xAxis,
     groupBy,
@@ -83,6 +84,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/AreaChartPro/index.tsx
+++ b/src/components/charts/lines/AreaChartPro/index.tsx
@@ -79,7 +79,7 @@ const AreaChartPro = (props: AreaChartProProps) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
@@ -105,7 +105,7 @@ const meta = {
       category: 'Component Settings',
     },
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/definition.ts
@@ -105,6 +105,7 @@ const meta = {
       category: 'Component Settings',
     },
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -84,10 +84,10 @@ describe('LineChartComparisonDefaultPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<LineChartComparisonDefaultPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<LineChartComparisonDefaultPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders LineChart', () => {

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure, TimeRange } from '@embeddable.com/core';
+import LineChartComparisonDefaultPro from './index';
+import type { LineChartComparisonDefaultProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  LineChart: () => <div data-testid="line-chart" />,
+}));
+
+vi.mock('./LineChartComparisonDefaultPro.utils', () => ({
+  createComparisonClickHandler: vi.fn(() => vi.fn()),
+  getLineChartComparisonProData: vi.fn(() => ({ datasets: [] })),
+  getLineChartComparisonProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../utils/timeRange.utils', () => ({
+  getComparisonPeriodDateRange: vi.fn(() => ({})),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const xAxis = { name: 'date', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+const dateRange = {} as unknown as TimeRange;
+
+const defaultProps: LineChartComparisonDefaultProProps = {
+  xAxis,
+  measures: [measure],
+  results: emptyResults,
+  resultsComparison: emptyResults,
+  primaryDateRange: dateRange,
+  comparisonDateRange: dateRange,
+};
+
+describe('LineChartComparisonDefaultPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<LineChartComparisonDefaultPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<LineChartComparisonDefaultPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders LineChart', () => {
+    render(<LineChartComparisonDefaultPro {...defaultProps} />);
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
@@ -47,6 +47,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     comparisonPeriod,
     measures,
     xAxis,
@@ -137,6 +138,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
       description={description}
       title={title}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
@@ -138,7 +138,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
@@ -3,7 +3,11 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse, Dimension, Granularity, Measure, TimeRange } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { useEffect } from 'react';
 import { getComparisonPeriodDateRange } from '../../../utils/timeRange.utils';
 import {
@@ -44,10 +48,9 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     comparisonPeriod,
     measures,
     xAxis,
@@ -135,10 +138,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      description={description}
-      title={title}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
@@ -6,7 +6,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { useEffect } from 'react';
 import { getComparisonPeriodDateRange } from '../../../utils/timeRange.utils';
@@ -48,8 +48,8 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
   const {
     comparisonPeriod,
     measures,
@@ -138,7 +138,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonDefaultPro/index.tsx
@@ -138,7 +138,7 @@ const LineChartComparisonDefaultPro = (props: LineChartComparisonDefaultProProps
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.test.tsx
@@ -23,7 +23,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
@@ -136,7 +136,7 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
@@ -4,7 +4,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartTabs, LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
@@ -27,10 +27,9 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     measures,
     xAxis,
     reverseXAxis,
@@ -137,11 +136,7 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
@@ -136,7 +136,7 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
@@ -4,7 +4,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartTabs, LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
@@ -27,8 +27,8 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
   const {
     measures,
     xAxis,
@@ -136,7 +136,7 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
       data={resultsCombined}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error || resultsComparison?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartComparisonWithKpiTabsPro/index.tsx
@@ -30,6 +30,7 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     measures,
     xAxis,
     reverseXAxis,
@@ -140,6 +141,7 @@ const LineChartComparisonWithKpiTabsPro = (props: LineChartComparisonWithKpiTabs
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/definition.ts
@@ -62,7 +62,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/lines/LineChartDefaultPro/definition.ts
+++ b/src/components/charts/lines/LineChartDefaultPro/definition.ts
@@ -62,6 +62,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/lines/LineChartDefaultPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -79,10 +79,10 @@ describe('LineChartDefaultPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<LineChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<LineChartPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders LineChart', () => {

--- a/src/components/charts/lines/LineChartDefaultPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartDefaultPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import LineChartPro from './index';
+import type { LineChartProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  LineChart: () => <div data-testid="line-chart" />,
+}));
+
+vi.mock('./LineChartDefaultPro.utils', () => ({
+  getLineChartProData: vi.fn(() => ({ datasets: [] })),
+  getLineChartProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createSimpleClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const xAxis = { name: 'date', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: LineChartProProps = {
+  xAxis,
+  measures: [measure],
+  results: emptyResults,
+};
+
+describe('LineChartDefaultPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<LineChartPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<LineChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders LineChart', () => {
+    render(<LineChartPro {...defaultProps} />);
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/lines/LineChartDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.tsx
@@ -3,7 +3,11 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { getLineChartProData, getLineChartProOptions } from './LineChartDefaultPro.utils';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { LineChartProOptionsClick } from '../lines.types';
@@ -35,10 +39,9 @@ const LineChartPro = (props: LineChartProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     measures,
     granularity,
     xAxis,
@@ -83,11 +86,7 @@ const LineChartPro = (props: LineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.tsx
@@ -38,6 +38,7 @@ const LineChartPro = (props: LineChartProProps) => {
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     measures,
     granularity,
     xAxis,
@@ -86,6 +87,7 @@ const LineChartPro = (props: LineChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.tsx
@@ -86,7 +86,7 @@ const LineChartPro = (props: LineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.tsx
@@ -6,7 +6,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { getLineChartProData, getLineChartProOptions } from './LineChartDefaultPro.utils';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
@@ -39,8 +39,8 @@ const LineChartPro = (props: LineChartProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
   const {
     measures,
     granularity,
@@ -86,7 +86,7 @@ const LineChartPro = (props: LineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartDefaultPro/index.tsx
+++ b/src/components/charts/lines/LineChartDefaultPro/index.tsx
@@ -86,7 +86,7 @@ const LineChartPro = (props: LineChartProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartGroupedPro/definition.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/definition.ts
@@ -57,7 +57,7 @@ const meta = {
     inputs.reverseXAxis,
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/lines/LineChartGroupedPro/definition.ts
+++ b/src/components/charts/lines/LineChartGroupedPro/definition.ts
@@ -57,6 +57,7 @@ const meta = {
     inputs.reverseXAxis,
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/lines/LineChartGroupedPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartGroupedPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -81,10 +81,10 @@ describe('LineChartGroupedPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<LineChartGroupedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<LineChartGroupedPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders LineChart', () => {

--- a/src/components/charts/lines/LineChartGroupedPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import LineChartGroupedPro from './index';
+import type { LineChartGroupedProProp } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  LineChart: () => <div data-testid="line-chart" />,
+}));
+
+vi.mock('./LineChartGroupedPro.utils', () => ({
+  getLineChartGroupedProData: vi.fn(() => ({ datasets: [] })),
+  getLineChartGroupedProOptions: vi.fn(() => ({})),
+}));
+
+vi.mock('../../charts.utils', () => ({
+  createGroupedClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../shared/ChartGranularitySelectField/ChartGranularitySelectField', () => ({
+  ChartGranularitySelectField: () => <div data-testid="granularity-select" />,
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const xAxis = { name: 'date', inputs: {} } as unknown as Dimension;
+const groupBy = { name: 'group', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: LineChartGroupedProProp = {
+  xAxis,
+  groupBy,
+  measure,
+  results: emptyResults,
+};
+
+describe('LineChartGroupedPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<LineChartGroupedPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<LineChartGroupedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders LineChart', () => {
+    render(<LineChartGroupedPro {...defaultProps} />);
+    expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -3,7 +3,11 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse, Dimension, Granularity, Measure } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import {
   getLineChartGroupedProData,
   getLineChartGroupedProOptions,
@@ -37,10 +41,9 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     measure,
     xAxis,
     groupBy,
@@ -91,11 +94,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -94,7 +94,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -40,6 +40,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     measure,
     xAxis,
     groupBy,
@@ -94,6 +95,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -6,7 +6,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import {
   getLineChartGroupedProData,
@@ -41,8 +41,8 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
   const {
     measure,
     xAxis,
@@ -94,7 +94,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartGroupedPro/index.tsx
+++ b/src/components/charts/lines/LineChartGroupedPro/index.tsx
@@ -94,7 +94,7 @@ const LineChartGroupedPro = (props: LineChartGroupedProProp) => {
       data={results}
       dimensionsAndMeasures={[measure, xAxis, groupBy]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       {setGranularity && (
         <ChartGranularitySelectField

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.test.tsx
@@ -22,7 +22,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.test.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="chart-card">{children}</div>
   ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
@@ -4,7 +4,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartTabs, ChartTabsProps, LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
@@ -24,10 +24,9 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     measures,
     xAxis,
     reverseXAxis,
@@ -97,11 +96,7 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
@@ -4,7 +4,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { DataResponse } from '@embeddable.com/core';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { useFillGaps } from '../../charts.fillGaps.hooks';
 import { ChartTabs, ChartTabsProps, LineChart } from '@embeddable.com/remarkable-ui';
 import { ChartGranularitySelectField } from '../../shared/ChartGranularitySelectField/ChartGranularitySelectField';
@@ -24,8 +24,8 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
   const theme: Theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolvedI18nProps;
   const {
     measures,
     xAxis,
@@ -96,7 +96,7 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
@@ -27,6 +27,7 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     measures,
     xAxis,
     reverseXAxis,
@@ -100,6 +101,7 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
@@ -96,7 +96,7 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
+++ b/src/components/charts/lines/LineChartWithKpiTabsPro/index.tsx
@@ -96,7 +96,7 @@ const LineChartWithKpiTabsPro = (props: LineChartWithKpiTabsProProps) => {
       data={results}
       dimensionsAndMeasures={[...measures, xAxis]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <ChartTabs items={chartTabsItems} value={activeMeasureName} onChange={setActiveMeasureName} />
       {setGranularity && (

--- a/src/components/charts/pies/DonutChartPro/definition.ts
+++ b/src/components/charts/pies/DonutChartPro/definition.ts
@@ -25,6 +25,7 @@ const meta = {
     inputs.maxLegendItems,
     inputs.showTooltips,
     inputs.showValueLabels,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/pies/DonutChartPro/definition.ts
+++ b/src/components/charts/pies/DonutChartPro/definition.ts
@@ -25,7 +25,7 @@ const meta = {
     inputs.maxLegendItems,
     inputs.showTooltips,
     inputs.showValueLabels,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/pies/DonutChartPro/index.test.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import DonutChartPro from './index';
+import type { DonutChartProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({ charts: { donutChartPro: {} } })),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  DonutChart: () => <div data-testid="donut-chart" />,
+}));
+
+vi.mock('../pies.utils', () => ({
+  getPieChartProData: vi.fn(() => ({ datasets: [] })),
+  getPieChartProOptions: vi.fn(() => ({})),
+  createPieClickHandler: vi.fn(() => vi.fn()),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'category', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: DonutChartProProps = {
+  dimension,
+  measure,
+  results: emptyResults,
+};
+
+describe('DonutChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<DonutChartPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<DonutChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders DonutChart', () => {
+    render(<DonutChartPro {...defaultProps} />);
+    expect(screen.getByTestId('donut-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/pies/DonutChartPro/index.test.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.test.tsx
@@ -20,14 +20,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -66,10 +66,10 @@ describe('DonutChartPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<DonutChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<DonutChartPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders DonutChart', () => {

--- a/src/components/charts/pies/DonutChartPro/index.test.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/pies/DonutChartPro/index.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.tsx
@@ -6,15 +6,11 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { DonutChart } from '@embeddable.com/remarkable-ui';
 import { mergician } from 'mergician';
-import { resolveI18nProps } from '../../../component.utils';
-
 export type DonutChartProProps = DefaultPieChartProps;
 
 const DonutChartPro = (props: DonutChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
-
-  const resolvedI18nProps = resolveI18nProps(props);
 
   const {
     dimension,
@@ -44,7 +40,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <DonutChart
         data={data}

--- a/src/components/charts/pies/DonutChartPro/index.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.tsx
@@ -3,7 +3,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { getPieChartProOptions, getPieChartProData, createPieClickHandler } from '../pies.utils';
 import { DefaultPieChartProps } from '../pies.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { DonutChart } from '@embeddable.com/remarkable-ui';
 import { mergician } from 'mergician';
 import { resolveI18nProps } from '../../../component.utils';
@@ -14,12 +14,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const {
-    description,
-
-    title,
-    tooltip,
-  } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
 
   const {
     dimension,
@@ -29,8 +24,6 @@ const DonutChartPro = (props: DonutChartProProps) => {
     showLegend,
     showTooltips,
     showValueLabels,
-    hideMenu,
-    exportOptions,
     onSegmentClick,
   } = props;
 
@@ -51,11 +44,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <DonutChart
         data={data}

--- a/src/components/charts/pies/DonutChartPro/index.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.tsx
@@ -3,7 +3,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { getPieChartProOptions, getPieChartProData, createPieClickHandler } from '../pies.utils';
 import { DefaultPieChartProps } from '../pies.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { DonutChart } from '@embeddable.com/remarkable-ui';
 import { mergician } from 'mergician';
 import { resolveI18nProps } from '../../../component.utils';
@@ -14,7 +14,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
+  const resolvedI18nProps = resolveI18nProps(props);
 
   const {
     dimension,
@@ -44,7 +44,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <DonutChart
         data={data}

--- a/src/components/charts/pies/DonutChartPro/index.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.tsx
@@ -44,7 +44,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <DonutChart
         data={data}

--- a/src/components/charts/pies/DonutChartPro/index.tsx
+++ b/src/components/charts/pies/DonutChartPro/index.tsx
@@ -30,6 +30,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
     showTooltips,
     showValueLabels,
     hideMenu,
+    exportOptions,
     onSegmentClick,
   } = props;
 
@@ -54,6 +55,7 @@ const DonutChartPro = (props: DonutChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <DonutChart
         data={data}

--- a/src/components/charts/pies/DonutLabelChartPro/definition.ts
+++ b/src/components/charts/pies/DonutLabelChartPro/definition.ts
@@ -33,6 +33,7 @@ const meta = {
     inputs.maxLegendItems,
     inputs.showTooltips,
     inputs.showValueLabels,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/pies/DonutLabelChartPro/definition.ts
+++ b/src/components/charts/pies/DonutLabelChartPro/definition.ts
@@ -33,7 +33,7 @@ const meta = {
     inputs.maxLegendItems,
     inputs.showTooltips,
     inputs.showValueLabels,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/pies/DonutLabelChartPro/index.test.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import DonutLabelChartPro from './index';
+import type { DonutLabelChartProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({ charts: { donutLabelChartPro: {} } })),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  DonutChart: () => <div data-testid="donut-chart" />,
+}));
+
+vi.mock('../pies.utils', () => ({
+  getPieChartProData: vi.fn(() => ({ datasets: [] })),
+  getPieChartProOptions: vi.fn(() => ({})),
+  createPieClickHandler: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({
+  getThemeFormatter: vi.fn(() => ({
+    data: vi.fn(() => ''),
+  })),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'category', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+const innerLabelMeasure = { name: 'total', inputs: {} } as unknown as Measure;
+
+const defaultProps: DonutLabelChartProProps = {
+  dimension,
+  measure,
+  results: emptyResults,
+  innerLabelMeasure,
+  resultsInnerLabel: emptyResults,
+};
+
+describe('DonutLabelChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<DonutLabelChartPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<DonutLabelChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders DonutChart', () => {
+    render(<DonutLabelChartPro {...defaultProps} />);
+    expect(screen.getByTestId('donut-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/pies/DonutLabelChartPro/index.test.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.test.tsx
@@ -20,14 +20,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -75,10 +75,10 @@ describe('DonutLabelChartPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<DonutLabelChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<DonutLabelChartPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders DonutChart', () => {

--- a/src/components/charts/pies/DonutLabelChartPro/index.test.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/pies/DonutLabelChartPro/index.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.tsx
@@ -35,7 +35,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
 
   const { description, title, tooltip, innerLabelText, onSegmentClick } = resolveI18nProps(props);
 
-  const { hideMenu } = props;
+  const { hideMenu, exportOptions } = props;
 
   const data = getPieChartProData(
     { data: results.data, dimension, measure, maxLegendItems },
@@ -63,6 +63,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <DonutChart
         label={label}

--- a/src/components/charts/pies/DonutLabelChartPro/index.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.tsx
@@ -58,7 +58,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <DonutChart
         label={label}

--- a/src/components/charts/pies/DonutLabelChartPro/index.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.tsx
@@ -5,7 +5,7 @@ import { DefaultPieChartProps } from '../pies.types';
 import { DataResponse, Measure } from '@embeddable.com/core';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { DonutChart } from '@embeddable.com/remarkable-ui';
 import { mergician } from 'mergician';
 import { resolveI18nProps } from '../../../component.utils';
@@ -33,8 +33,8 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
     innerLabelMeasure,
   } = props;
 
-  const resolvedProps = resolveI18nProps(props);
-  const { innerLabelText, onSegmentClick } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { innerLabelText, onSegmentClick } = resolvedI18nProps;
 
   const data = getPieChartProData(
     { data: results.data, dimension, measure, maxLegendItems },
@@ -58,7 +58,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <DonutChart
         label={label}

--- a/src/components/charts/pies/DonutLabelChartPro/index.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.tsx
@@ -5,7 +5,7 @@ import { DefaultPieChartProps } from '../pies.types';
 import { DataResponse, Measure } from '@embeddable.com/core';
 import { getThemeFormatter } from '../../../../theme/formatter/formatter.utils';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { DonutChart } from '@embeddable.com/remarkable-ui';
 import { mergician } from 'mergician';
 import { resolveI18nProps } from '../../../component.utils';
@@ -33,9 +33,8 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
     innerLabelMeasure,
   } = props;
 
-  const { description, title, tooltip, innerLabelText, onSegmentClick } = resolveI18nProps(props);
-
-  const { hideMenu, exportOptions } = props;
+  const resolvedProps = resolveI18nProps(props);
+  const { innerLabelText, onSegmentClick } = resolvedProps;
 
   const data = getPieChartProData(
     { data: results.data, dimension, measure, maxLegendItems },
@@ -59,11 +58,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <DonutChart
         label={label}

--- a/src/components/charts/pies/DonutLabelChartPro/index.tsx
+++ b/src/components/charts/pies/DonutLabelChartPro/index.tsx
@@ -58,7 +58,7 @@ const DonutChartPro = (props: DonutLabelChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <DonutChart
         label={label}

--- a/src/components/charts/pies/PieChartPro/definition.ts
+++ b/src/components/charts/pies/PieChartPro/definition.ts
@@ -25,6 +25,7 @@ const meta = {
     inputs.maxLegendItems,
     inputs.showTooltips,
     inputs.showValueLabels,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/pies/PieChartPro/definition.ts
+++ b/src/components/charts/pies/PieChartPro/definition.ts
@@ -25,7 +25,7 @@ const meta = {
     inputs.maxLegendItems,
     inputs.showTooltips,
     inputs.showValueLabels,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/pies/PieChartPro/index.test.tsx
+++ b/src/components/charts/pies/PieChartPro/index.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import PieChartPro from './index';
+import type { PieChartProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({ charts: { pieChartPro: {} } })),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  PieChart: () => <div data-testid="pie-chart" />,
+}));
+
+vi.mock('../pies.utils', () => ({
+  getPieChartProData: vi.fn(() => ({ datasets: [] })),
+  getPieChartProOptions: vi.fn(() => ({})),
+  createPieClickHandler: vi.fn(() => vi.fn()),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'category', inputs: {} } as unknown as Dimension;
+const measure = { name: 'revenue', inputs: {} } as unknown as Measure;
+
+const defaultProps: PieChartProProps = {
+  dimension,
+  measure,
+  results: emptyResults,
+};
+
+describe('PieChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<PieChartPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<PieChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders PieChart', () => {
+    render(<PieChartPro {...defaultProps} />);
+    expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/pies/PieChartPro/index.test.tsx
+++ b/src/components/charts/pies/PieChartPro/index.test.tsx
@@ -20,14 +20,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -66,10 +66,10 @@ describe('PieChartPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<PieChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<PieChartPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders PieChart', () => {

--- a/src/components/charts/pies/PieChartPro/index.test.tsx
+++ b/src/components/charts/pies/PieChartPro/index.test.tsx
@@ -33,7 +33,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -6,15 +6,11 @@ import { DefaultPieChartProps } from '../pies.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
 import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { mergician } from 'mergician';
-import { resolveI18nProps } from '../../../component.utils';
-
 export type PieChartProProps = DefaultPieChartProps;
 
 const PieChartPro = (props: PieChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
-
-  const resolvedI18nProps = resolveI18nProps(props);
 
   const {
     dimension,
@@ -44,7 +40,7 @@ const PieChartPro = (props: PieChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <PieChart
         data={data}

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -44,7 +44,7 @@ const PieChartPro = (props: PieChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <PieChart
         data={data}

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -27,7 +27,7 @@ const PieChartPro = (props: PieChartProProps) => {
     onSegmentClick,
   } = props;
 
-  const { hideMenu } = props;
+  const { hideMenu, exportOptions } = props;
 
   const data = getPieChartProData(
     { data: results.data, dimension, measure, maxLegendItems },
@@ -50,6 +50,7 @@ const PieChartPro = (props: PieChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <PieChart
         data={data}

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -4,7 +4,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { getPieChartProOptions, getPieChartProData, createPieClickHandler } from '../pies.utils';
 import { DefaultPieChartProps } from '../pies.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, asChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { mergician } from 'mergician';
 import { resolveI18nProps } from '../../../component.utils';
 
@@ -14,7 +14,7 @@ const PieChartPro = (props: PieChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
+  const resolvedI18nProps = resolveI18nProps(props);
 
   const {
     dimension,
@@ -44,7 +44,7 @@ const PieChartPro = (props: PieChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <PieChart
         data={data}

--- a/src/components/charts/pies/PieChartPro/index.tsx
+++ b/src/components/charts/pies/PieChartPro/index.tsx
@@ -4,7 +4,7 @@ import { Theme } from '../../../../theme/theme.types';
 import { getPieChartProOptions, getPieChartProData, createPieClickHandler } from '../pies.utils';
 import { DefaultPieChartProps } from '../pies.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard } from '../../shared/ChartCard/ChartCard';
+import { ChartCard, pickChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
 import { mergician } from 'mergician';
 import { resolveI18nProps } from '../../../component.utils';
 
@@ -14,7 +14,7 @@ const PieChartPro = (props: PieChartProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { description, title, tooltip } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
 
   const {
     dimension,
@@ -26,8 +26,6 @@ const PieChartPro = (props: PieChartProProps) => {
     showValueLabels,
     onSegmentClick,
   } = props;
-
-  const { hideMenu, exportOptions } = props;
 
   const data = getPieChartProData(
     { data: results.data, dimension, measure, maxLegendItems },
@@ -46,11 +44,7 @@ const PieChartPro = (props: PieChartProProps) => {
       data={results}
       dimensionsAndMeasures={[dimension, measure]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <PieChart
         data={data}

--- a/src/components/charts/scatter/BubbleChartPro/definition.ts
+++ b/src/components/charts/scatter/BubbleChartPro/definition.ts
@@ -66,6 +66,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/scatter/BubbleChartPro/definition.ts
+++ b/src/components/charts/scatter/BubbleChartPro/definition.ts
@@ -66,7 +66,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/scatter/BubbleChartPro/index.test.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import BubbleChartPro from './index';
+import type { BubbleChartProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({ charts: { bubbleChartPro: {} } })),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn(() => '') },
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  BubbleChart: () => <div data-testid="bubble-chart" />,
+}));
+
+vi.mock('./BubbleChartPro.utils', () => ({
+  createBubbleClickHandler: vi.fn(() => vi.fn()),
+  getBubbleChartProData: vi.fn(() => ({ datasets: [] })),
+  getBubbleChartProOptions: vi.fn(() => ({})),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const pointDimension = { name: 'point', inputs: {} } as unknown as Dimension;
+const xMeasure = { name: 'x', inputs: {} } as unknown as Measure;
+const yMeasure = { name: 'y', inputs: {} } as unknown as Measure;
+const bubbleSizeMeasure = { name: 'size', inputs: {} } as unknown as Measure;
+
+const defaultProps: BubbleChartProProps = {
+  xMeasure,
+  yMeasure,
+  bubbleSizeMeasure,
+  pointDimension,
+  results: emptyResults,
+};
+
+describe('BubbleChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<BubbleChartPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<BubbleChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders BubbleChart', () => {
+    render(<BubbleChartPro {...defaultProps} />);
+    expect(screen.getByTestId('bubble-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/scatter/BubbleChartPro/index.test.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/scatter/BubbleChartPro/index.test.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -71,10 +71,10 @@ describe('BubbleChartPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<BubbleChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<BubbleChartPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders BubbleChart', () => {

--- a/src/components/charts/scatter/BubbleChartPro/index.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.tsx
@@ -126,7 +126,7 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <BubbleChart
         data={chartData}

--- a/src/components/charts/scatter/BubbleChartPro/index.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.tsx
@@ -8,7 +8,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import {
   createBubbleClickHandler,
@@ -70,8 +70,8 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
     onPointClick,
   } = props;
 
-  const resolvedProps = resolveI18nProps(props);
-  const { xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const noValueLabel = i18n.t('charts.scatterChart.noValue');
 
@@ -126,7 +126,7 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <BubbleChart
         data={chartData}

--- a/src/components/charts/scatter/BubbleChartPro/index.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.tsx
@@ -126,7 +126,7 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <BubbleChart
         data={chartData}

--- a/src/components/charts/scatter/BubbleChartPro/index.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.tsx
@@ -65,6 +65,7 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
     bubbleRadiusMax,
     onPointClick,
     hideMenu,
+    exportOptions,
   } = props;
 
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
@@ -126,6 +127,7 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <BubbleChart
         data={chartData}

--- a/src/components/charts/scatter/BubbleChartPro/index.tsx
+++ b/src/components/charts/scatter/BubbleChartPro/index.tsx
@@ -5,7 +5,11 @@ import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup, i18n } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import {
   createBubbleClickHandler,
   getBubbleChartProData,
@@ -64,11 +68,10 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
     bubbleRadiusMin,
     bubbleRadiusMax,
     onPointClick,
-    hideMenu,
-    exportOptions,
   } = props;
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { xAxisLabel, yAxisLabel } = resolvedProps;
 
   const noValueLabel = i18n.t('charts.scatterChart.noValue');
 
@@ -123,11 +126,7 @@ const BubbleChartPro = (props: BubbleChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <BubbleChart
         data={chartData}

--- a/src/components/charts/scatter/ScatterChartPro/definition.ts
+++ b/src/components/charts/scatter/ScatterChartPro/definition.ts
@@ -53,6 +53,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/scatter/ScatterChartPro/definition.ts
+++ b/src/components/charts/scatter/ScatterChartPro/definition.ts
@@ -53,7 +53,7 @@ const meta = {
     inputs.yAxisRangeMin,
     inputs.yAxisRangeMax,
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/scatter/ScatterChartPro/index.test.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import ScatterChartPro from './index';
+import type { ScatterChartProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({ charts: { scatterChartPro: {} } })),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn(() => '') },
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  ScatterChart: () => <div data-testid="scatter-chart" />,
+}));
+
+vi.mock('./ScatterChartPro.utils', () => ({
+  createScatterClickHandler: vi.fn(() => vi.fn()),
+  getScatterChartProData: vi.fn(() => ({ datasets: [] })),
+  getScatterChartProOptions: vi.fn(() => ({})),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const pointDimension = { name: 'point', inputs: {} } as unknown as Dimension;
+const xMeasure = { name: 'x', inputs: {} } as unknown as Measure;
+const yMeasure = { name: 'y', inputs: {} } as unknown as Measure;
+
+const defaultProps: ScatterChartProProps = {
+  xMeasure,
+  yMeasure,
+  pointDimension,
+  results: emptyResults,
+};
+
+describe('ScatterChartPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<ScatterChartPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<ScatterChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders ScatterChart', () => {
+    render(<ScatterChartPro {...defaultProps} />);
+    expect(screen.getByTestId('scatter-chart')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/scatter/ScatterChartPro/index.test.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/scatter/ScatterChartPro/index.test.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -69,10 +69,10 @@ describe('ScatterChartPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<ScatterChartPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<ScatterChartPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders ScatterChart', () => {

--- a/src/components/charts/scatter/ScatterChartPro/index.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.tsx
@@ -8,7 +8,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import {
   createScatterClickHandler,
@@ -64,8 +64,8 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
     onPointClick,
   } = props;
 
-  const resolvedProps = resolveI18nProps(props);
-  const { xAxisLabel, yAxisLabel } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { xAxisLabel, yAxisLabel } = resolvedI18nProps;
 
   const noValueLabel = i18n.t('charts.scatterChart.noValue');
 
@@ -107,7 +107,7 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <ScatterChart
         data={chartData}

--- a/src/components/charts/scatter/ScatterChartPro/index.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.tsx
@@ -5,7 +5,11 @@ import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup, i18n } from '../../../../theme/i18n/i18n';
 import { resolveI18nProps } from '../../../component.utils';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import {
   createScatterClickHandler,
   getScatterChartProData,
@@ -58,11 +62,10 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
     yAxisRangeMax,
     reverseXAxis,
     onPointClick,
-    hideMenu,
-    exportOptions,
   } = props;
 
-  const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { xAxisLabel, yAxisLabel } = resolvedProps;
 
   const noValueLabel = i18n.t('charts.scatterChart.noValue');
 
@@ -104,11 +107,7 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      description={description}
-      title={title}
-      tooltip={tooltip}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <ScatterChart
         data={chartData}

--- a/src/components/charts/scatter/ScatterChartPro/index.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.tsx
@@ -107,7 +107,7 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <ScatterChart
         data={chartData}

--- a/src/components/charts/scatter/ScatterChartPro/index.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.tsx
@@ -59,6 +59,7 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
     reverseXAxis,
     onPointClick,
     hideMenu,
+    exportOptions,
   } = props;
 
   const { title, description, tooltip, xAxisLabel, yAxisLabel } = resolveI18nProps(props);
@@ -107,6 +108,7 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
       title={title}
       tooltip={tooltip}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <ScatterChart
         data={chartData}

--- a/src/components/charts/scatter/ScatterChartPro/index.tsx
+++ b/src/components/charts/scatter/ScatterChartPro/index.tsx
@@ -107,7 +107,7 @@ const ScatterChartPro = (props: ScatterChartProProps) => {
         ...(groupByDimension ? [groupByDimension] : []),
       ]}
       errorMessage={results.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <ScatterChart
         data={chartData}

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -25,7 +25,7 @@ export type ChartCardHeaderProps = {
   exportOptions?: (string | unknown)[];
 };
 
-export const pickChartCardHeaderProps = <T extends ChartCardHeaderProps>(
+export const asChartCardHeaderProps = <T extends ChartCardHeaderProps>(
   props: T,
 ): ChartCardHeaderProps => {
   const { title, description, tooltip, hideMenu, exportOptions } = props;

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -22,14 +22,14 @@ export type ChartCardHeaderProps = {
   description?: string;
   tooltip?: string;
   hideMenu?: boolean;
-  exportOptions?: (string | unknown)[];
+  menuOptions?: (string | unknown)[];
 };
 
 export const asChartCardHeaderProps = <T extends ChartCardHeaderProps>(
   props: T,
 ): ChartCardHeaderProps => {
-  const { title, description, tooltip, hideMenu, exportOptions } = props;
-  return { title, description, tooltip, hideMenu, exportOptions };
+  const { title, description, tooltip, hideMenu, menuOptions } = props;
+  return { title, description, tooltip, hideMenu, menuOptions };
 };
 
 type ChartCardProps = {
@@ -53,7 +53,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
       dimensionsAndMeasures = [],
       hideMenu = false,
       onCustomDownload,
-      exportOptions,
+      menuOptions,
     },
     ref,
   ) => {
@@ -112,7 +112,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                   data={data?.data}
                   dimensionsAndMeasures={dimensionsAndMeasures}
                   onCustomDownload={onCustomDownload}
-                  exportOptions={exportOptions as string[]}
+                  menuOptions={menuOptions as string[]}
                 />
               </div>
             </div>

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -22,7 +22,7 @@ export type ChartCardHeaderProps = {
   description?: string;
   tooltip?: string;
   hideMenu?: boolean;
-  exportOptions?: string[];
+  exportOptions?: (string | unknown)[];
 };
 
 type ChartCardProps = {
@@ -105,7 +105,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                   data={data?.data}
                   dimensionsAndMeasures={dimensionsAndMeasures}
                   onCustomDownload={onCustomDownload}
-                  enabledExportOptions={exportOptions}
+                  enabledExportOptions={exportOptions as string[]}
                 />
               </div>
             </div>

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -25,6 +25,13 @@ export type ChartCardHeaderProps = {
   exportOptions?: (string | unknown)[];
 };
 
+export const pickChartCardHeaderProps = <T extends ChartCardHeaderProps>(
+  props: T,
+): ChartCardHeaderProps => {
+  const { title, description, tooltip, hideMenu, exportOptions } = props;
+  return { title, description, tooltip, hideMenu, exportOptions };
+};
+
 type ChartCardProps = {
   children: React.ReactNode;
   data: DataResponse;

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -22,6 +22,7 @@ export type ChartCardHeaderProps = {
   description?: string;
   tooltip?: string;
   hideMenu?: boolean;
+  exportOptions?: string[];
 };
 
 type ChartCardProps = {
@@ -45,6 +46,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
       dimensionsAndMeasures = [],
       hideMenu = false,
       onCustomDownload,
+      exportOptions,
     },
     ref,
   ) => {
@@ -103,6 +105,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                   data={data?.data}
                   dimensionsAndMeasures={dimensionsAndMeasures}
                   onCustomDownload={onCustomDownload}
+                  enabledExportOptions={exportOptions}
                 />
               </div>
             </div>

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -14,6 +14,7 @@ import { ChartCardLoading } from './ChartCardLoading/ChartCardLoading';
 import { ChartCardMenuPro } from './ChartCardMenuPro/ChartCardMenuPro';
 import { Theme } from '../../../../theme/theme.types';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
+import { resolveI18nString } from '../../../component.utils';
 import clsx from 'clsx';
 import { ChartCardMenuOptionOnClickProps } from '../../../../theme/defaults/defaults.ChartCardMenu.constants';
 
@@ -26,11 +27,9 @@ export type ChartCardHeaderProps = {
 };
 
 export const asChartCardHeaderProps = <T extends ChartCardHeaderProps>(
-  resolvedProps: T,
-  originalProps?: T,
+  props: T,
 ): Omit<ChartCardHeaderProps, 'menuOptions'> & { menuOptions?: string[] } => {
-  const { title, description, tooltip, hideMenu } = resolvedProps;
-  const { menuOptions } = originalProps ?? resolvedProps;
+  const { title, description, tooltip, hideMenu, menuOptions } = props;
   return {
     title,
     description,
@@ -67,6 +66,10 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
   ) => {
     const theme: Theme = useTheme() as Theme;
     i18nSetup(theme);
+
+    const resolvedTitle = title ? resolveI18nString(title) : title;
+    const resolvedDescription = description ? resolveI18nString(description) : description;
+    const resolvedTooltip = tooltip ? resolveI18nString(tooltip) : tooltip;
 
     const chartRef = useRef<HTMLDivElement>(null);
 
@@ -107,7 +110,11 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
         {hideMenu ? null : (
           <>
             <div className={styles.chartCardHeader}>
-              <CardHeader title={title} subtitle={description} tooltip={tooltip} />
+              <CardHeader
+                title={resolvedTitle}
+                subtitle={resolvedDescription}
+                tooltip={resolvedTooltip}
+              />
             </div>
             <div className={styles.chartCardRightContent}>
               <div className={clsx(!isLoading && styles.hidden)}>

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -26,9 +26,11 @@ export type ChartCardHeaderProps = {
 };
 
 export const asChartCardHeaderProps = <T extends ChartCardHeaderProps>(
-  props: T,
+  resolvedProps: T,
+  originalProps?: T,
 ): ChartCardHeaderProps => {
-  const { title, description, tooltip, hideMenu, menuOptions } = props;
+  const { title, description, tooltip, hideMenu } = resolvedProps;
+  const { menuOptions } = originalProps ?? resolvedProps;
   return { title, description, tooltip, hideMenu, menuOptions };
 };
 

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -112,7 +112,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                   data={data?.data}
                   dimensionsAndMeasures={dimensionsAndMeasures}
                   onCustomDownload={onCustomDownload}
-                  enabledExportOptions={exportOptions as string[]}
+                  exportOptions={exportOptions as string[]}
                 />
               </div>
             </div>

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -28,10 +28,16 @@ export type ChartCardHeaderProps = {
 export const asChartCardHeaderProps = <T extends ChartCardHeaderProps>(
   resolvedProps: T,
   originalProps?: T,
-): ChartCardHeaderProps => {
+): Omit<ChartCardHeaderProps, 'menuOptions'> & { menuOptions?: string[] } => {
   const { title, description, tooltip, hideMenu } = resolvedProps;
   const { menuOptions } = originalProps ?? resolvedProps;
-  return { title, description, tooltip, hideMenu, menuOptions };
+  return {
+    title,
+    description,
+    tooltip,
+    hideMenu,
+    menuOptions: menuOptions as string[] | undefined,
+  };
 };
 
 type ChartCardProps = {
@@ -41,7 +47,7 @@ type ChartCardProps = {
   style?: CSSProperties;
   dimensionsAndMeasures?: (Dimension | Measure)[];
   onCustomDownload?: (props: (props: ChartCardMenuOptionOnClickProps) => void) => void;
-} & ChartCardHeaderProps;
+} & Omit<ChartCardHeaderProps, 'menuOptions'> & { menuOptions?: string[] };
 
 export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
   (
@@ -114,7 +120,7 @@ export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
                   data={data?.data}
                   dimensionsAndMeasures={dimensionsAndMeasures}
                   onCustomDownload={onCustomDownload}
-                  menuOptions={menuOptions as string[]}
+                  menuOptions={menuOptions}
                 />
               </div>
             </div>

--- a/src/components/charts/shared/ChartCard/ChartCard.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCard.tsx
@@ -14,7 +14,7 @@ import { ChartCardLoading } from './ChartCardLoading/ChartCardLoading';
 import { ChartCardMenuPro } from './ChartCardMenuPro/ChartCardMenuPro';
 import { Theme } from '../../../../theme/theme.types';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
-import { resolveI18nString } from '../../../component.utils';
+import { resolveI18nProps } from '../../../component.utils';
 import clsx from 'clsx';
 import { ChartCardMenuOptionOnClickProps } from '../../../../theme/defaults/defaults.ChartCardMenu.constants';
 
@@ -48,96 +48,80 @@ type ChartCardProps = {
   onCustomDownload?: (props: (props: ChartCardMenuOptionOnClickProps) => void) => void;
 } & Omit<ChartCardHeaderProps, 'menuOptions'> & { menuOptions?: string[] };
 
-export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>(
-  (
-    {
-      tooltip,
-      title,
-      description,
-      children,
-      data,
-      errorMessage,
-      dimensionsAndMeasures = [],
-      hideMenu = false,
-      onCustomDownload,
-      menuOptions,
-    },
-    ref,
-  ) => {
-    const theme: Theme = useTheme() as Theme;
-    i18nSetup(theme);
+export const ChartCard = React.forwardRef<HTMLDivElement, ChartCardProps>((props, ref) => {
+  const theme: Theme = useTheme() as Theme;
+  i18nSetup(theme);
 
-    const resolvedTitle = title ? resolveI18nString(title) : title;
-    const resolvedDescription = description ? resolveI18nString(description) : description;
-    const resolvedTooltip = tooltip ? resolveI18nString(tooltip) : tooltip;
+  const { title, description, tooltip } = resolveI18nProps(props);
+  const {
+    children,
+    data,
+    errorMessage,
+    dimensionsAndMeasures = [],
+    hideMenu = false,
+    onCustomDownload,
+    menuOptions,
+  } = props;
 
-    const chartRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
 
-    const hasData = Boolean(data?.data && data.data?.length > 0);
+  const hasData = Boolean(data?.data && data.data?.length > 0);
 
-    const isLoading = !data || data?.isLoading;
+  const isLoading = !data || data?.isLoading;
 
-    const getDisplay = () => {
-      if (isLoading && !hasData) {
-        return <Skeleton />;
-      }
+  const getDisplay = () => {
+    if (isLoading && !hasData) {
+      return <Skeleton />;
+    }
 
-      if (errorMessage) {
-        return (
-          <CardFeedback
-            variant="error"
-            icon={IconAlertCircle}
-            title={i18n.t('charts.errorTitle')}
-            message={errorMessage}
-          />
-        );
-      }
+    if (errorMessage) {
+      return (
+        <CardFeedback
+          variant="error"
+          icon={IconAlertCircle}
+          title={i18n.t('charts.errorTitle')}
+          message={errorMessage}
+        />
+      );
+    }
 
-      if (!hasData) {
-        return (
-          <CardFeedback
-            title={i18n.t('charts.emptyTitle')}
-            message={i18n.t('charts.emptyMessage')}
-          />
-        );
-      }
+    if (!hasData) {
+      return (
+        <CardFeedback title={i18n.t('charts.emptyTitle')} message={i18n.t('charts.emptyMessage')} />
+      );
+    }
 
-      return children;
-    };
+    return children;
+  };
 
-    return (
-      <Card className={styles.chartCard}>
-        {hideMenu ? null : (
-          <>
-            <div className={styles.chartCardHeader}>
-              <CardHeader
-                title={resolvedTitle}
-                subtitle={resolvedDescription}
-                tooltip={resolvedTooltip}
+  return (
+    <Card className={styles.chartCard}>
+      {hideMenu ? null : (
+        <>
+          <div className={styles.chartCardHeader}>
+            <CardHeader title={title} subtitle={description} tooltip={tooltip} />
+          </div>
+          <div className={styles.chartCardRightContent}>
+            <div className={clsx(!isLoading && styles.hidden)}>
+              <ChartCardLoading />
+            </div>
+            <div className={clsx(isLoading && styles.hidden)}>
+              <ChartCardMenuPro
+                title={title}
+                containerRef={chartRef}
+                data={data?.data}
+                dimensionsAndMeasures={dimensionsAndMeasures}
+                onCustomDownload={onCustomDownload}
+                menuOptions={menuOptions}
               />
             </div>
-            <div className={styles.chartCardRightContent}>
-              <div className={clsx(!isLoading && styles.hidden)}>
-                <ChartCardLoading />
-              </div>
-              <div className={clsx(isLoading && styles.hidden)}>
-                <ChartCardMenuPro
-                  title={title}
-                  containerRef={chartRef}
-                  data={data?.data}
-                  dimensionsAndMeasures={dimensionsAndMeasures}
-                  onCustomDownload={onCustomDownload}
-                  menuOptions={menuOptions}
-                />
-              </div>
-            </div>
-          </>
-        )}
+          </div>
+        </>
+      )}
 
-        <CardContent ref={onCustomDownload ? ref : chartRef}>{getDisplay()}</CardContent>
-      </Card>
-    );
-  },
-);
+      <CardContent ref={onCustomDownload ? ref : chartRef}>{getDisplay()}</CardContent>
+    </Card>
+  );
+});
 
 ChartCard.displayName = 'ChartCard';

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { ChartCardMenuPro } from './ChartCardMenuPro';
+import { ChartCardMenuPro, InlineSvgFromData } from './ChartCardMenuPro';
 
 vi.mock('@embeddable.com/react', () => ({
   useTheme: vi.fn(() => ({
@@ -50,6 +50,31 @@ vi.mock('../ChartCardLoading/ChartCardLoading', () => ({
 }));
 
 import { useTheme } from '@embeddable.com/react';
+
+describe('InlineSvgFromData', () => {
+  it('decodes and renders an SVG from a data URL', () => {
+    const svgContent = '<svg><circle cx="50" cy="50" r="40"/></svg>';
+    const encoded = `data:image/svg+xml,${encodeURIComponent(svgContent)}`;
+
+    const { container } = render(<InlineSvgFromData src={encoded} />);
+
+    expect(container.querySelector('div')).toBeTruthy();
+    expect(container.innerHTML).toContain('circle');
+  });
+
+  it('forwards className and extra props to the wrapper div', () => {
+    const { container } = render(
+      <InlineSvgFromData
+        src="data:image/svg+xml,%3Csvg%2F%3E"
+        className="icon"
+        data-testid="svg-wrapper"
+      />,
+    );
+
+    expect(container.querySelector('.icon')).toBeTruthy();
+    expect(container.querySelector('[data-testid="svg-wrapper"]')).toBeTruthy();
+  });
+});
 
 describe('ChartCardMenuPro', () => {
   beforeEach(() => {

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { ChartCardMenuPro } from './ChartCardMenuPro';
 
@@ -31,8 +31,10 @@ vi.mock('@embeddable.com/remarkable-ui', () => ({
   SelectFieldContent: ({ children }: { children: React.ReactNode }) => (
     <div data-testid="select-field-content">{children}</div>
   ),
-  SelectListOption: ({ label }: { label: string }) => (
-    <div data-testid="select-list-option">{label}</div>
+  SelectListOption: ({ label, onClick }: { label: string; onClick?: () => void }) => (
+    <div data-testid="select-list-option" onClick={onClick}>
+      {label}
+    </div>
   ),
 }));
 
@@ -93,5 +95,74 @@ describe('ChartCardMenuPro', () => {
     const { container } = render(<ChartCardMenuPro />);
 
     expect(container.firstChild).toBeNull();
+  });
+
+  it('calls the option onClick with theme and props when an option is clicked', async () => {
+    vi.useFakeTimers();
+    const onClickMock = vi.fn().mockResolvedValue(undefined);
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({
+      defaults: {
+        chartMenuOptions: [{ value: 'csv', labelKey: 'export.csv', onClick: onClickMock }],
+      },
+    });
+
+    render(<ChartCardMenuPro title="My Chart" />);
+    fireEvent.click(screen.getByText('export.csv'));
+
+    await vi.runAllTimersAsync();
+
+    expect(onClickMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'My Chart' }));
+    vi.useRealTimers();
+  });
+
+  it('calls onCustomDownload instead of onClick directly when provided', async () => {
+    vi.useFakeTimers();
+    const onClickMock = vi.fn().mockResolvedValue(undefined);
+    const onCustomDownload = vi.fn((cb) => cb({ title: 'custom' }));
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({
+      defaults: {
+        chartMenuOptions: [{ value: 'csv', labelKey: 'export.csv', onClick: onClickMock }],
+      },
+    });
+
+    render(<ChartCardMenuPro onCustomDownload={onCustomDownload} />);
+    fireEvent.click(screen.getByText('export.csv'));
+
+    await vi.runAllTimersAsync();
+
+    expect(onCustomDownload).toHaveBeenCalled();
+    expect(onClickMock).toHaveBeenCalledWith(expect.objectContaining({ title: 'custom' }));
+    vi.useRealTimers();
+  });
+
+  it('shows loading state while export is in progress', async () => {
+    vi.useFakeTimers();
+    let resolveExport!: () => void;
+    const onClickMock = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveExport = resolve;
+        }),
+    );
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({
+      defaults: {
+        chartMenuOptions: [{ value: 'csv', labelKey: 'export.csv', onClick: onClickMock }],
+      },
+    });
+
+    render(<ChartCardMenuPro />);
+    fireEvent.click(screen.getByText('export.csv'));
+
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(screen.getByTestId('chart-card-loading')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveExport();
+      await vi.runAllTimersAsync();
+    });
+
+    expect(screen.queryByTestId('chart-card-loading')).not.toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { ChartCardMenuPro } from './ChartCardMenuPro';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({
+    defaults: {
+      chartMenuOptions: [
+        { value: 'csv', labelKey: 'export.csv', onClick: vi.fn() },
+        { value: 'png', labelKey: 'export.png', onClick: vi.fn() },
+        { value: 'pdf', labelKey: 'export.pdf', onClick: vi.fn() },
+      ],
+    },
+  })),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  Dropdown: ({
+    children,
+    triggerComponent,
+  }: {
+    children: React.ReactNode;
+    triggerComponent: React.ReactNode;
+  }) => (
+    <div data-testid="dropdown">
+      {triggerComponent}
+      {children}
+    </div>
+  ),
+  ActionIcon: (_props: { icon: unknown }) => <button data-testid="action-icon" />,
+  SelectFieldContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="select-field-content">{children}</div>
+  ),
+  SelectListOption: ({ label }: { label: string }) => (
+    <div data-testid="select-list-option">{label}</div>
+  ),
+}));
+
+vi.mock('../../../../../theme/i18n/i18n', () => ({
+  i18n: { t: (key: string) => key },
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('@tabler/icons-react', () => ({ IconDotsVertical: {} }));
+
+vi.mock('../ChartCardLoading/ChartCardLoading', () => ({
+  ChartCardLoading: () => <div data-testid="chart-card-loading" />,
+}));
+
+import { useTheme } from '@embeddable.com/react';
+
+describe('ChartCardMenuPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({
+      defaults: {
+        chartMenuOptions: [
+          { value: 'csv', labelKey: 'export.csv', onClick: vi.fn() },
+          { value: 'png', labelKey: 'export.png', onClick: vi.fn() },
+          { value: 'pdf', labelKey: 'export.pdf', onClick: vi.fn() },
+        ],
+      },
+    });
+  });
+
+  it('renders all menu options when enabledExportOptions is not provided', () => {
+    render(<ChartCardMenuPro />);
+
+    expect(screen.getByText('export.csv')).toBeInTheDocument();
+    expect(screen.getByText('export.png')).toBeInTheDocument();
+    expect(screen.getByText('export.pdf')).toBeInTheDocument();
+  });
+
+  it('renders only the enabled options when enabledExportOptions filters to a subset', () => {
+    render(<ChartCardMenuPro enabledExportOptions={['csv', 'png']} />);
+
+    expect(screen.getByText('export.csv')).toBeInTheDocument();
+    expect(screen.getByText('export.png')).toBeInTheDocument();
+    expect(screen.queryByText('export.pdf')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when enabledExportOptions is an empty array', () => {
+    const { container } = render(<ChartCardMenuPro enabledExportOptions={[]} />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when theme has no chartMenuOptions', () => {
+    (useTheme as ReturnType<typeof vi.fn>).mockReturnValue({
+      defaults: {},
+    });
+
+    const { container } = render(<ChartCardMenuPro />);
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
@@ -99,7 +99,7 @@ describe('ChartCardMenuPro', () => {
   });
 
   it('renders only the enabled options when enabledExportOptions filters to a subset', () => {
-    render(<ChartCardMenuPro enabledExportOptions={['csv', 'png']} />);
+    render(<ChartCardMenuPro exportOptions={['csv', 'png']} />);
 
     expect(screen.getByText('export.csv')).toBeInTheDocument();
     expect(screen.getByText('export.png')).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe('ChartCardMenuPro', () => {
   });
 
   it('renders nothing when enabledExportOptions is an empty array', () => {
-    const { container } = render(<ChartCardMenuPro enabledExportOptions={[]} />);
+    const { container } = render(<ChartCardMenuPro exportOptions={[]} />);
 
     expect(container.firstChild).toBeNull();
   });

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.test.tsx
@@ -99,7 +99,7 @@ describe('ChartCardMenuPro', () => {
   });
 
   it('renders only the enabled options when enabledExportOptions filters to a subset', () => {
-    render(<ChartCardMenuPro exportOptions={['csv', 'png']} />);
+    render(<ChartCardMenuPro menuOptions={['csv', 'png']} />);
 
     expect(screen.getByText('export.csv')).toBeInTheDocument();
     expect(screen.getByText('export.png')).toBeInTheDocument();
@@ -107,7 +107,7 @@ describe('ChartCardMenuPro', () => {
   });
 
   it('renders nothing when enabledExportOptions is an empty array', () => {
-    const { container } = render(<ChartCardMenuPro exportOptions={[]} />);
+    const { container } = render(<ChartCardMenuPro menuOptions={[]} />);
 
     expect(container.firstChild).toBeNull();
   });

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
@@ -37,7 +37,7 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
   const allOptions = theme.defaults.chartMenuOptions ?? [];
   const { enabledExportOptions } = props;
   const options = enabledExportOptions
-    ? allOptions.filter((option) => enabledExportOptions.includes(option.key))
+    ? allOptions.filter((option) => enabledExportOptions.includes(option.value))
     : allOptions;
 
   if (options.length === 0) {

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
@@ -25,7 +25,7 @@ export function InlineSvgFromData({ src, className, ...rest }: InlineSvgFromData
 }
 
 type ChartCardMenuProProps = Omit<ChartCardMenuOptionOnClickProps, 'theme'> & {
-  exportOptions?: string[];
+  menuOptions?: string[];
 };
 
 export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
@@ -35,9 +35,9 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const allOptions = theme.defaults.chartMenuOptions ?? [];
-  const { exportOptions } = props;
-  const options = exportOptions
-    ? allOptions.filter((option) => exportOptions.includes(option.value))
+  const { menuOptions } = props;
+  const options = menuOptions
+    ? allOptions.filter((option) => menuOptions.includes(option.value))
     : allOptions;
 
   if (options.length === 0) {

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
@@ -24,7 +24,9 @@ export function InlineSvgFromData({ src, className, ...rest }: InlineSvgFromData
   return <div className={className} {...rest} dangerouslySetInnerHTML={{ __html: svgMarkup }} />;
 }
 
-type ChartCardMenuProProps = Omit<ChartCardMenuOptionOnClickProps, 'theme'>;
+type ChartCardMenuProProps = Omit<ChartCardMenuOptionOnClickProps, 'theme'> & {
+  enabledExportOptions?: string[];
+};
 
 export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
   const theme: Theme = useTheme() as Theme;
@@ -32,7 +34,11 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
 
   const [isLoading, setIsLoading] = React.useState(false);
 
-  const options = theme.defaults.chartMenuOptions ?? [];
+  const allOptions = theme.defaults.chartMenuOptions ?? [];
+  const options =
+    props.enabledExportOptions !== undefined
+      ? allOptions.filter((option) => props.enabledExportOptions!.includes(option.key))
+      : allOptions;
 
   if (options.length === 0) {
     return null;

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
@@ -25,7 +25,7 @@ export function InlineSvgFromData({ src, className, ...rest }: InlineSvgFromData
 }
 
 type ChartCardMenuProProps = Omit<ChartCardMenuOptionOnClickProps, 'theme'> & {
-  enabledExportOptions?: string[];
+  exportOptions?: string[];
 };
 
 export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
@@ -35,9 +35,9 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const allOptions = theme.defaults.chartMenuOptions ?? [];
-  const { enabledExportOptions } = props;
-  const options = enabledExportOptions
-    ? allOptions.filter((option) => enabledExportOptions.includes(option.value))
+  const { exportOptions } = props;
+  const options = exportOptions
+    ? allOptions.filter((option) => exportOptions.includes(option.value))
     : allOptions;
 
   if (options.length === 0) {

--- a/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
+++ b/src/components/charts/shared/ChartCard/ChartCardMenuPro/ChartCardMenuPro.tsx
@@ -35,10 +35,10 @@ export const ChartCardMenuPro: React.FC<ChartCardMenuProProps> = (props) => {
   const [isLoading, setIsLoading] = React.useState(false);
 
   const allOptions = theme.defaults.chartMenuOptions ?? [];
-  const options =
-    props.enabledExportOptions !== undefined
-      ? allOptions.filter((option) => props.enabledExportOptions!.includes(option.key))
-      : allOptions;
+  const { enabledExportOptions } = props;
+  const options = enabledExportOptions
+    ? allOptions.filter((option) => enabledExportOptions.includes(option.key))
+    : allOptions;
 
   if (options.length === 0) {
     return null;

--- a/src/components/charts/tables/HeatMapPro/definition.ts
+++ b/src/components/charts/tables/HeatMapPro/definition.ts
@@ -81,7 +81,7 @@ const meta = {
       category: 'Component Settings',
     },
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/tables/HeatMapPro/definition.ts
+++ b/src/components/charts/tables/HeatMapPro/definition.ts
@@ -81,6 +81,7 @@ const meta = {
       category: 'Component Settings',
     },
     inputs.maxResults,
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/tables/HeatMapPro/index.test.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/tables/HeatMapPro/index.test.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -80,10 +80,10 @@ describe('HeatMapPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<HeatMapPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<HeatMapPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders HeatMap', () => {

--- a/src/components/charts/tables/HeatMapPro/index.test.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.test.tsx
@@ -1,0 +1,93 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import HeatMapPro from './index';
+import type { HeatMapProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  HeatMap: () => <div data-testid="heat-map" />,
+  getStyle: vi.fn(() => '#FF5400'),
+}));
+
+vi.mock('../../../../theme/formatter/formatter.utils', () => ({
+  getThemeFormatter: vi.fn(() => ({
+    dimensionOrMeasureTitle: vi.fn(() => ''),
+    data: vi.fn(() => ''),
+  })),
+}));
+
+vi.mock('../tables.hooks', () => ({
+  useGetTableSortedResults: vi.fn((args: { results: DataResponse }) => args.results),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const rowDimension = { name: 'row', inputs: {} } as unknown as Dimension;
+const columnDimension = { name: 'col', inputs: {} } as unknown as Dimension;
+const measure = { name: 'value', inputs: {} } as unknown as Measure;
+
+const defaultProps: HeatMapProProps = {
+  rowDimension,
+  columnDimension,
+  measure,
+  results: emptyResults,
+};
+
+describe('HeatMapPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<HeatMapPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<HeatMapPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders HeatMap', () => {
+    render(<HeatMapPro {...defaultProps} />);
+    expect(screen.getByTestId('heat-map')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/tables/HeatMapPro/index.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.tsx
@@ -72,6 +72,7 @@ const HeatMapPro = (props: HeatMapProProps) => {
   const { title, description, tooltip } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     measure,
     rowDimension,
     columnDimension,
@@ -148,6 +149,7 @@ const HeatMapPro = (props: HeatMapProProps) => {
       dimensionsAndMeasures={[rowDimension, columnDimension, measure]}
       errorMessage={props.results?.error}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <HeatMap
         data={results}

--- a/src/components/charts/tables/HeatMapPro/index.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.tsx
@@ -147,7 +147,7 @@ const HeatMapPro = (props: HeatMapProProps) => {
       data={props.results}
       dimensionsAndMeasures={[rowDimension, columnDimension, measure]}
       errorMessage={props.results?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <HeatMap
         data={results}

--- a/src/components/charts/tables/HeatMapPro/index.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.tsx
@@ -4,7 +4,7 @@ import { i18nSetup } from '../../../../theme/i18n/i18n';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
@@ -73,7 +73,7 @@ const HeatMapPro = (props: HeatMapProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
+  const resolvedI18nProps = resolveI18nProps(props);
   const {
     measure,
     rowDimension,
@@ -147,7 +147,7 @@ const HeatMapPro = (props: HeatMapProProps) => {
       data={props.results}
       dimensionsAndMeasures={[rowDimension, columnDimension, measure]}
       errorMessage={props.results?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <HeatMap
         data={results}

--- a/src/components/charts/tables/HeatMapPro/index.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.tsx
@@ -6,7 +6,6 @@ import {
   ChartCardHeaderProps,
   asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
-import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import {
   getStyle,
@@ -73,7 +72,6 @@ const HeatMapPro = (props: HeatMapProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedI18nProps = resolveI18nProps(props);
   const {
     measure,
     rowDimension,
@@ -147,7 +145,7 @@ const HeatMapPro = (props: HeatMapProProps) => {
       data={props.results}
       dimensionsAndMeasures={[rowDimension, columnDimension, measure]}
       errorMessage={props.results?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <HeatMap
         data={results}

--- a/src/components/charts/tables/HeatMapPro/index.tsx
+++ b/src/components/charts/tables/HeatMapPro/index.tsx
@@ -1,7 +1,11 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import {
@@ -69,10 +73,8 @@ const HeatMapPro = (props: HeatMapProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
   const {
-    hideMenu,
-    exportOptions,
     measure,
     rowDimension,
     columnDimension,
@@ -142,14 +144,10 @@ const HeatMapPro = (props: HeatMapProProps) => {
 
   return (
     <ChartCard
-      title={title}
-      description={description}
-      tooltip={tooltip}
       data={props.results}
       dimensionsAndMeasures={[rowDimension, columnDimension, measure]}
       errorMessage={props.results?.error}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <HeatMap
         data={results}

--- a/src/components/charts/tables/PivotTablePro/definition.ts
+++ b/src/components/charts/tables/PivotTablePro/definition.ts
@@ -76,6 +76,7 @@ const meta = {
       category: 'Component Settings',
     },
     inputs.maxResults,
+    inputs.exportOptions,
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/components/charts/tables/PivotTablePro/definition.ts
+++ b/src/components/charts/tables/PivotTablePro/definition.ts
@@ -76,7 +76,7 @@ const meta = {
       category: 'Component Settings',
     },
     inputs.maxResults,
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
 } as const satisfies EmbeddedComponentMeta;
 

--- a/src/components/charts/tables/PivotTablePro/index.test.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.test.tsx
@@ -35,7 +35,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('../../charts.fillGaps.hooks', () => ({

--- a/src/components/charts/tables/PivotTablePro/index.test.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.test.tsx
@@ -22,14 +22,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -86,10 +86,10 @@ describe('PivotTablePro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<PivotTablePro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<PivotTablePro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders PivotTable', () => {

--- a/src/components/charts/tables/PivotTablePro/index.test.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, Measure } from '@embeddable.com/core';
+import PivotTablePro from './index';
+import type { PivotTableProProps } from './index';
+import { useFillGaps } from '../../charts.fillGaps.hooks';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn(() => '') },
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('../../charts.fillGaps.hooks', () => ({
+  useFillGaps: vi.fn(),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  PivotTable: () => <div data-testid="pivot-table" />,
+}));
+
+vi.mock('./PivotPro.utils', () => ({
+  getPivotMeasures: vi.fn(() => []),
+  getPivotDimension: vi.fn(() => ({})),
+  getPivotColumnTotalsFor: vi.fn(() => []),
+  getPivotRowTotalsFor: vi.fn(() => []),
+}));
+
+vi.mock('../tables.hooks', () => ({
+  useGetTableSortedResults: vi.fn((args: { results: DataResponse }) => args.results),
+}));
+
+vi.mock('../../../../utils/array.utils', () => ({
+  sortArrayByProp: vi.fn((arr: unknown[]) => arr),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const rowDimension = { name: 'row', inputs: {} } as unknown as Dimension;
+const columnDimension = { name: 'col', inputs: {} } as unknown as Dimension;
+const measure = { name: 'value', inputs: {} } as unknown as Measure;
+
+const defaultProps: PivotTableProProps = {
+  rowDimension,
+  columnDimension,
+  measures: [measure],
+  results: emptyResults,
+  expandedRowKeys: [],
+  setExpandedRowKey: vi.fn(),
+};
+
+describe('PivotTablePro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useFillGaps).mockReturnValue(emptyResults);
+  });
+
+  it('renders ChartCard', () => {
+    render(<PivotTablePro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<PivotTablePro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders PivotTable', () => {
+    render(<PivotTablePro {...defaultProps} />);
+    expect(screen.getByTestId('pivot-table')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -143,7 +143,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
       data={data}
       dimensionsAndMeasures={[rowDimension, columnDimension, ...measures]}
       errorMessage={props.results?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <PivotTable
         firstColumnWidth={firstColumnWidth}

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -6,7 +6,6 @@ import {
   ChartCardHeaderProps,
   asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
-import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { PivotTable } from '@embeddable.com/remarkable-ui';
 import { useEffect, useRef, useState } from 'react';
@@ -40,7 +39,6 @@ const PivotTablePro = (props: PivotTableProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedI18nProps = resolveI18nProps(props);
   const {
     resultsSubRows,
     measures,
@@ -143,7 +141,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
       data={data}
       dimensionsAndMeasures={[rowDimension, columnDimension, ...measures]}
       errorMessage={props.results?.error}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <PivotTable
         firstColumnWidth={firstColumnWidth}

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -4,7 +4,7 @@ import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
@@ -40,7 +40,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const resolvedProps = resolveI18nProps(props);
+  const resolvedI18nProps = resolveI18nProps(props);
   const {
     resultsSubRows,
     measures,
@@ -143,7 +143,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
       data={data}
       dimensionsAndMeasures={[rowDimension, columnDimension, ...measures]}
       errorMessage={props.results?.error}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <PivotTable
         firstColumnWidth={firstColumnWidth}

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -1,7 +1,11 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import { DataResponse, Dimension, Measure } from '@embeddable.com/core';
 import { PivotTable } from '@embeddable.com/remarkable-ui';
@@ -36,7 +40,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
   const theme = useTheme() as Theme;
   i18nSetup(theme);
 
-  const { title, description, tooltip } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
   const {
     resultsSubRows,
     measures,
@@ -46,8 +50,6 @@ const PivotTablePro = (props: PivotTableProProps) => {
     displayNullAs,
     columnWidth,
     firstColumnWidth,
-    hideMenu,
-    exportOptions,
     expandedRowKeys,
     setExpandedRowKey,
   } = props;
@@ -138,14 +140,10 @@ const PivotTablePro = (props: PivotTableProProps) => {
   return (
     <ChartCard
       ref={cardContentRef}
-      title={title}
-      description={description}
-      tooltip={tooltip}
       data={data}
       dimensionsAndMeasures={[rowDimension, columnDimension, ...measures]}
       errorMessage={props.results?.error}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <PivotTable
         firstColumnWidth={firstColumnWidth}

--- a/src/components/charts/tables/PivotTablePro/index.tsx
+++ b/src/components/charts/tables/PivotTablePro/index.tsx
@@ -47,6 +47,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
     columnWidth,
     firstColumnWidth,
     hideMenu,
+    exportOptions,
     expandedRowKeys,
     setExpandedRowKey,
   } = props;
@@ -144,6 +145,7 @@ const PivotTablePro = (props: PivotTableProProps) => {
       dimensionsAndMeasures={[rowDimension, columnDimension, ...measures]}
       errorMessage={props.results?.error}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <PivotTable
         firstColumnWidth={firstColumnWidth}

--- a/src/components/charts/tables/TableChartPaginated/definition.ts
+++ b/src/components/charts/tables/TableChartPaginated/definition.ts
@@ -59,7 +59,7 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
-    inputs.exportOptions,
+    inputs.menuOptions,
   ],
   events: [
     {

--- a/src/components/charts/tables/TableChartPaginated/definition.ts
+++ b/src/components/charts/tables/TableChartPaginated/definition.ts
@@ -59,6 +59,7 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/tables/TableChartPaginated/index.test.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/tables/TableChartPaginated/index.test.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -73,10 +73,10 @@ describe('TableChartPaginatedPro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<TableChartPaginatedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<TableChartPaginatedPro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders TablePaginated', () => {

--- a/src/components/charts/tables/TableChartPaginated/index.test.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, DimensionOrMeasure } from '@embeddable.com/core';
+import TableChartPaginatedPro from './index';
+import type { TableChartPaginatedProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn(() => '') },
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  TablePaginated: () => <div data-testid="table-paginated" />,
+  getStyleNumber: vi.fn(() => 40),
+  getTableTotalPages: vi.fn(() => 1),
+  useTableGetRowsPerPage: vi.fn(() => 10),
+  useResizeObserver: vi.fn(() => ({ height: 400 })),
+}));
+
+vi.mock('../tables.utils', () => ({
+  getTableHeaders: vi.fn(() => []),
+  getTableRows: vi.fn(() => []),
+}));
+
+vi.mock('../../../utils/dimension.utils', () => ({
+  getTimeRangeFromDimensionValue: vi.fn(() => undefined),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'category', inputs: {} } as unknown as Dimension;
+const dimensionsAndMeasures: DimensionOrMeasure[] = [dimension];
+
+const defaultProps: TableChartPaginatedProProps = {
+  dimensionsAndMeasures,
+  results: emptyResults,
+};
+
+describe('TableChartPaginatedPro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<TableChartPaginatedPro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<TableChartPaginatedPro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders TablePaginated', () => {
+    render(<TableChartPaginatedPro {...defaultProps} />);
+    expect(screen.getByTestId('table-paginated')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -164,7 +164,7 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <TablePaginated
         onRowIndexClick={handleRowIndexClick}

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -66,6 +66,7 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
   const { title, description, tooltip } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     totalResults,
     results,
     allResults,
@@ -164,6 +165,7 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <TablePaginated
         onRowIndexClick={handleRowIndexClick}

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -164,7 +164,7 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <TablePaginated
         onRowIndexClick={handleRowIndexClick}

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -1,7 +1,11 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import {
   DataResponse,
@@ -63,10 +67,9 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
 
   const [isDownloadingData, setIsDownloadingData] = useState(false);
 
-  const { title, description, tooltip } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     totalResults,
     results,
     allResults,
@@ -157,15 +160,11 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
   return (
     <ChartCard
       ref={cardContentRef}
-      title={title}
-      description={description}
-      tooltip={tooltip}
       data={results}
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <TablePaginated
         onRowIndexClick={handleRowIndexClick}

--- a/src/components/charts/tables/TableChartPaginated/index.tsx
+++ b/src/components/charts/tables/TableChartPaginated/index.tsx
@@ -4,7 +4,7 @@ import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import {
@@ -67,8 +67,8 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
 
   const [isDownloadingData, setIsDownloadingData] = useState(false);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title } = resolvedI18nProps;
   const {
     totalResults,
     results,
@@ -164,7 +164,7 @@ const TableChartPaginatedPro = (props: TableChartPaginatedProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <TablePaginated
         onRowIndexClick={handleRowIndexClick}

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -12,7 +12,7 @@ import TableScrollableChart, {
   TableScrollableProState,
 } from './index';
 import { inputs } from '../../../component.inputs.constants';
-import { ExportOption } from '../../../types/ExportOption.type.emb';
+import { ExportOptionTypeOptions } from '../../../types/ExportOption.type.emb';
 import { getSortDirectionValue } from '../../../types/SortDirection.type.emb';
 import { subInputs } from '../../../component.subinputs.constants';
 import { TABLE_SCROLLABLE_SIZE } from './TableScrollable.utils';
@@ -62,7 +62,10 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
-    { ...inputs.menuOptions, defaultValue: [ExportOption.csv, ExportOption.xlsx] },
+    {
+      ...inputs.menuOptions,
+      defaultValue: [ExportOptionTypeOptions.csv, ExportOptionTypeOptions.xlsx],
+    },
   ],
   events: [
     {

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -12,6 +12,7 @@ import TableScrollableChart, {
   TableScrollableProState,
 } from './index';
 import { inputs } from '../../../component.inputs.constants';
+import { ExportOption } from '../../../types/ExportOption.type.emb';
 import { getSortDirectionValue } from '../../../types/SortDirection.type.emb';
 import { subInputs } from '../../../component.subinputs.constants';
 import { TABLE_SCROLLABLE_SIZE } from './TableScrollable.utils';
@@ -61,7 +62,7 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
-    { ...inputs.menuOptions, defaultValue: ['csv', 'xlsx'] },
+    { ...inputs.menuOptions, defaultValue: [ExportOption.csv, ExportOption.xlsx] },
   ],
   events: [
     {

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -61,6 +61,7 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
+    inputs.exportOptions,
   ],
   events: [
     {

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -61,7 +61,7 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
-    { ...inputs.exportOptions, defaultValue: ['csv', 'xlsx'] },
+    { ...inputs.menuOptions, defaultValue: ['csv', 'xlsx'] },
   ],
   events: [
     {

--- a/src/components/charts/tables/TableScrollable/definition.ts
+++ b/src/components/charts/tables/TableScrollable/definition.ts
@@ -61,7 +61,7 @@ const meta = {
       category: 'Component Settings',
     },
     { ...inputs.sortDirection, label: 'Default sort direction', category: 'Component Settings' },
-    inputs.exportOptions,
+    { ...inputs.exportOptions, defaultValue: ['csv', 'xlsx'] },
   ],
   events: [
     {

--- a/src/components/charts/tables/TableScrollable/index.test.tsx
+++ b/src/components/charts/tables/TableScrollable/index.test.tsx
@@ -21,14 +21,14 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
   ChartCard: vi.fn(
     ({
       children,
-      exportOptions,
+      menuOptions,
     }: {
       children: React.ReactNode;
-      exportOptions?: (string | unknown)[];
+      menuOptions?: (string | unknown)[];
     }) => (
       <div
         data-testid="chart-card"
-        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+        {...(menuOptions ? { 'data-menu-options': JSON.stringify(menuOptions) } : {})}
       >
         {children}
       </div>
@@ -82,10 +82,10 @@ describe('TableScrollablePro', () => {
     expect(screen.getByTestId('chart-card')).toBeInTheDocument();
   });
 
-  it('passes exportOptions to ChartCard when provided', () => {
-    render(<TableScrollablePro {...defaultProps} exportOptions={['csv', 'png']} />);
+  it('passes menuOptions to ChartCard when provided', () => {
+    render(<TableScrollablePro {...defaultProps} menuOptions={['csv', 'png']} />);
     const card = screen.getByTestId('chart-card');
-    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+    expect(JSON.parse(card.getAttribute('data-menu-options') || '[]')).toEqual(['csv', 'png']);
   });
 
   it('renders TableScrollable', () => {

--- a/src/components/charts/tables/TableScrollable/index.test.tsx
+++ b/src/components/charts/tables/TableScrollable/index.test.tsx
@@ -34,7 +34,7 @@ vi.mock('../../shared/ChartCard/ChartCard', () => ({
       </div>
     ),
   ),
-  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+  asChartCardHeaderProps: (props: Record<string, unknown>) => props,
 }));
 
 vi.mock('@embeddable.com/remarkable-ui', () => ({

--- a/src/components/charts/tables/TableScrollable/index.test.tsx
+++ b/src/components/charts/tables/TableScrollable/index.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import type { DataResponse, Dimension, DimensionOrMeasure } from '@embeddable.com/core';
+import TableScrollablePro from './index';
+import type { TableScrollableProProps } from './index';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn(() => '') },
+}));
+
+vi.mock('../../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props) => props),
+}));
+
+vi.mock('../../shared/ChartCard/ChartCard', () => ({
+  ChartCard: vi.fn(
+    ({
+      children,
+      exportOptions,
+    }: {
+      children: React.ReactNode;
+      exportOptions?: (string | unknown)[];
+    }) => (
+      <div
+        data-testid="chart-card"
+        {...(exportOptions ? { 'data-export-options': JSON.stringify(exportOptions) } : {})}
+      >
+        {children}
+      </div>
+    ),
+  ),
+  pickChartCardHeaderProps: (props: Record<string, unknown>) => props,
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  TableScrollable: vi.fn(({ ref: _ref, ...rest }: Record<string, unknown>) => (
+    <div data-testid="table-scrollable" {...rest} />
+  )),
+}));
+
+vi.mock('../tables.utils', () => ({
+  getTableHeaders: vi.fn(() => []),
+  getTableRows: vi.fn(() => []),
+}));
+
+vi.mock('./TableScrollable.utils', () => ({
+  TABLE_SCROLLABLE_SIZE: 100,
+}));
+
+vi.mock('../../../utils/dimension.utils', () => ({
+  getTimeRangeFromDimensionValue: vi.fn(() => undefined),
+}));
+
+vi.mock('fast-equals', () => ({
+  deepEqual: vi.fn(() => true),
+}));
+
+const emptyResults: DataResponse = { data: [], isLoading: false } as unknown as DataResponse;
+const dimension = { name: 'category', inputs: {} } as unknown as Dimension;
+const dimensionsAndMeasures: DimensionOrMeasure[] = [dimension];
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const dataset = { variableValues: {} } as any;
+
+const defaultProps: TableScrollableProProps = {
+  dataset,
+  dimensionsAndMeasures,
+  results: emptyResults,
+};
+
+describe('TableScrollablePro', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders ChartCard', () => {
+    render(<TableScrollablePro {...defaultProps} />);
+    expect(screen.getByTestId('chart-card')).toBeInTheDocument();
+  });
+
+  it('passes exportOptions to ChartCard when provided', () => {
+    render(<TableScrollablePro {...defaultProps} exportOptions={['csv', 'png']} />);
+    const card = screen.getByTestId('chart-card');
+    expect(JSON.parse(card.getAttribute('data-export-options') || '[]')).toEqual(['csv', 'png']);
+  });
+
+  it('renders TableScrollable', () => {
+    render(<TableScrollablePro {...defaultProps} />);
+    expect(screen.getByTestId('table-scrollable')).toBeInTheDocument();
+  });
+});

--- a/src/components/charts/tables/TableScrollable/index.tsx
+++ b/src/components/charts/tables/TableScrollable/index.tsx
@@ -58,6 +58,7 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
   const { title, description, tooltip } = resolveI18nProps(props);
   const {
     hideMenu,
+    exportOptions,
     dataset,
     results,
     allResults,
@@ -186,6 +187,7 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
       hideMenu={hideMenu}
+      exportOptions={exportOptions}
     >
       <TableScrollable
         ref={tableRef}

--- a/src/components/charts/tables/TableScrollable/index.tsx
+++ b/src/components/charts/tables/TableScrollable/index.tsx
@@ -1,7 +1,11 @@
 import { useTheme } from '@embeddable.com/react';
 import { Theme } from '../../../../theme/theme.types';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
-import { ChartCard, ChartCardHeaderProps } from '../../shared/ChartCard/ChartCard';
+import {
+  ChartCard,
+  ChartCardHeaderProps,
+  pickChartCardHeaderProps,
+} from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import {
   DataResponse,
@@ -55,10 +59,9 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
   const [isDownloadingData, setIsDownloadingData] = useState(false);
   const [rowsToDisplay, setRowsToDisplay] = useState<any[]>([]);
 
-  const { title, description, tooltip } = resolveI18nProps(props);
+  const resolvedProps = resolveI18nProps(props);
+  const { title } = resolvedProps;
   const {
-    hideMenu,
-    exportOptions,
     dataset,
     results,
     allResults,
@@ -176,9 +179,6 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
   return (
     <ChartCard
       ref={cardContentRef}
-      title={title}
-      description={description}
-      tooltip={tooltip}
       data={{
         isLoading,
         data: rowsToDisplay,
@@ -186,8 +186,7 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      hideMenu={hideMenu}
-      exportOptions={exportOptions}
+      {...pickChartCardHeaderProps(resolvedProps)}
     >
       <TableScrollable
         ref={tableRef}

--- a/src/components/charts/tables/TableScrollable/index.tsx
+++ b/src/components/charts/tables/TableScrollable/index.tsx
@@ -186,7 +186,7 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      {...asChartCardHeaderProps(resolvedI18nProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps, props)}
     >
       <TableScrollable
         ref={tableRef}

--- a/src/components/charts/tables/TableScrollable/index.tsx
+++ b/src/components/charts/tables/TableScrollable/index.tsx
@@ -186,7 +186,7 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      {...asChartCardHeaderProps(resolvedI18nProps, props)}
+      {...asChartCardHeaderProps(props)}
     >
       <TableScrollable
         ref={tableRef}

--- a/src/components/charts/tables/TableScrollable/index.tsx
+++ b/src/components/charts/tables/TableScrollable/index.tsx
@@ -4,7 +4,7 @@ import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
 import {
   ChartCard,
   ChartCardHeaderProps,
-  pickChartCardHeaderProps,
+  asChartCardHeaderProps,
 } from '../../shared/ChartCard/ChartCard';
 import { resolveI18nProps } from '../../../component.utils';
 import {
@@ -59,8 +59,8 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
   const [isDownloadingData, setIsDownloadingData] = useState(false);
   const [rowsToDisplay, setRowsToDisplay] = useState<any[]>([]);
 
-  const resolvedProps = resolveI18nProps(props);
-  const { title } = resolvedProps;
+  const resolvedI18nProps = resolveI18nProps(props);
+  const { title } = resolvedI18nProps;
   const {
     dataset,
     results,
@@ -186,7 +186,7 @@ const TableScrollablePro = (props: TableScrollableProProps) => {
       dimensionsAndMeasures={dimensionsAndMeasures}
       errorMessage={results?.error}
       onCustomDownload={handleCustomDownload}
-      {...pickChartCardHeaderProps(resolvedProps)}
+      {...asChartCardHeaderProps(resolvedI18nProps)}
     >
       <TableScrollable
         ref={tableRef}

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,5 +1,5 @@
 import ColorType from '../editors/ColorEditor/Color.type.emb';
-import ExportOptionType, { ExportOption } from './types/ExportOption.type.emb';
+import ExportOptionType, { ExportOptionTypeOptions } from './types/ExportOption.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {
   dimensionMeasureSubInputs,
@@ -498,7 +498,11 @@ const menuOptions = {
   type: ExportOptionType,
   label: 'Menu options',
   array: true,
-  defaultValue: [ExportOption.csv, ExportOption.xlsx, ExportOption.png],
+  defaultValue: [
+    ExportOptionTypeOptions.csv,
+    ExportOptionTypeOptions.xlsx,
+    ExportOptionTypeOptions.png,
+  ],
   category: 'Component Settings',
 } as const;
 

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,4 +1,5 @@
 import ColorType from '../editors/ColorEditor/Color.type.emb';
+import ExportOptionType from './types/ExportOption.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {
   dimensionMeasureSubInputs,
@@ -492,26 +493,13 @@ const yMeasure = {
   label: 'Y-axis measure',
 } as const;
 
-export const ExportOption = {
-  csv: 'csv',
-  xlsx: 'xlsx',
-  png: 'png',
-} as const;
-
 const exportOptions = {
   name: 'exportOptions',
-  type: 'string',
+  type: ExportOptionType,
   label: 'Export options',
   array: true,
-  defaultValue: [ExportOption.csv, ExportOption.xlsx, ExportOption.png],
+  defaultValue: ['csv', 'xlsx', 'png'],
   category: 'Component Settings',
-  config: {
-    options: [
-      { value: ExportOption.csv, label: 'Export CSV' },
-      { value: ExportOption.xlsx, label: 'Export XLSX' },
-      { value: ExportOption.png, label: 'Export PNG' },
-    ],
-  },
 } as const;
 
 export const inputs = {

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -1,5 +1,5 @@
 import ColorType from '../editors/ColorEditor/Color.type.emb';
-import ExportOptionType from './types/ExportOption.type.emb';
+import ExportOptionType, { ExportOption } from './types/ExportOption.type.emb';
 import { Granularity } from '../theme/defaults/defaults.GranularityOptions.constants';
 import {
   dimensionMeasureSubInputs,
@@ -498,7 +498,7 @@ const menuOptions = {
   type: ExportOptionType,
   label: 'Menu options',
   array: true,
-  defaultValue: ['csv', 'xlsx', 'png'],
+  defaultValue: [ExportOption.csv, ExportOption.xlsx, ExportOption.png],
   category: 'Component Settings',
 } as const;
 

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -492,6 +492,22 @@ const yMeasure = {
   label: 'Y-axis measure',
 } as const;
 
+const exportOptions = {
+  name: 'exportOptions',
+  type: 'string',
+  label: 'Export options',
+  array: true,
+  defaultValue: ['csv', 'xlsx', 'png'],
+  category: 'Component Settings',
+  config: {
+    options: [
+      { value: 'csv', label: 'Export CSV' },
+      { value: 'xlsx', label: 'Export XLSX' },
+      { value: 'png', label: 'Export PNG' },
+    ],
+  },
+} as const;
+
 export const inputs = {
   boolean,
   timeRange,
@@ -551,4 +567,5 @@ export const inputs = {
   granularities,
   markdown,
   filters,
+  exportOptions,
 } as const;

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -492,18 +492,24 @@ const yMeasure = {
   label: 'Y-axis measure',
 } as const;
 
+export const ExportOption = {
+  csv: 'csv',
+  xlsx: 'xlsx',
+  png: 'png',
+} as const;
+
 const exportOptions = {
   name: 'exportOptions',
   type: 'string',
   label: 'Export options',
   array: true,
-  defaultValue: ['csv', 'xlsx', 'png'],
+  defaultValue: [ExportOption.csv, ExportOption.xlsx, ExportOption.png],
   category: 'Component Settings',
   config: {
     options: [
-      { value: 'csv', label: 'Export CSV' },
-      { value: 'xlsx', label: 'Export XLSX' },
-      { value: 'png', label: 'Export PNG' },
+      { value: ExportOption.csv, label: 'Export CSV' },
+      { value: ExportOption.xlsx, label: 'Export XLSX' },
+      { value: ExportOption.png, label: 'Export PNG' },
     ],
   },
 } as const;

--- a/src/components/component.inputs.constants.ts
+++ b/src/components/component.inputs.constants.ts
@@ -493,10 +493,10 @@ const yMeasure = {
   label: 'Y-axis measure',
 } as const;
 
-const exportOptions = {
-  name: 'exportOptions',
+const menuOptions = {
+  name: 'menuOptions',
   type: ExportOptionType,
-  label: 'Export options',
+  label: 'Menu options',
   array: true,
   defaultValue: ['csv', 'xlsx', 'png'],
   category: 'Component Settings',
@@ -561,5 +561,5 @@ export const inputs = {
   granularities,
   markdown,
   filters,
-  exportOptions,
+  menuOptions,
 } as const;

--- a/src/components/types/ExportOption.type.emb.test.ts
+++ b/src/components/types/ExportOption.type.emb.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import ExportOptionType, { ExportOption } from './ExportOption.type.emb';
+import ExportOptionType, { ExportOptionTypeOptions } from './ExportOption.type.emb';
 
-describe('ExportOption', () => {
+describe('ExportOptionTypeOptions', () => {
   it('exports the expected option keys', () => {
-    expect(ExportOption.csv).toBe('csv');
-    expect(ExportOption.xlsx).toBe('xlsx');
-    expect(ExportOption.png).toBe('png');
+    expect(ExportOptionTypeOptions.csv).toBe('csv');
+    expect(ExportOptionTypeOptions.xlsx).toBe('xlsx');
+    expect(ExportOptionTypeOptions.png).toBe('png');
   });
 });
 

--- a/src/components/types/ExportOption.type.emb.test.ts
+++ b/src/components/types/ExportOption.type.emb.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import ExportOptionType, { ExportOption } from './ExportOption.type.emb';
+
+describe('ExportOption', () => {
+  it('exports the expected option keys', () => {
+    expect(ExportOption.csv).toBe('csv');
+    expect(ExportOption.xlsx).toBe('xlsx');
+    expect(ExportOption.png).toBe('png');
+  });
+});
+
+describe('ExportOptionType', () => {
+  it('has the correct type name', () => {
+    expect(ExportOptionType.toString()).toBe('exportOption');
+  });
+
+  it('optionLabel returns the value as-is', () => {
+    expect(ExportOptionType.typeConfig.optionLabel('csv')).toBe('csv');
+    expect(ExportOptionType.typeConfig.optionLabel('json')).toBe('json');
+  });
+
+  it('registers csv, xlsx and png options in the global registry', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const options = (globalThis as any).__EMBEDDABLE__?.types?.exportOption?.options;
+    expect(options).toEqual(expect.arrayContaining(['csv', 'xlsx', 'png']));
+  });
+});

--- a/src/components/types/ExportOption.type.emb.ts
+++ b/src/components/types/ExportOption.type.emb.ts
@@ -1,6 +1,6 @@
 import { defineOption, defineType } from '@embeddable.com/core';
 
-export const ExportOption = {
+export const ExportOptionTypeOptions = {
   csv: 'csv',
   xlsx: 'xlsx',
   png: 'png',
@@ -11,8 +11,8 @@ const ExportOptionType = defineType('exportOption', {
   optionLabel: (value: string) => value,
 });
 
-defineOption(ExportOptionType, ExportOption.csv);
-defineOption(ExportOptionType, ExportOption.xlsx);
-defineOption(ExportOptionType, ExportOption.png);
+defineOption(ExportOptionType, ExportOptionTypeOptions.csv);
+defineOption(ExportOptionType, ExportOptionTypeOptions.xlsx);
+defineOption(ExportOptionType, ExportOptionTypeOptions.png);
 
 export default ExportOptionType;

--- a/src/components/types/ExportOption.type.emb.ts
+++ b/src/components/types/ExportOption.type.emb.ts
@@ -1,0 +1,18 @@
+import { defineOption, defineType } from '@embeddable.com/core';
+
+export const ExportOption = {
+  csv: 'csv',
+  xlsx: 'xlsx',
+  png: 'png',
+} as const;
+
+const ExportOptionType = defineType('exportOption', {
+  label: 'Export option',
+  optionLabel: (value: string) => value,
+});
+
+defineOption(ExportOptionType, ExportOption.csv);
+defineOption(ExportOptionType, ExportOption.xlsx);
+defineOption(ExportOptionType, ExportOption.png);
+
+export default ExportOptionType;

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,7 @@ export * from './components/editors/utils/dimensionsAndMeasures.utils';
 export { default as ComparisonPeriodType } from './components/types/ComparisonPeriod.type.emb';
 export {
   default as ExportOptionType,
-  ExportOption,
+  ExportOptionTypeOptions,
 } from './components/types/ExportOption.type.emb';
 
 // Custom Editors

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,6 +237,10 @@ export * from './components/editors/utils/dimensionsAndMeasures.utils';
 
 // Custom types
 export { default as ComparisonPeriodType } from './components/types/ComparisonPeriod.type.emb';
+export {
+  default as ExportOptionType,
+  ExportOption,
+} from './components/types/ExportOption.type.emb';
 
 // Custom Editors
 export * as ColorEditorPro from './editors/ColorEditor';

--- a/src/theme/defaults/defaults.ChartCardMenu.constants.ts
+++ b/src/theme/defaults/defaults.ChartCardMenu.constants.ts
@@ -14,6 +14,7 @@ export type ChartCardMenuOptionOnClickProps = {
 };
 
 export type ChartCardMenuOption = {
+  key: string;
   labelKey: string;
   iconSrc?: string;
   onClick: (props: ChartCardMenuOptionOnClickProps) => void;
@@ -21,16 +22,19 @@ export type ChartCardMenuOption = {
 
 export const defaultChartMenuProOptions: ChartCardMenuOption[] = [
   {
+    key: 'csv',
     labelKey: 'charts.menuOptions.downloadCSV',
     onClick: exportCSV,
     iconSrc: CloudDownload,
   },
   {
+    key: 'xlsx',
     labelKey: 'charts.menuOptions.downloadXLSX',
     onClick: exportXLSX,
     iconSrc: CloudDownload,
   },
   {
+    key: 'png',
     labelKey: 'charts.menuOptions.downloadPNG',
     onClick: exportPNG,
     iconSrc: PhotoDown,

--- a/src/theme/defaults/defaults.ChartCardMenu.constants.ts
+++ b/src/theme/defaults/defaults.ChartCardMenu.constants.ts
@@ -3,7 +3,7 @@ import CloudDownload from '../../assets/icons/cloud-download.svg';
 import PhotoDown from '../../assets/icons/photo-down.svg';
 import { exportCSV, exportPNG, exportXLSX } from '../utils/export.utils';
 import { Theme } from '../theme.types';
-import { ExportOption } from '../../components/types/ExportOption.type.emb';
+import { ExportOptionTypeOptions } from '../../components/types/ExportOption.type.emb';
 
 export type ChartCardMenuOptionOnClickProps = {
   title?: string;
@@ -23,19 +23,19 @@ export type ChartCardMenuOption = {
 
 export const defaultChartMenuProOptions: ChartCardMenuOption[] = [
   {
-    value: ExportOption.csv,
+    value: ExportOptionTypeOptions.csv,
     labelKey: 'charts.menuOptions.downloadCSV',
     onClick: exportCSV,
     iconSrc: CloudDownload,
   },
   {
-    value: ExportOption.xlsx,
+    value: ExportOptionTypeOptions.xlsx,
     labelKey: 'charts.menuOptions.downloadXLSX',
     onClick: exportXLSX,
     iconSrc: CloudDownload,
   },
   {
-    value: ExportOption.png,
+    value: ExportOptionTypeOptions.png,
     labelKey: 'charts.menuOptions.downloadPNG',
     onClick: exportPNG,
     iconSrc: PhotoDown,

--- a/src/theme/defaults/defaults.ChartCardMenu.constants.ts
+++ b/src/theme/defaults/defaults.ChartCardMenu.constants.ts
@@ -3,7 +3,7 @@ import CloudDownload from '../../assets/icons/cloud-download.svg';
 import PhotoDown from '../../assets/icons/photo-down.svg';
 import { exportCSV, exportPNG, exportXLSX } from '../utils/export.utils';
 import { Theme } from '../theme.types';
-import { ExportOption } from '../../components/component.inputs.constants';
+import { ExportOption } from '../../components/types/ExportOption.type.emb';
 
 export type ChartCardMenuOptionOnClickProps = {
   title?: string;

--- a/src/theme/defaults/defaults.ChartCardMenu.constants.ts
+++ b/src/theme/defaults/defaults.ChartCardMenu.constants.ts
@@ -3,6 +3,7 @@ import CloudDownload from '../../assets/icons/cloud-download.svg';
 import PhotoDown from '../../assets/icons/photo-down.svg';
 import { exportCSV, exportPNG, exportXLSX } from '../utils/export.utils';
 import { Theme } from '../theme.types';
+import { ExportOption } from '../../components/component.inputs.constants';
 
 export type ChartCardMenuOptionOnClickProps = {
   title?: string;
@@ -14,7 +15,7 @@ export type ChartCardMenuOptionOnClickProps = {
 };
 
 export type ChartCardMenuOption = {
-  key: string;
+  value: string;
   labelKey: string;
   iconSrc?: string;
   onClick: (props: ChartCardMenuOptionOnClickProps) => void;
@@ -22,19 +23,19 @@ export type ChartCardMenuOption = {
 
 export const defaultChartMenuProOptions: ChartCardMenuOption[] = [
   {
-    key: 'csv',
+    value: ExportOption.csv,
     labelKey: 'charts.menuOptions.downloadCSV',
     onClick: exportCSV,
     iconSrc: CloudDownload,
   },
   {
-    key: 'xlsx',
+    value: ExportOption.xlsx,
     labelKey: 'charts.menuOptions.downloadXLSX',
     onClick: exportXLSX,
     iconSrc: CloudDownload,
   },
   {
-    key: 'png',
+    value: ExportOption.png,
     labelKey: 'charts.menuOptions.downloadPNG',
     onClick: exportPNG,
     iconSrc: PhotoDown,


### PR DESCRIPTION
# Why is this pull-request needed?
We need to allow users to enable / disable export options for each chart.

# Main changes
Added new input exportOptions
Updated ChartCardMenuPro to properly display options based on what was selected

# Test evidence

https://github.com/user-attachments/assets/9285e25a-29d0-4dd9-b04a-d2c41f083f2a




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added export options configuration to chart components, enabling users to customize which export formats (CSV, XLSX, PNG) are available in the chart export menu. Export options can now be selected and configured in the component builder settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->