### PR TITLE
[RUI-292]: Add support for or operator in filter builder

### DIFF
--- a/.changeset/fast-swans-smash.md
+++ b/.changeset/fast-swans-smash.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Add support for or operator

--- a/src/components/editors/FilterBuilderPro/FilterBuilderPro.module.css
+++ b/src/components/editors/FilterBuilderPro/FilterBuilderPro.module.css
@@ -316,3 +316,12 @@
 .andOrButton:hover {
   background: var(--em-filterbuilder-andor-button-background--hover, #e4e4ea);
 }
+
+.andOrButton[data-disabled] {
+  cursor: not-allowed;
+  opacity: var(--em-filterbuilder-andor-button-opacity--disabled, 0.5);
+}
+
+.andOrButton[data-disabled]:hover {
+  background: var(--em-filterbuilder-andor-button-background, #ededf1);
+}

--- a/src/components/editors/FilterBuilderPro/FilterBuilderPro.module.css
+++ b/src/components/editors/FilterBuilderPro/FilterBuilderPro.module.css
@@ -317,11 +317,11 @@
   background: var(--em-filterbuilder-andor-button-background--hover, #e4e4ea);
 }
 
-.andOrButton[data-disabled] {
+.andOrButton:disabled {
   cursor: not-allowed;
   opacity: var(--em-filterbuilder-andor-button-opacity--disabled, 0.5);
 }
 
-.andOrButton[data-disabled]:hover {
+.andOrButton:disabled:hover {
   background: var(--em-filterbuilder-andor-button-background, #ededf1);
 }

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
@@ -14,6 +14,15 @@ vi.mock('../../../../theme/i18n/i18n', () => ({
   i18n: { t: vi.fn((key: string) => key) },
 }));
 
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  Tooltip: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
+    <div data-testid="tooltip">
+      {trigger}
+      <span data-testid="tooltip-content">{children}</span>
+    </div>
+  ),
+}));
+
 describe('FilterBuilderProAndOrButton', () => {
   const onChange = vi.fn();
 
@@ -63,5 +72,47 @@ describe('FilterBuilderProAndOrButton', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(onChange).toHaveBeenCalledOnce();
     expect(onChange).toHaveBeenCalledWith(filterBuilderAndOrOperator.AND);
+  });
+
+  it('does not call onChange when disabled and clicked', () => {
+    render(
+      <FilterBuilderProAndOrButton
+        operator={filterBuilderAndOrOperator.AND}
+        onChange={onChange}
+        disabled
+      />,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('marks the button aria-disabled when disabled', () => {
+    render(
+      <FilterBuilderProAndOrButton
+        operator={filterBuilderAndOrOperator.AND}
+        onChange={onChange}
+        disabled
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('shows the explanatory tooltip only when disabled', () => {
+    const { rerender } = render(
+      <FilterBuilderProAndOrButton operator={filterBuilderAndOrOperator.AND} onChange={onChange} />,
+    );
+    expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+
+    rerender(
+      <FilterBuilderProAndOrButton
+        operator={filterBuilderAndOrOperator.AND}
+        onChange={onChange}
+        disabled
+      />,
+    );
+    expect(screen.getByTestId('tooltip')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+      'editors.filterBuilder.orDisabledMixedTypes',
+    );
   });
 });

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
@@ -112,7 +112,7 @@ describe('FilterBuilderProAndOrButton', () => {
     );
     expect(screen.getByTestId('tooltip')).toBeInTheDocument();
     expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
-      'editors.filterBuilder.orDisabledMixedTypes',
+      'editors.filterBuilder.disableOrOperatorToolTip',
     );
   });
 });

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
@@ -70,27 +70,25 @@ describe('FilterBuilderProAndOrButton', () => {
     expect(onChange).toHaveBeenCalledWith(filterBuilderAndOrOperator.AND);
   });
 
-  it('does not call onChange when disabled and clicked', () => {
-    render(
-      <FilterBuilderProAndOrButton
-        operator={filterBuilderAndOrOperator.AND}
-        onChange={onChange}
-        disabled
-      />,
-    );
-    fireEvent.click(screen.getByRole('button'));
-    expect(onChange).not.toHaveBeenCalled();
-  });
+  describe('when disabled', () => {
+    beforeEach(() => {
+      render(
+        <FilterBuilderProAndOrButton
+          operator={filterBuilderAndOrOperator.AND}
+          onChange={onChange}
+          disabled
+        />,
+      );
+    });
 
-  it('marks the button disabled when disabled', () => {
-    render(
-      <FilterBuilderProAndOrButton
-        operator={filterBuilderAndOrOperator.AND}
-        onChange={onChange}
-        disabled
-      />,
-    );
-    expect(screen.getByRole('button')).toBeDisabled();
+    it('does not call onChange when clicked', () => {
+      fireEvent.click(screen.getByRole('button'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('marks the button as disabled', () => {
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
   });
 
   it('shows the explanatory tooltip only when disabled', () => {

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
@@ -14,14 +14,10 @@ vi.mock('../../../../theme/i18n/i18n', () => ({
   i18n: { t: vi.fn((key: string) => key) },
 }));
 
-vi.mock('@embeddable.com/remarkable-ui', () => ({
-  Tooltip: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
-    <div data-testid="tooltip">
-      {trigger}
-      <span data-testid="tooltip-content">{children}</span>
-    </div>
-  ),
-}));
+vi.mock('@embeddable.com/remarkable-ui', async () => {
+  const { TooltipMock } = await import('../test-utils');
+  return { Tooltip: TooltipMock };
+});
 
 describe('FilterBuilderProAndOrButton', () => {
   const onChange = vi.fn();

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.test.tsx
@@ -86,7 +86,7 @@ describe('FilterBuilderProAndOrButton', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('marks the button aria-disabled when disabled', () => {
+  it('marks the button disabled when disabled', () => {
     render(
       <FilterBuilderProAndOrButton
         operator={filterBuilderAndOrOperator.AND}
@@ -94,7 +94,7 @@ describe('FilterBuilderProAndOrButton', () => {
         disabled
       />,
     );
-    expect(screen.getByRole('button')).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('button')).toBeDisabled();
   });
 
   it('shows the explanatory tooltip only when disabled', () => {

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.tsx
@@ -42,7 +42,7 @@ export const FilterBuilderProAndOrButton: FC<FilterBuilderProAndOrButtonProps> =
 
   return (
     <Tooltip side="top" trigger={<span>{button}</span>}>
-      {i18n.t('editors.filterBuilder.orDisabledMixedTypes')}
+      {i18n.t('editors.filterBuilder.disableOrOperatorToolTip')}
     </Tooltip>
   );
 };

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.tsx
@@ -16,7 +16,6 @@ export const FilterBuilderProAndOrButton: FC<FilterBuilderProAndOrButtonProps> =
   disabled = false,
 }) => {
   const handleChange = () => {
-    if (disabled) return;
     onChange(
       operator === filterBuilderAndOrOperator.AND
         ? filterBuilderAndOrOperator.OR
@@ -29,12 +28,7 @@ export const FilterBuilderProAndOrButton: FC<FilterBuilderProAndOrButtonProps> =
   const inactiveLabel = operator === filterBuilderAndOrOperator.AND ? orLabel : andLabel;
 
   const button = (
-    <button
-      className={styles.andOrButton}
-      onClick={handleChange}
-      aria-disabled={disabled}
-      data-disabled={disabled || undefined}
-    >
+    <button className={styles.andOrButton} onClick={handleChange} disabled={disabled}>
       <span>{activeLabel}</span>
       <span className={styles.andOrButtonSizer} aria-hidden>
         {inactiveLabel}
@@ -47,7 +41,7 @@ export const FilterBuilderProAndOrButton: FC<FilterBuilderProAndOrButtonProps> =
   }
 
   return (
-    <Tooltip side="top" trigger={button}>
+    <Tooltip side="top" trigger={<span>{button}</span>}>
       {i18n.t('editors.filterBuilder.orDisabledMixedTypes')}
     </Tooltip>
   );

--- a/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.tsx
+++ b/src/components/editors/FilterBuilderPro/components/FilterBuilderProAndOrButton.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import { Tooltip } from '@embeddable.com/remarkable-ui';
 import styles from '../FilterBuilderPro.module.css';
 import { i18n } from '../../../../theme/i18n/i18n';
 import { filterBuilderAndOrOperator, FilterBuilderAndOrOperator } from '../FilterBuilderPro.utils';
@@ -6,13 +7,16 @@ import { filterBuilderAndOrOperator, FilterBuilderAndOrOperator } from '../Filte
 type FilterBuilderProAndOrButtonProps = {
   operator: FilterBuilderAndOrOperator;
   onChange: (value: FilterBuilderAndOrOperator) => void;
+  disabled?: boolean;
 };
 
 export const FilterBuilderProAndOrButton: FC<FilterBuilderProAndOrButtonProps> = ({
   operator,
   onChange,
+  disabled = false,
 }) => {
   const handleChange = () => {
+    if (disabled) return;
     onChange(
       operator === filterBuilderAndOrOperator.AND
         ? filterBuilderAndOrOperator.OR
@@ -24,12 +28,27 @@ export const FilterBuilderProAndOrButton: FC<FilterBuilderProAndOrButtonProps> =
   const activeLabel = operator === filterBuilderAndOrOperator.AND ? andLabel : orLabel;
   const inactiveLabel = operator === filterBuilderAndOrOperator.AND ? orLabel : andLabel;
 
-  return (
-    <button className={styles.andOrButton} onClick={handleChange}>
+  const button = (
+    <button
+      className={styles.andOrButton}
+      onClick={handleChange}
+      aria-disabled={disabled}
+      data-disabled={disabled || undefined}
+    >
       <span>{activeLabel}</span>
       <span className={styles.andOrButtonSizer} aria-hidden>
         {inactiveLabel}
       </span>
     </button>
+  );
+
+  if (!disabled) {
+    return button;
+  }
+
+  return (
+    <Tooltip side="top" trigger={button}>
+      {i18n.t('editors.filterBuilder.orDisabledMixedTypes')}
+    </Tooltip>
   );
 };

--- a/src/components/editors/FilterBuilderPro/definition.ts
+++ b/src/components/editors/FilterBuilderPro/definition.ts
@@ -2,7 +2,11 @@ import { definePreview, EmbeddedComponentMeta, Inputs } from '@embeddable.com/re
 import { DimensionOrMeasure, FilterOperator, loadData, Value } from '@embeddable.com/core';
 import Component from '.';
 import { inputs } from '../../component.inputs.constants';
-import { FilterBuilderClause, filterToLoadDataFilters } from './FilterBuilderPro.utils';
+import {
+  FilterBuilderAndOrOperator,
+  FilterBuilderClause,
+  filterToLoadDataFilters,
+} from './FilterBuilderPro.utils';
 
 const meta = {
   name: 'FilterBuilderPro',
@@ -74,6 +78,7 @@ export type FilterBuilderFilter = {
 
 export type FilterBuilderState = {
   filters: FilterBuilderFilter[];
+  operator: FilterBuilderAndOrOperator;
 };
 
 const props = (

--- a/src/components/editors/FilterBuilderPro/index.test.tsx
+++ b/src/components/editors/FilterBuilderPro/index.test.tsx
@@ -3,6 +3,7 @@ import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import FilterBuilderPro from './index';
 import type { DimensionOrMeasure } from '@embeddable.com/core';
 import type { FilterBuilderFilter, FilterBuilderState } from './definition';
+import { filterBuilderAndOrOperator } from './FilterBuilderPro.utils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -60,6 +61,12 @@ vi.mock('@embeddable.com/remarkable-ui', () => ({
     <button data-testid="action-icon">
       <Icon />
     </button>
+  ),
+  Tooltip: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
+    <div data-testid="tooltip">
+      {trigger}
+      <span data-testid="tooltip-content">{children}</span>
+    </div>
   ),
 }));
 
@@ -122,12 +129,16 @@ vi.mock('../../component.utils', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-const makeDim = (name = 'country', nativeType = 'string'): DimensionOrMeasure =>
+const makeDim = (
+  name = 'country',
+  nativeType = 'string',
+  type: 'dimension' | 'measure' = 'dimension',
+): DimensionOrMeasure =>
   ({
     name,
     title: name.charAt(0).toUpperCase() + name.slice(1),
     nativeType,
-    __type__: 'dimension',
+    __type__: type,
   }) as unknown as DimensionOrMeasure;
 
 const makeFilter = (overrides: Partial<FilterBuilderFilter> = {}): FilterBuilderFilter => ({
@@ -193,6 +204,7 @@ describe('FilterBuilderPro', () => {
 
     it('renders a FilterBuilderItem for each filter in embeddableState', () => {
       const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 1 }), makeFilter({ id: 2 })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
@@ -207,6 +219,7 @@ describe('FilterBuilderPro', () => {
 
     it('renders the add-filter (+) button when the first filter has a dimensionOrMeasure', () => {
       const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 1, dimensionOrMeasure: makeDim('country') })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
@@ -220,6 +233,7 @@ describe('FilterBuilderPro', () => {
 
     it('renders the clear-all button when at least one filter is fully set', () => {
       const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [
           makeFilter({
             id: 1,
@@ -236,7 +250,10 @@ describe('FilterBuilderPro', () => {
 
   describe('handleSelectDimensionOrMeasure', () => {
     it('calls setEmbeddableState with an updated filter when a dimension is selected', () => {
-      const prevState: FilterBuilderState = { filters: [makeFilter({ id: 1 })] };
+      const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [makeFilter({ id: 1 })],
+      };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
 
       fireEvent.click(screen.getByTestId('select-dim-1'));
@@ -249,7 +266,10 @@ describe('FilterBuilderPro', () => {
     });
 
     it('preserves the existing filter id when updating the dimension', () => {
-      const prevState: FilterBuilderState = { filters: [makeFilter({ id: 5 })] };
+      const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [makeFilter({ id: 5 })],
+      };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
 
       fireEvent.click(screen.getByTestId('select-dim-5'));
@@ -262,6 +282,7 @@ describe('FilterBuilderPro', () => {
   describe('handleSelectOperator', () => {
     it('calls setEmbeddableState with the new operator and resets value', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 1, dimensionOrMeasure: makeDim('country'), value: 'old' })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
@@ -277,6 +298,7 @@ describe('FilterBuilderPro', () => {
   describe('handleSelectValue', () => {
     it('calls setEmbeddableState with the new value', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 1, dimensionOrMeasure: makeDim('country'), operator: 'is' })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
@@ -290,7 +312,10 @@ describe('FilterBuilderPro', () => {
 
   describe('handleDimensionSearch', () => {
     it('calls setEmbeddableState with the updated search string', () => {
-      const prevState: FilterBuilderState = { filters: [makeFilter({ id: 1 })] };
+      const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [makeFilter({ id: 1 })],
+      };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
 
       fireEvent.click(screen.getByTestId('search-1'));
@@ -303,6 +328,7 @@ describe('FilterBuilderPro', () => {
   describe('handleDeleteFilter', () => {
     it('removes the filter at the given index', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 1 }), makeFilter({ id: 2 })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
@@ -316,6 +342,7 @@ describe('FilterBuilderPro', () => {
 
     it('removes the correct filter when deleting the second of two', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 1 }), makeFilter({ id: 2 })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
@@ -331,6 +358,7 @@ describe('FilterBuilderPro', () => {
   describe('handleAddFilter', () => {
     it('appends a new filter when an option is selected from the add-filter dropdown', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 3, dimensionOrMeasure: makeDim('country') })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
@@ -344,6 +372,7 @@ describe('FilterBuilderPro', () => {
 
     it('assigns an id one greater than the last filter id', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [makeFilter({ id: 7, dimensionOrMeasure: makeDim('country') })],
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={prevState} />);
@@ -358,6 +387,7 @@ describe('FilterBuilderPro', () => {
   describe('handleClearAll', () => {
     it('resets filters to a single empty filter when clear-all is clicked', () => {
       const prevState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [
           makeFilter({
             id: 1,
@@ -393,6 +423,7 @@ describe('FilterBuilderPro', () => {
 
     it('calls onChange with a filter clause when a complete filter is present', () => {
       const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [
           makeFilter({
             id: 1,
@@ -410,6 +441,7 @@ describe('FilterBuilderPro', () => {
 
     it('does not call onChange again when the filter value has not changed', () => {
       const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
         filters: [
           makeFilter({
             id: 1,
@@ -427,6 +459,77 @@ describe('FilterBuilderPro', () => {
       rerender(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
 
       expect(defaultProps.onChange).toHaveBeenCalledTimes(callCount);
+    });
+  });
+
+  describe('AND/OR operator with mixed dimension and measure types', () => {
+    const measureFilter = (overrides: Partial<FilterBuilderFilter> = {}): FilterBuilderFilter =>
+      makeFilter({
+        id: 1,
+        dimensionOrMeasure: makeDim('total_listens', 'number', 'measure'),
+        operator: 'gt',
+        value: 10,
+        ...overrides,
+      });
+    const dimensionFilter = (overrides: Partial<FilterBuilderFilter> = {}): FilterBuilderFilter =>
+      makeFilter({
+        id: 2,
+        dimensionOrMeasure: makeDim('age_group'),
+        operator: 'is',
+        value: '13-17',
+        ...overrides,
+      });
+
+    it('disables the AND/OR toggle and shows a tooltip when a dimension and a measure are mixed', () => {
+      const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [measureFilter(), dimensionFilter()],
+      };
+      render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
+
+      expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
+        'editors.filterBuilder.orDisabledMixedTypes',
+      );
+      expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+
+    it('keeps the AND/OR toggle enabled when all filters share the same type', () => {
+      const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [
+          makeFilter({
+            id: 1,
+            dimensionOrMeasure: makeDim('country'),
+            operator: 'is',
+            value: 'France',
+          }),
+          dimensionFilter(),
+        ],
+      };
+      render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
+
+      expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).toHaveAttribute(
+        'aria-disabled',
+        'false',
+      );
+    });
+
+    it('detects a mix from the selected member even when the measure value is incomplete (regression)', () => {
+      // Changing a clause's operator clears its value, making the measure "incomplete".
+      // The mix must still be detected from the selected member, otherwise OR slips through.
+      const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.OR,
+        filters: [measureFilter({ value: null }), dimensionFilter()],
+      };
+      render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
+
+      expect(defaultProps.setEmbeddableState).toHaveBeenCalled();
+      const next = applyUpdater(defaultProps.setEmbeddableState, embeddableState);
+      expect(next.operator).toBe(filterBuilderAndOrOperator.AND);
     });
   });
 

--- a/src/components/editors/FilterBuilderPro/index.test.tsx
+++ b/src/components/editors/FilterBuilderPro/index.test.tsx
@@ -34,41 +34,39 @@ vi.mock('@tabler/icons-react', () => ({
   IconChevronLeft: () => <span data-testid="icon-chevron-left" />,
 }));
 
-vi.mock('@embeddable.com/remarkable-ui', () => ({
-  SingleSelectField: ({
-    triggerComponent,
-    onChange,
-    options,
-  }: {
-    triggerComponent: React.ReactNode;
-    onChange: (v: string | null) => void;
-    options: { value: string; label: string }[];
-  }) => (
-    <div data-testid="new-filter-select">
-      {triggerComponent}
-      {options.map((o) => (
-        <button
-          key={o.value}
-          data-testid={`add-option-${o.value}`}
-          onClick={() => onChange(o.value)}
-        >
-          {o.label}
-        </button>
-      ))}
-    </div>
-  ),
-  ActionIcon: ({ icon: Icon }: { icon: React.ComponentType }) => (
-    <button data-testid="action-icon">
-      <Icon />
-    </button>
-  ),
-  Tooltip: ({ trigger, children }: { trigger: React.ReactNode; children: React.ReactNode }) => (
-    <div data-testid="tooltip">
-      {trigger}
-      <span data-testid="tooltip-content">{children}</span>
-    </div>
-  ),
-}));
+vi.mock('@embeddable.com/remarkable-ui', async () => {
+  const { TooltipMock } = await import('./test-utils');
+  return {
+    SingleSelectField: ({
+      triggerComponent,
+      onChange,
+      options,
+    }: {
+      triggerComponent: React.ReactNode;
+      onChange: (v: string | null) => void;
+      options: { value: string; label: string }[];
+    }) => (
+      <div data-testid="new-filter-select">
+        {triggerComponent}
+        {options.map((o) => (
+          <button
+            key={o.value}
+            data-testid={`add-option-${o.value}`}
+            onClick={() => onChange(o.value)}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+    ),
+    ActionIcon: ({ icon: Icon }: { icon: React.ComponentType }) => (
+      <button data-testid="action-icon">
+        <Icon />
+      </button>
+    ),
+    Tooltip: TooltipMock,
+  };
+});
 
 vi.mock('./components/FilterBuilderItem', () => ({
   default: ({

--- a/src/components/editors/FilterBuilderPro/index.test.tsx
+++ b/src/components/editors/FilterBuilderPro/index.test.tsx
@@ -165,6 +165,29 @@ const applyUpdater = (
   return typeof updater === 'function' ? updater(prevState) : updater;
 };
 
+const emptyFilterState = (): FilterBuilderState => ({
+  filters: [],
+  operator: filterBuilderAndOrOperator.AND,
+});
+
+// A valid single-clause defaultFilters value used across multiple tests.
+const defaultFilterClause: FilterBuilderClause = {
+  operator: filterBuilderAndOrOperator.AND,
+  clauses: [{ property: 'country', operator: 'equals' as never, value: 'France' }],
+};
+
+const simulateScrollState = (
+  scrollEl: Element,
+  scrollLeft: number,
+  clientWidth: number,
+  scrollWidth: number,
+) => {
+  Object.defineProperty(scrollEl, 'scrollLeft', { value: scrollLeft, configurable: true });
+  Object.defineProperty(scrollEl, 'clientWidth', { value: clientWidth, configurable: true });
+  Object.defineProperty(scrollEl, 'scrollWidth', { value: scrollWidth, configurable: true });
+  fireEvent.scroll(scrollEl);
+};
+
 // ---------------------------------------------------------------------------
 // Setup
 // ---------------------------------------------------------------------------
@@ -249,25 +272,16 @@ describe('FilterBuilderPro', () => {
   });
 
   describe('defaultFilters', () => {
-    const clause: FilterBuilderClause = {
-      operator: filterBuilderAndOrOperator.AND,
-      clauses: [{ property: 'country', operator: 'equals' as never, value: 'France' }],
-    };
-
     it('seeds filters from defaultFilters when embeddableState has no existing filters', () => {
       render(
         <FilterBuilderPro
           {...defaultProps}
           dimensionsAndMeasures={[makeDim('country')]}
-          defaultFilters={clause}
+          defaultFilters={defaultFilterClause}
         />,
       );
       expect(defaultProps.setEmbeddableState).toHaveBeenCalled();
-      const emptyState: FilterBuilderState = {
-        filters: [],
-        operator: filterBuilderAndOrOperator.AND,
-      };
-      const next = applyUpdater(defaultProps.setEmbeddableState, emptyState);
+      const next = applyUpdater(defaultProps.setEmbeddableState, emptyFilterState());
       expect(next.filters).toHaveLength(1);
       expect(next.filters[0]!.value).toBe('France');
     });
@@ -288,7 +302,7 @@ describe('FilterBuilderPro', () => {
         <FilterBuilderPro
           {...defaultProps}
           dimensionsAndMeasures={[makeDim('country')]}
-          defaultFilters={clause}
+          defaultFilters={defaultFilterClause}
           embeddableState={existing}
         />,
       );
@@ -313,13 +327,11 @@ describe('FilterBuilderPro', () => {
           defaultFilters={emptyClause}
         />,
       );
-      const emptyState: FilterBuilderState = {
-        filters: [],
-        operator: filterBuilderAndOrOperator.AND,
-      };
       const seedCall = defaultProps.setEmbeddableState.mock.calls.find((call) => {
         if (typeof call[0] !== 'function') return false;
-        const result = (call[0] as (s: FilterBuilderState) => FilterBuilderState)(emptyState);
+        const result = (call[0] as (s: FilterBuilderState) => FilterBuilderState)(
+          emptyFilterState(),
+        );
         return Array.isArray(result.filters) && result.filters.length > 0;
       });
       expect(seedCall).toBeUndefined();
@@ -650,12 +662,7 @@ describe('FilterBuilderPro', () => {
 
     it('renders the scroll-right button and calls scrollBy when content overflows', () => {
       render(<FilterBuilderPro {...defaultProps} />);
-      const scrollEl = document.querySelector('.scroll')!;
-
-      Object.defineProperty(scrollEl, 'scrollLeft', { value: 0, configurable: true });
-      Object.defineProperty(scrollEl, 'clientWidth', { value: 100, configurable: true });
-      Object.defineProperty(scrollEl, 'scrollWidth', { value: 300, configurable: true });
-      fireEvent.scroll(scrollEl);
+      simulateScrollState(document.querySelector('.scroll')!, 0, 100, 300);
 
       fireEvent.click(screen.getByTestId('icon-chevron-right').closest('button')!);
       expect(Element.prototype.scrollBy).toHaveBeenCalledWith({ left: 200, behavior: 'smooth' });
@@ -663,12 +670,7 @@ describe('FilterBuilderPro', () => {
 
     it('renders the scroll-left button and calls scrollBy when scrolled right', () => {
       render(<FilterBuilderPro {...defaultProps} />);
-      const scrollEl = document.querySelector('.scroll')!;
-
-      Object.defineProperty(scrollEl, 'scrollLeft', { value: 10, configurable: true });
-      Object.defineProperty(scrollEl, 'clientWidth', { value: 100, configurable: true });
-      Object.defineProperty(scrollEl, 'scrollWidth', { value: 100, configurable: true });
-      fireEvent.scroll(scrollEl);
+      simulateScrollState(document.querySelector('.scroll')!, 10, 100, 100);
 
       fireEvent.click(screen.getByTestId('icon-chevron-left').closest('button')!);
       expect(Element.prototype.scrollBy).toHaveBeenCalledWith({ left: -200, behavior: 'smooth' });
@@ -677,13 +679,13 @@ describe('FilterBuilderPro', () => {
     it('auto-scrolls to the end when a filter changes after initialisation', () => {
       vi.useFakeTimers();
       const dims = [makeDim('country')];
-      const clause: FilterBuilderClause = {
-        operator: filterBuilderAndOrOperator.AND,
-        clauses: [{ property: 'country', operator: 'equals' as never, value: 'France' }],
-      };
 
       const { rerender } = render(
-        <FilterBuilderPro {...defaultProps} dimensionsAndMeasures={dims} defaultFilters={clause} />,
+        <FilterBuilderPro
+          {...defaultProps}
+          dimensionsAndMeasures={dims}
+          defaultFilters={defaultFilterClause}
+        />,
       );
 
       // Clear the disableAutoScroll guard set by defaultFilters effect
@@ -693,7 +695,7 @@ describe('FilterBuilderPro', () => {
         <FilterBuilderPro
           {...defaultProps}
           dimensionsAndMeasures={dims}
-          defaultFilters={clause}
+          defaultFilters={defaultFilterClause}
           embeddableState={{
             operator: filterBuilderAndOrOperator.AND,
             filters: [

--- a/src/components/editors/FilterBuilderPro/index.test.tsx
+++ b/src/components/editors/FilterBuilderPro/index.test.tsx
@@ -1,9 +1,9 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import FilterBuilderPro from './index';
 import type { DimensionOrMeasure } from '@embeddable.com/core';
 import type { FilterBuilderFilter, FilterBuilderState } from './definition';
-import { filterBuilderAndOrOperator } from './FilterBuilderPro.utils';
+import { filterBuilderAndOrOperator, FilterBuilderClause } from './FilterBuilderPro.utils';
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -245,6 +245,84 @@ describe('FilterBuilderPro', () => {
       };
       render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
       expect(screen.getByText('editors.filterBuilder.clearAll')).toBeInTheDocument();
+    });
+  });
+
+  describe('defaultFilters', () => {
+    const clause: FilterBuilderClause = {
+      operator: filterBuilderAndOrOperator.AND,
+      clauses: [{ property: 'country', operator: 'equals' as never, value: 'France' }],
+    };
+
+    it('seeds filters from defaultFilters when embeddableState has no existing filters', () => {
+      render(
+        <FilterBuilderPro
+          {...defaultProps}
+          dimensionsAndMeasures={[makeDim('country')]}
+          defaultFilters={clause}
+        />,
+      );
+      expect(defaultProps.setEmbeddableState).toHaveBeenCalled();
+      const emptyState: FilterBuilderState = {
+        filters: [],
+        operator: filterBuilderAndOrOperator.AND,
+      };
+      const next = applyUpdater(defaultProps.setEmbeddableState, emptyState);
+      expect(next.filters).toHaveLength(1);
+      expect(next.filters[0]!.value).toBe('France');
+    });
+
+    it('preserves existing filters when embeddableState already has filters', () => {
+      const existing: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [
+          makeFilter({
+            id: 1,
+            dimensionOrMeasure: makeDim('country'),
+            operator: 'is',
+            value: 'UK',
+          }),
+        ],
+      };
+      render(
+        <FilterBuilderPro
+          {...defaultProps}
+          dimensionsAndMeasures={[makeDim('country')]}
+          defaultFilters={clause}
+          embeddableState={existing}
+        />,
+      );
+      const seedCall = defaultProps.setEmbeddableState.mock.calls.find(
+        (call) => typeof call[0] === 'function',
+      );
+      if (seedCall) {
+        const result = (seedCall[0] as (s: FilterBuilderState) => FilterBuilderState)(existing);
+        expect(result.filters).toEqual(existing.filters);
+      }
+    });
+
+    it('does not seed filters when defaultFilters has no matching clauses', () => {
+      const emptyClause: FilterBuilderClause = {
+        operator: filterBuilderAndOrOperator.AND,
+        clauses: [],
+      };
+      render(
+        <FilterBuilderPro
+          {...defaultProps}
+          dimensionsAndMeasures={[makeDim('country')]}
+          defaultFilters={emptyClause}
+        />,
+      );
+      const emptyState: FilterBuilderState = {
+        filters: [],
+        operator: filterBuilderAndOrOperator.AND,
+      };
+      const seedCall = defaultProps.setEmbeddableState.mock.calls.find((call) => {
+        if (typeof call[0] !== 'function') return false;
+        const result = (call[0] as (s: FilterBuilderState) => FilterBuilderState)(emptyState);
+        return Array.isArray(result.filters) && result.filters.length > 0;
+      });
+      expect(seedCall).toBeUndefined();
     });
   });
 
@@ -512,6 +590,42 @@ describe('FilterBuilderPro', () => {
       expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).not.toBeDisabled();
     });
 
+    it('toggles the operator from AND to OR when the AND/OR button is clicked', () => {
+      const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.AND,
+        filters: [
+          makeFilter({
+            id: 1,
+            dimensionOrMeasure: makeDim('country'),
+            operator: 'is',
+            value: 'France',
+          }),
+          makeFilter({
+            id: 2,
+            dimensionOrMeasure: makeDim('city'),
+            operator: 'is',
+            value: 'Paris',
+          }),
+        ],
+      };
+      render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'editors.filterBuilder.and' }));
+
+      const next = applyUpdater(defaultProps.setEmbeddableState, embeddableState);
+      expect(next.operator).toBe(filterBuilderAndOrOperator.OR);
+    });
+
+    it('does not call onChange while operator is OR with mixed filter types', () => {
+      const embeddableState: FilterBuilderState = {
+        operator: filterBuilderAndOrOperator.OR,
+        filters: [measureFilter(), dimensionFilter()],
+      };
+      render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
+
+      expect(defaultProps.onChange).not.toHaveBeenCalled();
+    });
+
     it('detects a mix from the selected member even when the measure value is incomplete (regression)', () => {
       // Changing a clause's operator clears its value, making the measure "incomplete".
       // The mix must still be detected from the selected member, otherwise OR slips through.
@@ -532,6 +646,72 @@ describe('FilterBuilderPro', () => {
       render(<FilterBuilderPro {...defaultProps} />);
       expect(screen.queryByTestId('icon-chevron-left')).not.toBeInTheDocument();
       expect(screen.queryByTestId('icon-chevron-right')).not.toBeInTheDocument();
+    });
+
+    it('renders the scroll-right button and calls scrollBy when content overflows', () => {
+      render(<FilterBuilderPro {...defaultProps} />);
+      const scrollEl = document.querySelector('.scroll')!;
+
+      Object.defineProperty(scrollEl, 'scrollLeft', { value: 0, configurable: true });
+      Object.defineProperty(scrollEl, 'clientWidth', { value: 100, configurable: true });
+      Object.defineProperty(scrollEl, 'scrollWidth', { value: 300, configurable: true });
+      fireEvent.scroll(scrollEl);
+
+      fireEvent.click(screen.getByTestId('icon-chevron-right').closest('button')!);
+      expect(Element.prototype.scrollBy).toHaveBeenCalledWith({ left: 200, behavior: 'smooth' });
+    });
+
+    it('renders the scroll-left button and calls scrollBy when scrolled right', () => {
+      render(<FilterBuilderPro {...defaultProps} />);
+      const scrollEl = document.querySelector('.scroll')!;
+
+      Object.defineProperty(scrollEl, 'scrollLeft', { value: 10, configurable: true });
+      Object.defineProperty(scrollEl, 'clientWidth', { value: 100, configurable: true });
+      Object.defineProperty(scrollEl, 'scrollWidth', { value: 100, configurable: true });
+      fireEvent.scroll(scrollEl);
+
+      fireEvent.click(screen.getByTestId('icon-chevron-left').closest('button')!);
+      expect(Element.prototype.scrollBy).toHaveBeenCalledWith({ left: -200, behavior: 'smooth' });
+    });
+
+    it('auto-scrolls to the end when a filter changes after initialisation', () => {
+      vi.useFakeTimers();
+      const dims = [makeDim('country')];
+      const clause: FilterBuilderClause = {
+        operator: filterBuilderAndOrOperator.AND,
+        clauses: [{ property: 'country', operator: 'equals' as never, value: 'France' }],
+      };
+
+      const { rerender } = render(
+        <FilterBuilderPro {...defaultProps} dimensionsAndMeasures={dims} defaultFilters={clause} />,
+      );
+
+      // Clear the disableAutoScroll guard set by defaultFilters effect
+      act(() => vi.advanceTimersByTime(100));
+
+      rerender(
+        <FilterBuilderPro
+          {...defaultProps}
+          dimensionsAndMeasures={dims}
+          defaultFilters={clause}
+          embeddableState={{
+            operator: filterBuilderAndOrOperator.AND,
+            filters: [
+              makeFilter({
+                id: 1,
+                dimensionOrMeasure: makeDim('country'),
+                operator: 'is',
+                value: 'France',
+              }),
+            ],
+          }}
+        />,
+      );
+
+      act(() => vi.advanceTimersByTime(100));
+
+      expect(Element.prototype.scrollTo).toHaveBeenCalled();
+      vi.useRealTimers();
     });
   });
 });

--- a/src/components/editors/FilterBuilderPro/index.test.tsx
+++ b/src/components/editors/FilterBuilderPro/index.test.tsx
@@ -490,10 +490,7 @@ describe('FilterBuilderPro', () => {
       expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
         'editors.filterBuilder.disableOrOperatorToolTip',
       );
-      expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).toHaveAttribute(
-        'aria-disabled',
-        'true',
-      );
+      expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).toBeDisabled();
     });
 
     it('keeps the AND/OR toggle enabled when all filters share the same type', () => {
@@ -512,10 +509,7 @@ describe('FilterBuilderPro', () => {
       render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
 
       expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).toHaveAttribute(
-        'aria-disabled',
-        'false',
-      );
+      expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).not.toBeDisabled();
     });
 
     it('detects a mix from the selected member even when the measure value is incomplete (regression)', () => {

--- a/src/components/editors/FilterBuilderPro/index.test.tsx
+++ b/src/components/editors/FilterBuilderPro/index.test.tsx
@@ -488,7 +488,7 @@ describe('FilterBuilderPro', () => {
       render(<FilterBuilderPro {...defaultProps} embeddableState={embeddableState} />);
 
       expect(screen.getByTestId('tooltip-content')).toHaveTextContent(
-        'editors.filterBuilder.orDisabledMixedTypes',
+        'editors.filterBuilder.disableOrOperatorToolTip',
       );
       expect(screen.getByRole('button', { name: 'editors.filterBuilder.and' })).toHaveAttribute(
         'aria-disabled',

--- a/src/components/editors/FilterBuilderPro/index.tsx
+++ b/src/components/editors/FilterBuilderPro/index.tsx
@@ -1,6 +1,6 @@
-import { DataResponse, DimensionOrMeasure } from '@embeddable.com/core';
+import { DataResponse, DimensionOrMeasure, isDimension, isMeasure } from '@embeddable.com/core';
 import { useTheme } from '@embeddable.com/react';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Theme } from '../../../theme/theme.types';
 import FilterBuilderItem from './components/FilterBuilderItem';
 import { FilterBuilderFilter, FilterBuilderState } from './definition';
@@ -9,11 +9,13 @@ import { IconPlus, IconChevronRight, IconChevronLeft } from '@tabler/icons-react
 import styles from './FilterBuilderPro.module.css';
 import {
   filterBuilderAndOrOperator,
+  FilterBuilderAndOrOperator,
   filtersToClause,
   getSupportedDimensionsAndMeasures,
   clauseToFilters,
   FilterBuilderClause,
 } from './FilterBuilderPro.utils';
+import { FilterBuilderProAndOrButton } from './components/FilterBuilderProAndOrButton';
 import { i18n, i18nSetup } from '../../../theme/i18n/i18n';
 import { getDimensionAndMeasureOptions } from '../utils/dimensionsAndMeasures.utils';
 import { resolveI18nProps } from '../../component.utils';
@@ -50,10 +52,6 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
   const prevFilterValueRef = useRef<unknown>(undefined);
   const disableAutoScroll = useRef(true);
 
-  // Update embeddableState.filters from defaultFilters if any, but only when there
-  // is no existing filter state (i.e. on initial mount / after a remount). This prevents
-  // the variable feedback loop (inputs: ['defaultFilters']) from overwriting user edits
-  // mid-session when the platform re-sends props with the previous clause value.
   useEffect(() => {
     if (!defaultFilters || !dimensionsAndMeasures?.length) {
       return;
@@ -75,7 +73,7 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
     setTimeout(() => {
       disableAutoScroll.current = false;
     }, 100);
-  }, [defaultFilters, dimensionsAndMeasures]);
+  }, [defaultFilters, dimensionsAndMeasures, setEmbeddableState]);
 
   const updateScrollState = useCallback(() => {
     const el = scrollRef.current;
@@ -118,14 +116,25 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
     }, 100);
   }, [lastFilterKey]);
 
-  const newFilter = (dimensionOrMeasureValue: string | null = null): FilterBuilderFilter => {
-    const dimensionOrMeasure =
-      dimensionsAndMeasures.find((d) => d.name === dimensionOrMeasureValue) ?? null;
+  const newFilter = useCallback(
+    (dimensionOrMeasureValue: string | null = null): FilterBuilderFilter => {
+      const dimensionOrMeasure =
+        dimensionsAndMeasures.find((d) => d.name === dimensionOrMeasureValue) ?? null;
 
-    return { id: lastFilterId + 1, dimensionOrMeasure, search: '', operator: null, value: null };
+      return { id: lastFilterId + 1, dimensionOrMeasure, search: '', operator: null, value: null };
+    },
+    [dimensionsAndMeasures, lastFilterId],
+  );
+
+  const filters = useMemo(
+    () => (embeddableState?.filters?.length ? embeddableState.filters : [newFilter()]),
+    [embeddableState?.filters, newFilter],
+  );
+  const operator = embeddableState?.operator ?? filterBuilderAndOrOperator.AND;
+
+  const handleOperatorChange = (value: FilterBuilderAndOrOperator) => {
+    setEmbeddableState?.((prev) => ({ ...prev, operator: value }));
   };
-
-  const filters = embeddableState?.filters?.length ? embeddableState.filters : [newFilter()];
 
   const handleSelectDimensionOrMeasure = (index: number, name: string | null) => {
     setEmbeddableState?.((prev: FilterBuilderState) => {
@@ -184,14 +193,6 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
     }, 0);
   };
 
-  useEffect(() => {
-    const filterValue = filtersToClause(filterBuilderAndOrOperator.AND, filters);
-    const serialized = JSON.stringify(filterValue);
-    if (serialized === JSON.stringify(prevFilterValueRef.current)) return;
-    prevFilterValueRef.current = filterValue;
-    onChange?.(filterValue);
-  }, [filters]);
-
   const supportedDimensionsAndMeasures = getSupportedDimensionsAndMeasures(dimensionsAndMeasures);
 
   const dimensionOptionsNew = getDimensionAndMeasureOptions({
@@ -202,8 +203,34 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
 
   const hasClearAll = filters.some((f) => f.dimensionOrMeasure && f.operator && f.value != null);
 
+  // OR cannot combine dimensions (row-level WHERE) with measures (aggregate HAVING)
+  // in Cube. This depends on which members are *selected*, not whether their values
+  // are filled in — a measure mid-edit (e.g. value cleared after an operator change)
+  // still makes the set mixed, so we must not look only at "complete" filters.
+  const hasMixedTypes =
+    filters.some((f) => isDimension(f.dimensionOrMeasure ?? undefined)) &&
+    filters.some((f) => isMeasure(f.dimensionOrMeasure ?? undefined));
+
+  useEffect(() => {
+    if (hasMixedTypes && operator === filterBuilderAndOrOperator.OR) {
+      setEmbeddableState?.((prev) => ({ ...prev, operator: filterBuilderAndOrOperator.AND }));
+    }
+  }, [hasMixedTypes, operator, setEmbeddableState]);
+
+  useEffect(() => {
+    const filterValue = filtersToClause(operator, filters);
+    const serialized = JSON.stringify(filterValue);
+    if (serialized === JSON.stringify(prevFilterValueRef.current)) return;
+    prevFilterValueRef.current = filterValue;
+    onChange?.(filterValue);
+  }, [filters, operator, onChange]);
+
   const handleClearAll = () => {
-    setEmbeddableState?.((prev: FilterBuilderState) => ({ ...prev, filters: [newFilter()] }));
+    setEmbeddableState?.((prev: FilterBuilderState) => ({
+      ...prev,
+      filters: [newFilter()],
+      operator: filterBuilderAndOrOperator.AND,
+    }));
   };
 
   return (
@@ -217,6 +244,13 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
         <div className={styles.scroll} ref={scrollRef}>
           {filters.map((filter, index) => (
             <React.Fragment key={filter.id}>
+              {index > 0 && (
+                <FilterBuilderProAndOrButton
+                  operator={operator}
+                  onChange={handleOperatorChange}
+                  disabled={hasMixedTypes}
+                />
+              )}
               <FilterBuilderItem
                 filter={filter}
                 dimensionsAndMeasures={dimensionsAndMeasures}

--- a/src/components/editors/FilterBuilderPro/index.tsx
+++ b/src/components/editors/FilterBuilderPro/index.tsx
@@ -211,20 +211,22 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
     filters.some((f) => isDimension(f.dimensionOrMeasure ?? undefined)) &&
     filters.some((f) => isMeasure(f.dimensionOrMeasure ?? undefined));
 
-  useEffect(() => {
-    if (hasMixedTypes && operator === filterBuilderAndOrOperator.OR) {
-      setEmbeddableState?.((prev) => ({ ...prev, operator: filterBuilderAndOrOperator.AND }));
-    }
-  }, [hasMixedTypes, operator, setEmbeddableState]);
+  const isMixedOrOperator = hasMixedTypes && operator === filterBuilderAndOrOperator.OR;
 
   useEffect(() => {
-    if (hasMixedTypes && operator === filterBuilderAndOrOperator.OR) return;
+    if (isMixedOrOperator) {
+      setEmbeddableState?.((prev) => ({ ...prev, operator: filterBuilderAndOrOperator.AND }));
+    }
+  }, [isMixedOrOperator, setEmbeddableState]);
+
+  useEffect(() => {
+    if (isMixedOrOperator) return;
     const filterValue = filtersToClause(operator, filters);
     const serialized = JSON.stringify(filterValue);
     if (serialized === JSON.stringify(prevFilterValueRef.current)) return;
     prevFilterValueRef.current = filterValue;
     onChange?.(filterValue);
-  }, [filters, operator, onChange, hasMixedTypes]);
+  }, [filters, operator, onChange, isMixedOrOperator]);
 
   const handleClearAll = () => {
     setEmbeddableState?.((prev: FilterBuilderState) => ({

--- a/src/components/editors/FilterBuilderPro/index.tsx
+++ b/src/components/editors/FilterBuilderPro/index.tsx
@@ -136,58 +136,54 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
     setEmbeddableState?.((prev) => ({ ...prev, operator: value }));
   };
 
+  const updateFilters = useCallback(
+    (updater: (filters: FilterBuilderFilter[]) => FilterBuilderFilter[]) => {
+      setEmbeddableState?.((prev) => ({
+        ...prev,
+        filters: updater([...(prev?.filters ?? [])]),
+      }));
+    },
+    [setEmbeddableState],
+  );
+
   const handleSelectDimensionOrMeasure = (index: number, name: string | null) => {
-    setEmbeddableState?.((prev: FilterBuilderState) => {
-      const newFilters = [...(prev?.filters ?? [])];
-
-      const existing = newFilters[index];
-
-      newFilters[index] = {
-        ...newFilter(name),
-        ...(existing?.id ? { id: existing.id } : {}),
-      };
-
-      return { ...prev, filters: newFilters };
+    updateFilters((f) => {
+      const existing = f[index];
+      f[index] = { ...newFilter(name), ...(existing?.id ? { id: existing.id } : {}) };
+      return f;
     });
   };
 
   const handleSelectOperator = (index: number, operator: string | null) => {
-    setEmbeddableState?.((prev: FilterBuilderState) => {
-      const newFilters = [...(prev?.filters ?? [])];
-      newFilters[index] = { ...newFilters[index]!, operator, value: null };
-      return { ...prev, filters: newFilters };
+    updateFilters((f) => {
+      f[index] = { ...f[index]!, operator, value: null };
+      return f;
     });
   };
 
   const handleSelectValue = (index: number, value: FilterBuilderFilter['value']) => {
-    setEmbeddableState?.((prev: FilterBuilderState) => {
-      const newFilters = [...(prev?.filters ?? [])];
-      newFilters[index] = { ...newFilters[index]!, value };
-      return { ...prev, filters: newFilters };
+    updateFilters((f) => {
+      f[index] = { ...f[index]!, value };
+      return f;
     });
   };
 
   const handleDimensionSearch = (index: number, search: string) => {
-    setEmbeddableState?.((prev: FilterBuilderState) => {
-      const newFilters = [...(prev?.filters ?? [])];
-      newFilters[index] = { ...newFilters[index]!, search };
-      return { ...prev, filters: newFilters };
+    updateFilters((f) => {
+      f[index] = { ...f[index]!, search };
+      return f;
     });
   };
 
   const handleDeleteFilter = (index: number) => {
-    setEmbeddableState?.((prev: FilterBuilderState) => {
-      const newFilters = [...(prev?.filters ?? [])];
-      newFilters.splice(index, 1);
-      return { ...prev, filters: newFilters };
+    updateFilters((f) => {
+      f.splice(index, 1);
+      return f;
     });
   };
 
   const handleAddFilter = (value: string | null) => {
-    setEmbeddableState?.((prev: FilterBuilderState) => {
-      const newFilters = [...(prev?.filters ?? []), newFilter(value)];
-      return { ...prev, filters: newFilters };
-    });
+    updateFilters((f) => [...f, newFilter(value)]);
     setTimeout(() => {
       scrollRef.current?.scrollTo({ left: scrollRef.current.scrollWidth, behavior: 'smooth' });
     }, 0);

--- a/src/components/editors/FilterBuilderPro/index.tsx
+++ b/src/components/editors/FilterBuilderPro/index.tsx
@@ -218,12 +218,13 @@ const FilterBuilderPro = (props: FilterBuilderProProps) => {
   }, [hasMixedTypes, operator, setEmbeddableState]);
 
   useEffect(() => {
+    if (hasMixedTypes && operator === filterBuilderAndOrOperator.OR) return;
     const filterValue = filtersToClause(operator, filters);
     const serialized = JSON.stringify(filterValue);
     if (serialized === JSON.stringify(prevFilterValueRef.current)) return;
     prevFilterValueRef.current = filterValue;
     onChange?.(filterValue);
-  }, [filters, operator, onChange]);
+  }, [filters, operator, onChange, hasMixedTypes]);
 
   const handleClearAll = () => {
     setEmbeddableState?.((prev: FilterBuilderState) => ({

--- a/src/components/editors/FilterBuilderPro/test-utils.tsx
+++ b/src/components/editors/FilterBuilderPro/test-utils.tsx
@@ -1,0 +1,14 @@
+export function TooltipMock({
+  trigger,
+  children,
+}: {
+  trigger: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div data-testid="tooltip">
+      {trigger}
+      <span data-testid="tooltip-content">{children}</span>
+    </div>
+  );
+}

--- a/src/theme/i18n/translations/de.ts
+++ b/src/theme/i18n/translations/de.ts
@@ -59,7 +59,7 @@ export const de: ResourceLanguage = {
         betweenAnd: 'und',
         and: 'und',
         or: 'oder',
-        orDisabledMixedTypes:
+        disableOrOperatorToolTip:
           'Berechnungen und Kategoriefilter können nur mit "und" kombiniert werden, nicht mit "oder".',
         is: 'ist',
         isNot: 'ist nicht',

--- a/src/theme/i18n/translations/de.ts
+++ b/src/theme/i18n/translations/de.ts
@@ -59,6 +59,7 @@ export const de: ResourceLanguage = {
         betweenAnd: 'und',
         and: 'und',
         or: 'oder',
+        orDisabledMixedTypes: "'oder' kann Kennzahlen und Attribute nicht kombinieren",
         is: 'ist',
         isNot: 'ist nicht',
         isOneOf: 'ist eines von',

--- a/src/theme/i18n/translations/de.ts
+++ b/src/theme/i18n/translations/de.ts
@@ -59,7 +59,8 @@ export const de: ResourceLanguage = {
         betweenAnd: 'und',
         and: 'und',
         or: 'oder',
-        orDisabledMixedTypes: "'oder' kann Kennzahlen und Attribute nicht kombinieren",
+        orDisabledMixedTypes:
+          'Verwende "und" nur, wenn Berechnungen mit Kategoriefiltern kombiniert werden',
         is: 'ist',
         isNot: 'ist nicht',
         isOneOf: 'ist eines von',

--- a/src/theme/i18n/translations/de.ts
+++ b/src/theme/i18n/translations/de.ts
@@ -60,7 +60,7 @@ export const de: ResourceLanguage = {
         and: 'und',
         or: 'oder',
         orDisabledMixedTypes:
-          'Verwende "und" nur, wenn Berechnungen mit Kategoriefiltern kombiniert werden',
+          'Berechnungen und Kategoriefilter können nur mit "und" kombiniert werden, nicht mit "oder".',
         is: 'ist',
         isNot: 'ist nicht',
         isOneOf: 'ist eines von',

--- a/src/theme/i18n/translations/en.ts
+++ b/src/theme/i18n/translations/en.ts
@@ -48,6 +48,7 @@ export const en: ResourceLanguage = {
         betweenAnd: 'and',
         and: 'and',
         or: 'or',
+        orDisabledMixedTypes: "'or' can't combine metrics and attributes",
         is: 'is',
         isNot: 'is not',
         isOneOf: 'is one of',

--- a/src/theme/i18n/translations/en.ts
+++ b/src/theme/i18n/translations/en.ts
@@ -48,7 +48,7 @@ export const en: ResourceLanguage = {
         betweenAnd: 'and',
         and: 'and',
         or: 'or',
-        orDisabledMixedTypes:
+        disableOrOperatorToolTip:
           'Calculations and category filters can only be combined with "and", not "or".',
         is: 'is',
         isNot: 'is not',

--- a/src/theme/i18n/translations/en.ts
+++ b/src/theme/i18n/translations/en.ts
@@ -48,7 +48,8 @@ export const en: ResourceLanguage = {
         betweenAnd: 'and',
         and: 'and',
         or: 'or',
-        orDisabledMixedTypes: 'Use "and" only when combining calculations with category filters',
+        orDisabledMixedTypes:
+          'Calculations and category filters can only be combined with "and", not "or".',
         is: 'is',
         isNot: 'is not',
         isOneOf: 'is one of',

--- a/src/theme/i18n/translations/en.ts
+++ b/src/theme/i18n/translations/en.ts
@@ -48,7 +48,7 @@ export const en: ResourceLanguage = {
         betweenAnd: 'and',
         and: 'and',
         or: 'or',
-        orDisabledMixedTypes: "'or' can't combine metrics and attributes",
+        orDisabledMixedTypes: 'Use "and" only when combining calculations with category filters',
         is: 'is',
         isNot: 'is not',
         isOneOf: 'is one of',


### PR DESCRIPTION
# Why is this pull-request needed?

The FilterBuilder currently combines all clauses using AND logic only — every clause must be satisfied for a record to be included. There is no way for end users to switch between AND and OR at the top level.

# Main changes

* Wired FilterBuilderProAndOrButton between every pair of adjacent filter clauses; the operator is persisted in FilterBuilderState and emitted in the output FilterBuilderClause
* Added operator field to FilterBuilderState; defaults to AND
* Added unit tests covering the disabled state, tooltip display, and the mixed-type auto-reset behaviour

# Test evidence

https://github.com/user-attachments/assets/358e1e0e-6456-4159-b7ca-13b66dcd484d




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "or" operator support for filter combinations in the filter builder.
  * Automatically switches to "and" when mixing metrics and attributes.
  * Displays a tooltip explaining why "or" is unavailable for mixed types.

* **Tests**
  * Enhanced test coverage for operator toggle behavior and mixed-type filtering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->