### PR TITLE
TPS-1404: release new remarkable-ui version

### DIFF
--- a/.changeset/hungry-zebras-wash.md
+++ b/.changeset/hungry-zebras-wash.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Increase Remarkable-Ui version

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.3.10",
+  "version": "0.3.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.3.10",
+      "version": "0.3.12",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
-        "@embeddable.com/core": "^2.13.7",
-        "@embeddable.com/react": "^2.13.7",
-        "@embeddable.com/remarkable-ui": "^3.0.20",
+        "@embeddable.com/core": "^2.13.8",
+        "@embeddable.com/react": "^2.13.8",
+        "@embeddable.com/remarkable-ui": "^3.0.21",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -916,9 +916,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "3.0.20",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.0.20.tgz",
-      "integrity": "sha512-iqoOc3ybPdOITRtKyTx1FySTH2scjkgHYd1ymi4cEswzuVMzkDxteg24BccRRj4X6i1DEbG0mOlKDNXKtORN2Q==",
+      "version": "3.0.21",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.0.21.tgz",
+      "integrity": "sha512-kNoc6euqvPeUF/7W5Xy2gdY/p3kNW8+mZOnkJORcR2Vr6MkvhVR84jzaKqOmxvT+QLLmgrVFSsBxx52914HX1g==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",

--- a/package.json
+++ b/package.json
@@ -61,9 +61,9 @@
   },
   "dependencies": {
     "@changesets/cli": "^2.29.6",
-    "@embeddable.com/core": "^2.13.7",
-    "@embeddable.com/react": "^2.13.7",
-    "@embeddable.com/remarkable-ui": "^3.0.20",
+    "@embeddable.com/core": "^2.13.8",
+    "@embeddable.com/react": "^2.13.8",
+    "@embeddable.com/remarkable-ui": "^3.0.21",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",


### PR DESCRIPTION
# Why is this pull-request needed?

This uses the new remarkable ui version **3.0.21** that includes an improvement for the date-pickers, where we can select a date that is furthers until 5 years from now

# Main changes

- increase the version

# Test evidence

https://github.com/user-attachments/assets/b21734f4-0249-476b-9a1d-eeea5d8601ab



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several internal package versions to the latest patch releases.
  * Included a patch release note for `remarkable-pro` and a newer `Remarkable-Ui` version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->