### PR TITLE
EM-3037: Update RUI to 3.0.19

### DIFF
--- a/.changeset/sparkly-meals-own.md
+++ b/.changeset/sparkly-meals-own.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Fix tooltip positioning

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.3.3",
+  "version": "0.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.3.3",
+      "version": "0.3.5",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.7",
         "@embeddable.com/react": "^2.13.7",
-        "@embeddable.com/remarkable-ui": "^3.0.18",
+        "@embeddable.com/remarkable-ui": "^3.0.19",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -915,9 +915,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "3.0.18",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.0.18.tgz",
-      "integrity": "sha512-Tb+367ntsaIxJ5pL8B5XPgq7cy6gu0wek30B9qlvUp17GLI6+SYfuJroxwTSNki+35En7iz/j5zrXqAJ8PlytQ==",
+      "version": "3.0.19",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.0.19.tgz",
+      "integrity": "sha512-jlPFVL0gb/2aF2TxCzIjgUghRmhqOi9wkiHA76MLSHGiBjQ8u3jCayYz14RCJCydnbt1FT22aedkBbdTRnwJGQ==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.7",
     "@embeddable.com/react": "^2.13.7",
-    "@embeddable.com/remarkable-ui": "^3.0.18",
+    "@embeddable.com/remarkable-ui": "^3.0.19",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",


### PR DESCRIPTION
# Why is this pull-request needed?

This is to update the R.Pro to include the latest fix for tooltip positioning.

# Main changes

* Updated Remarkable-ui to 3.0.19
# Test evidence
N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal UI library dependency to the latest patch version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->