### PR TITLE
[RUI-282] Filter builder updates

### DIFF
--- a/.changeset/common-results-yawn.md
+++ b/.changeset/common-results-yawn.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Extend filter builder to allow cascading filtering

--- a/src/components/editors/FilterBuilderPro/FilterBuilderPro.utils.test.ts
+++ b/src/components/editors/FilterBuilderPro/FilterBuilderPro.utils.test.ts
@@ -4,6 +4,7 @@ import {
   clauseToFilter,
   clauseToFilters,
   filterBuilderAndOrOperator,
+  filterToLoadDataFilters,
   filtersToClause,
   getSupportedDimensionsAndMeasures,
   operatorNumber,
@@ -37,6 +38,103 @@ const makeFilter = (overrides: Partial<FilterBuilderFilter> = {}): FilterBuilder
 
 const generate = (...args: Parameters<typeof filtersToClause>): ClauseGroup | null =>
   filtersToClause(...args) as ClauseGroup | null;
+
+// ---------------------------------------------------------------------------
+// filterToLoadDataFilters
+// ---------------------------------------------------------------------------
+
+describe('filterToLoadDataFilters', () => {
+  it('returns [] for a filter missing dimensionOrMeasure', () => {
+    expect(filterToLoadDataFilters(makeFilter({ dimensionOrMeasure: null }))).toEqual([]);
+  });
+
+  it('returns [] for a filter missing operator', () => {
+    expect(filterToLoadDataFilters(makeFilter({ operator: null }))).toEqual([]);
+  });
+
+  it('returns [] for a filter with null value', () => {
+    expect(filterToLoadDataFilters(makeFilter({ value: null }))).toEqual([]);
+  });
+
+  it('maps a string "is" filter to a single equals load-data filter', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({ operator: operatorStringBoolean.is, value: 'Alice' }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ operator: FilterOperator.equals, value: 'Alice' });
+  });
+
+  it('maps a string "isNot" filter to notEquals', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({ operator: operatorStringBoolean.isNot, value: 'Bob' }),
+    );
+    expect(result[0]?.operator).toBe(FilterOperator.notEquals);
+  });
+
+  it('maps a string "isOneOf" filter to contains', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({ operator: operatorStringBoolean.isOneOf, value: ['a', 'b'] }),
+    );
+    expect(result[0]?.operator).toBe(FilterOperator.contains);
+    expect(result[0]?.value).toEqual(['a', 'b']);
+  });
+
+  it('maps a string "isNotOneOf" filter to notContains', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({ operator: operatorStringBoolean.isNotOneOf, value: ['x'] }),
+    );
+    expect(result[0]?.operator).toBe(FilterOperator.notContains);
+  });
+
+  it('maps a number gte filter correctly', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({
+        dimensionOrMeasure: makeDim(NativeDataType.number, 'age'),
+        operator: operatorNumber.gte,
+        value: 18,
+      }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ operator: FilterOperator.gte, value: 18 });
+  });
+
+  it('maps a number lte filter correctly', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({
+        dimensionOrMeasure: makeDim(NativeDataType.number, 'age'),
+        operator: operatorNumber.lte,
+        value: 65,
+      }),
+    );
+    expect(result[0]?.operator).toBe(FilterOperator.lte);
+  });
+
+  it('expands a number "between" filter into gte + lte load-data filters', () => {
+    const result = filterToLoadDataFilters(
+      makeFilter({
+        dimensionOrMeasure: makeDim(NativeDataType.number, 'price'),
+        operator: operatorNumber.between,
+        value: [10, 50] as unknown as FilterBuilderFilter['value'],
+      }),
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0]).toMatchObject({ operator: FilterOperator.gte, value: 10 });
+    expect(result[1]).toMatchObject({ operator: FilterOperator.lte, value: 50 });
+  });
+
+  it('returns [] for an unrecognised operator', () => {
+    const result = filterToLoadDataFilters(makeFilter({ operator: 'unknown_op' }));
+    expect(result).toEqual([]);
+  });
+
+  it('sets the property field to the dimensionOrMeasure object', () => {
+    const dim = makeDim(NativeDataType.string, 'country');
+    const result = filterToLoadDataFilters(
+      makeFilter({ dimensionOrMeasure: dim, operator: operatorStringBoolean.is, value: 'USA' }),
+    );
+    expect(result[0]?.property).toBe(dim);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // getSupportedDimensionsAndMeasures

--- a/src/components/editors/FilterBuilderPro/FilterBuilderPro.utils.ts
+++ b/src/components/editors/FilterBuilderPro/FilterBuilderPro.utils.ts
@@ -59,6 +59,38 @@ export type FilterBuilderClause =
     }
   | { operator: FilterBuilderAndOrOperator; clauses: FilterBuilderClause[] };
 
+export type LoadDataFilter = {
+  operator: FilterOperator;
+  property: DimensionOrMeasure;
+  value: NonNullable<FilterBuilderFilter['value']>;
+};
+
+export const filterToLoadDataFilters = (filter: FilterBuilderFilter): LoadDataFilter[] => {
+  const { dimensionOrMeasure, operator, value } = filter;
+  if (!dimensionOrMeasure || !operator || value == null) return [];
+
+  if (
+    operator === operatorNumber.between &&
+    dimensionOrMeasure.nativeType === NativeDataType.number &&
+    Array.isArray(value)
+  ) {
+    const numValue = value as [number, number];
+    return [
+      { operator: FilterOperator.gte, property: dimensionOrMeasure, value: numValue[0] },
+      { operator: FilterOperator.lte, property: dimensionOrMeasure, value: numValue[1] },
+    ];
+  }
+
+  const map =
+    dimensionOrMeasure.nativeType === NativeDataType.number
+      ? operatorNumberMappedFilterOperator
+      : operatorStringBooleanMappedFilterOperator;
+  const mappedOperator = map[operator];
+  if (!mappedOperator) return [];
+
+  return [{ operator: mappedOperator, property: dimensionOrMeasure, value }];
+};
+
 const filterToClause = (f: FilterBuilderFilter): FilterBuilderClause[] => {
   if (
     f.operator === operatorNumber.between &&

--- a/src/components/editors/FilterBuilderPro/definition.ts
+++ b/src/components/editors/FilterBuilderPro/definition.ts
@@ -2,7 +2,7 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import { DimensionOrMeasure, FilterOperator, loadData, Value } from '@embeddable.com/core';
 import Component from '.';
 import { inputs } from '../../component.inputs.constants';
-import { FilterBuilderClause } from './FilterBuilderPro.utils';
+import { FilterBuilderClause, filterToLoadDataFilters } from './FilterBuilderPro.utils';
 
 const meta = {
   name: 'FilterBuilderPro',
@@ -26,6 +26,13 @@ const meta = {
       name: 'defaultFilters',
       label: 'Default filters',
       defaultValue: null,
+    },
+    {
+      ...inputs.boolean,
+      name: 'applyCascadingFilters',
+      label: 'Apply cascading filters',
+      defaultValue: false,
+      category: 'Component Settings',
     },
     inputs.title,
     inputs.description,
@@ -81,15 +88,25 @@ const props = (
     }
 
     const { dimensionOrMeasure } = item;
-    const operator =
+    const searchOperator =
       dimensionOrMeasure.nativeType === 'string' ? FilterOperator.contains : FilterOperator.equals;
+
+    const searchFilter = item.search
+      ? [{ operator: searchOperator, property: dimensionOrMeasure, value: item.search }]
+      : [];
+
+    const cascadingFilters = inputs.applyCascadingFilters
+      ? (state.filters ?? [])
+          .filter((other) => other.id !== item.id)
+          .flatMap(filterToLoadDataFilters)
+      : [];
+
+    const filters = [...cascadingFilters, ...searchFilter];
 
     acc[`filterResults${item.id}`] = loadData({
       from: inputs.dataset,
       select: [item.dimensionOrMeasure],
-      filters: item.search
-        ? [{ operator, property: dimensionOrMeasure, value: item.search }]
-        : undefined,
+      filters: filters.length > 0 ? filters : undefined,
     });
     return acc;
   }, {});

--- a/src/components/editors/FilterBuilderPro/definition.ts
+++ b/src/components/editors/FilterBuilderPro/definition.ts
@@ -30,9 +30,10 @@ const meta = {
     {
       ...inputs.boolean,
       name: 'applyCascadingFilters',
-      label: 'Apply cascading filters',
+      label: 'Apply dynamic filters',
       defaultValue: false,
       category: 'Component Settings',
+      description: "Each filter's available options update based on the other active filters.",
     },
     inputs.title,
     inputs.description,


### PR DESCRIPTION
# Why is this pull-request needed?

When users build cascading filters (e.g. filtering a City dropdown by a previously selected Country), the FilterBuilder had no built-in way to narrow each clause's available options based on the other active clauses. The only workaround was wiring the component's own output back into its dataset input, which caused a side effect: selecting a value in a clause would immediately filter out other values in that same clause's dropdown, making it impossible to add multiple values without clearing first.

# Main changes

Added a new "Apply dynamic filters" boolean input (Component Settings) to the FilterBuilder component. When enabled, each clause's value dropdown is filtered by all other active clauses, but never by its own selections.
Extracted a filterToLoadDataFilters utility function in FilterBuilderPro.utils.ts that converts a FilterBuilderFilter into typed LoadDataFilter objects, handling all operator types including the between → gte + lte expansion.
The cascading logic lives entirely in definition.ts props, keeping the React component unchanged.
Added unit tests for filterToLoadDataFilters covering all operator types, the between expansion, incomplete filters, and unknown operators.

# Test evidence

https://github.com/user-attachments/assets/61747ec8-3da1-4436-90f4-7abb49eae654




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended filter builder with cascading filter support: available filter options now intelligently update in real-time based on selections in other active filters.
  * Added new component setting to enable/disable cascading filter behavior per use case.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->