### PR TITLE
TPS-1412: fallback for i18n not initialized (improvement)

### DIFF
--- a/.changeset/free-jokes-win.md
+++ b/.changeset/free-jokes-win.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Fallback string value when the i18n is not initialized

--- a/src/components/component.utils.ts
+++ b/src/components/component.utils.ts
@@ -2,9 +2,16 @@ import { i18n } from '../theme/i18n/i18n';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const resolveI18nString = (value: string, args?: Record<string, any>): string => {
-  if (!value || !value.includes('|')) return i18n.t(value, args);
+  // Not a translation key, return the value as is
+  if (!value?.includes('|')) return value;
 
   const [key, fallback] = value.split('|', 2).map((part) => part.trim());
+
+  // i18n is not initialized, return the fallback or the key
+  if (!i18n.isInitialized) {
+    return (fallback ?? key) as string;
+  }
+
   return i18n.t(
     [key, fallback].filter((v): v is string => !!v),
     args,

--- a/src/components/component.utils.ts
+++ b/src/components/component.utils.ts
@@ -9,7 +9,7 @@ export const resolveI18nString = (value: string, args?: Record<string, any>): st
 
   // i18n is not initialized, return the fallback or the key
   if (!i18n.isInitialized) {
-    return (fallback ?? key) as string;
+    return (fallback || key) as string;
   }
 
   return i18n.t(


### PR DESCRIPTION
# Why is this pull-request needed?

A user forgot to set the client-context on the `<em-beddable>`. The client theme files uses this client-context, to define the i18n translations. Because the client-context was not arriving, it was not possible to init the i18n. And for that reason no translation happen.

Additionally, we should only make usage of the i18n.t(), when it is clearly a field asking for translation (including a "|").


# Main changes

Add a fallback for the scenario where the i18n is not initialized, due wrong configuration. 
The fallback should always be the values defined by the user on the configurator input field.

# Test evidence


<img width="605" height="1275" alt="image" src="https://github.com/user-attachments/assets/0877c48c-b4c7-480a-8e2b-1d1800eff09b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how text is resolved when internationalization isn’t ready, so fallback text now appears instead of breaking or showing unexpected output.
  * Non-translation text is now returned as-is, making plain values behave more consistently.
* **Chores**
  * Added a release note entry for a patch update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->