### PR TITLE
[RUI-295]: Fix color label for pie chart not being update

### DIFF
--- a/.changeset/three-pianos-smell.md
+++ b/.changeset/three-pianos-smell.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Pass color for labels in pie chart

--- a/src/components/charts/pies/pies.utils.test.ts
+++ b/src/components/charts/pies/pies.utils.test.ts
@@ -284,6 +284,7 @@ describe('getPieChartProOptions', () => {
   describe('legend.labels.generateLabels', () => {
     const makeChart = (labels: string[], visibilities: boolean[] = []) => ({
       data: { labels },
+      options: { plugins: { legend: { labels: { color: '#000' } } } },
       getDatasetMeta: vi.fn(() => ({
         controller: {
           getStyle: vi.fn((i: number) => ({

--- a/src/components/charts/pies/pies.utils.ts
+++ b/src/components/charts/pies/pies.utils.ts
@@ -118,6 +118,7 @@ export const getPieChartProOptions = (
         labels: {
           generateLabels: (chart) => {
             const labels = chart.data.labels ?? [];
+            const labelColor = chart.options.plugins?.legend?.labels?.color as string | undefined;
             return labels.map((label, i) => {
               const meta = chart.getDatasetMeta(0);
               const style = meta.controller.getStyle(i, false);
@@ -128,6 +129,7 @@ export const getPieChartProOptions = (
                 lineWidth: style.borderWidth,
                 hidden: !chart.getDataVisibility(i),
                 index: i,
+                fontColor: labelColor,
               };
             });
           },


### PR DESCRIPTION
# Why is this pull-request needed?

Pie and donut chart legend labels were always rendering in black, ignoring the --em-chart-category-color CSS variable set by the active theme. This affected both light and dark themes.

# Main changes

The root cause was in getPieChartProOptions in src/components/charts/pies/pies.utils.ts. Pie and donut charts use a custom generateLabels function to build legend items, but the returned label objects were missing a fontColor property. Chart.js uses fontColor on individual label items to determine text color — without it, it falls back to its own default (black), completely ignoring the labels.color value set by the theme

# Test evidence

https://github.com/user-attachments/assets/f0087a6b-8352-411e-8784-0017b20dd402



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pie chart legend labels now properly apply custom color settings for improved visual control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->