### PR TITLE
RUI-000: can clear single multi select fields

### DIFF
--- a/.changeset/gentle-taxis-thank.md
+++ b/.changeset/gentle-taxis-thank.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Add "can be cleared" field to the Single and Multi select field component

--- a/src/components/editors/MultiSelectFieldPro/definition.ts
+++ b/src/components/editors/MultiSelectFieldPro/definition.ts
@@ -41,6 +41,7 @@ const meta = {
       category: 'Data Mapping for Interactions',
       description: 'Send a different dimension to embeddable when the user clicks. Must be unique.',
     },
+    inputs.clearable,
   ],
   events: [
     {

--- a/src/components/editors/MultiSelectFieldPro/index.test.tsx
+++ b/src/components/editors/MultiSelectFieldPro/index.test.tsx
@@ -1,0 +1,261 @@
+import { render, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import MultiSelectFieldPro from './index';
+import type { Dimension, DataResponse } from '@embeddable.com/core';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../theme/formatter/formatter.utils', () => ({
+  getThemeFormatter: vi.fn(() => ({
+    data: vi.fn((_dim: unknown, value: unknown) => String(value)),
+  })),
+}));
+
+vi.mock('../../../theme/i18n/i18n', () => ({
+  i18nSetup: vi.fn(),
+  i18n: { t: vi.fn((key: string) => key) },
+}));
+
+vi.mock('../shared/EditorCard/EditorCard', () => ({
+  EditorCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props: object) => props),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', async () => {
+  const { MultiSelectFieldMock } = await import('../test-utils/multiSelectField.mock');
+  return { MultiSelectField: MultiSelectFieldMock };
+});
+
+const country = { name: 'country', title: 'Country' } as Dimension;
+const region = { name: 'region', title: 'Region' } as Dimension;
+
+const resultsWith = (data: Record<string, unknown>[], isLoading = false): DataResponse => ({
+  isLoading,
+  data,
+});
+
+describe('MultiSelectFieldPro', () => {
+  it('renders the MultiSelectField', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toBeInTheDocument();
+  });
+
+  it('maps results.data into options using the dimension value/label', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+        selectedValues={['US']}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('option-US')).toBeInTheDocument();
+    expect(getByTestId('option-UK')).toBeInTheDocument();
+  });
+
+  it('uses optionalSecondDimension for option value while keeping the first dimension label', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        optionalSecondDimension={region}
+        results={resultsWith([{ country: 'US', region: 'na' }])}
+        selectedValues={['na']}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('option-na')).toBeInTheDocument();
+  });
+
+  it('passes selectedValues as values to MultiSelectField', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+        selectedValues={['US', 'UK']}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute('data-values', 'US,UK');
+  });
+
+  it('passes empty values when selectedValues is undefined', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }])}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute('data-values', '');
+  });
+
+  it('passes clearable prop through as isClearable', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }])}
+        clearable
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute('data-clearable', 'true');
+  });
+
+  it('passes placeholder prop to MultiSelectField', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }])}
+        placeholder="Select country"
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute('data-placeholder', 'Select country');
+  });
+
+  it('shows noOptionsMessage when results.data is empty and not loading', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro dimension={country} results={resultsWith([])} onChange={vi.fn()} />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute(
+      'data-no-options-message',
+      'common.noOptionsFound',
+    );
+  });
+
+  it('does not show noOptionsMessage while loading, even with no data', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([], true)}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute('data-no-options-message', '');
+  });
+
+  it('does not show noOptionsMessage when data is present', () => {
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }])}
+        onChange={vi.fn()}
+      />,
+    );
+    expect(getByTestId('multi-select')).toHaveAttribute('data-no-options-message', '');
+  });
+
+  it('calls onChange with the selected value added when an option is clicked', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+        selectedValues={['US']}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(getByTestId('option-UK'));
+    expect(onChange).toHaveBeenCalledWith(['US', 'UK']);
+  });
+
+  it('calls onChange with the value removed when an already-selected option is clicked', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+        selectedValues={['US', 'UK']}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(getByTestId('option-UK'));
+    expect(onChange).toHaveBeenCalledWith(['US']);
+  });
+
+  it('wires setSearchValue to the MultiSelectField search input', () => {
+    const setSearchValue = vi.fn();
+    const { getByTestId } = render(
+      <MultiSelectFieldPro
+        dimension={country}
+        results={resultsWith([{ country: 'US' }])}
+        setSearchValue={setSearchValue}
+        onChange={vi.fn()}
+      />,
+    );
+    fireEvent.change(getByTestId('search-input'), { target: { value: 'U' } });
+    expect(setSearchValue).toHaveBeenCalledWith('U');
+  });
+
+  describe('auto-selecting the first option when not clearable', () => {
+    it('auto-selects the first option when not clearable and nothing is selected', () => {
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFieldPro
+          dimension={country}
+          results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+          onChange={onChange}
+        />,
+      );
+      expect(onChange).toHaveBeenCalledWith(['US']);
+    });
+
+    it('does not auto-select when clearable is true', () => {
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFieldPro
+          dimension={country}
+          results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+          clearable
+          onChange={onChange}
+        />,
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-select when a value is already selected', () => {
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFieldPro
+          dimension={country}
+          results={resultsWith([{ country: 'US' }, { country: 'UK' }])}
+          selectedValues={['UK']}
+          onChange={onChange}
+        />,
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-select when there are no options', () => {
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFieldPro dimension={country} results={resultsWith([])} onChange={onChange} />,
+      );
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not auto-select when selectedValues is an empty array', () => {
+      const onChange = vi.fn();
+      render(
+        <MultiSelectFieldPro
+          dimension={country}
+          results={resultsWith([{ country: 'US' }])}
+          selectedValues={[]}
+          onChange={onChange}
+        />,
+      );
+      expect(onChange).toHaveBeenCalledWith(['US']);
+    });
+  });
+});

--- a/src/components/editors/MultiSelectFieldPro/index.tsx
+++ b/src/components/editors/MultiSelectFieldPro/index.tsx
@@ -1,6 +1,7 @@
 import { DataResponse, Dimension } from '@embeddable.com/core';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { useTheme } from '@embeddable.com/react';
+import { useEffect } from 'react';
 import { Theme } from '../../../theme/theme.types';
 import { EditorCard, EditorCardHeaderProps } from '../shared/EditorCard/EditorCard';
 import { resolveI18nProps } from '../../component.utils';
@@ -16,6 +17,7 @@ export type MultiSelectFieldProProps = {
   results: DataResponse;
   selectedValues?: string[];
   maxOptions?: number;
+  clearable?: boolean;
   setSearchValue?: (search: string) => void;
   onChange?: (newValues: string[]) => void;
 } & EditorCardHeaderProps;
@@ -25,8 +27,15 @@ const MultiSelectFieldPro = (props: MultiSelectFieldProProps) => {
   const themeFormatter = getThemeFormatter(theme);
 
   const { tooltip, title, description, placeholder } = resolveI18nProps(props);
-  const { dimension, optionalSecondDimension, results, selectedValues, setSearchValue, onChange } =
-    props;
+  const {
+    dimension,
+    optionalSecondDimension,
+    results,
+    selectedValues,
+    clearable,
+    setSearchValue,
+    onChange,
+  } = props;
 
   const options =
     results.data?.map((data) => {
@@ -38,10 +47,20 @@ const MultiSelectFieldPro = (props: MultiSelectFieldProProps) => {
 
   const showNoOptionsMessage = Boolean(!results.isLoading && (results.data?.length ?? 0) === 0);
 
+  const firstOptionValue = options[0]?.value;
+
+  useEffect(() => {
+    if (clearable) return;
+    if ((selectedValues?.length ?? 0) > 0) return;
+    if (firstOptionValue === undefined) return;
+
+    onChange?.([firstOptionValue]);
+  }, [clearable, selectedValues, firstOptionValue, onChange]);
+
   return (
     <EditorCard title={title} description={description} tooltip={tooltip}>
       <MultiSelectField
-        isClearable
+        isClearable={clearable}
         isSearchable
         isLoading={results.isLoading}
         values={selectedValues ?? []}

--- a/src/components/editors/MultiSelectFieldPro/index.tsx
+++ b/src/components/editors/MultiSelectFieldPro/index.tsx
@@ -49,6 +49,7 @@ const MultiSelectFieldPro = (props: MultiSelectFieldProProps) => {
 
   const firstOptionValue = options[0]?.value;
 
+  // Auto-select first option when not clearable and there is no selection
   useEffect(() => {
     if (clearable) return;
     if ((selectedValues?.length ?? 0) > 0) return;

--- a/src/components/editors/SingleSelectFieldPro/definition.ts
+++ b/src/components/editors/SingleSelectFieldPro/definition.ts
@@ -43,6 +43,7 @@ const meta = {
       category: 'Data Mapping for Interactions',
       description: 'Send a different dimension to embeddable when the user clicks. Must be unique.',
     },
+    inputs.clearable,
   ],
   events: [
     {

--- a/src/components/editors/SingleSelectFieldPro/index.test.tsx
+++ b/src/components/editors/SingleSelectFieldPro/index.test.tsx
@@ -1,0 +1,239 @@
+import { render, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+import SingleSelectFieldPro from './index';
+import type { Dimension, DataResponse } from '@embeddable.com/core';
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: vi.fn(() => ({})),
+}));
+
+vi.mock('../../../theme/formatter/formatter.utils', () => ({
+  getThemeFormatter: vi.fn(() => ({
+    data: vi.fn((_dim: unknown, value: unknown) => `label-${String(value)}`),
+  })),
+}));
+
+vi.mock('../../../theme/i18n/i18n', () => ({
+  i18n: { t: vi.fn((key: string) => key) },
+}));
+
+vi.mock('../shared/EditorCard/EditorCard', () => ({
+  EditorCard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../component.utils', () => ({
+  resolveI18nProps: vi.fn((props: object) => props),
+}));
+
+vi.mock('@embeddable.com/remarkable-ui', () => ({
+  SingleSelectField: ({
+    value,
+    onChange,
+    onSearch,
+    clearable,
+    placeholder,
+    isLoading,
+    noOptionsMessage,
+    options,
+  }: {
+    value?: string;
+    onChange: (v: string | null) => void;
+    onSearch?: (v: string) => void;
+    clearable?: boolean;
+    placeholder?: string;
+    isLoading?: boolean;
+    noOptionsMessage?: string;
+    options: { value: string; label: string }[];
+  }) => (
+    <div
+      data-testid="single-select"
+      data-value={value ?? ''}
+      data-clearable={String(clearable ?? false)}
+      data-placeholder={placeholder ?? ''}
+      data-loading={String(isLoading ?? false)}
+      data-no-options-message={noOptionsMessage ?? ''}
+    >
+      {options.map((o) => (
+        <button key={o.value} data-testid={`option-${o.value}`} onClick={() => onChange(o.value)}>
+          {o.label}
+        </button>
+      ))}
+      <input data-testid="search-input" onChange={(e) => onSearch?.(e.target.value)} />
+    </div>
+  ),
+}));
+
+const country = { name: 'country', title: 'Country' } as Dimension;
+const region = { name: 'region', title: 'Region' } as Dimension;
+
+const makeResults = (values: string[] = [], isLoading = false): DataResponse =>
+  ({
+    data: values.map((v) => ({ country: v, region: `${v}-region` })),
+    isLoading,
+  }) as unknown as DataResponse;
+
+describe('SingleSelectFieldPro', () => {
+  it('renders the SingleSelectField', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults(['US', 'UK'])} clearable />,
+    );
+    expect(getByTestId('single-select')).toBeInTheDocument();
+  });
+
+  it('maps results.data into options using the dimension field', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults(['US', 'UK'])} clearable />,
+    );
+    expect(getByTestId('option-US')).toBeInTheDocument();
+    expect(getByTestId('option-UK')).toBeInTheDocument();
+  });
+
+  it('uses optionalSecondDimension as the option value while keeping the dimension label', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro
+        dimension={country}
+        optionalSecondDimension={region}
+        results={makeResults(['US'])}
+        clearable
+      />,
+    );
+    expect(getByTestId('option-US-region')).toBeInTheDocument();
+    expect(getByTestId('option-US-region')).toHaveTextContent('label-US');
+  });
+
+  it('passes selectedValue as value to SingleSelectField', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US', 'UK'])}
+        selectedValue="UK"
+        clearable
+      />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute('data-value', 'UK');
+  });
+
+  it('passes clearable prop to SingleSelectField', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults(['US'])} clearable />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute('data-clearable', 'true');
+  });
+
+  it('passes placeholder prop to SingleSelectField', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US'])}
+        placeholder="Select a country"
+        clearable
+      />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute('data-placeholder', 'Select a country');
+  });
+
+  it('passes isLoading through to SingleSelectField', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults(['US'], true)} clearable />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute('data-loading', 'true');
+  });
+
+  it('shows noOptionsMessage when results are empty and not loading', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults([], false)} clearable />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute(
+      'data-no-options-message',
+      'common.noOptionsFound',
+    );
+  });
+
+  it('does not show noOptionsMessage while loading, even with no data', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults([], true)} clearable />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute('data-no-options-message', '');
+  });
+
+  it('does not show noOptionsMessage when there are options', () => {
+    const { getByTestId } = render(
+      <SingleSelectFieldPro dimension={country} results={makeResults(['US'])} clearable />,
+    );
+    expect(getByTestId('single-select')).toHaveAttribute('data-no-options-message', '');
+  });
+
+  it('calls onChange with the selected option value', () => {
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US', 'UK'])}
+        clearable
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(getByTestId('option-UK'));
+    expect(onChange).toHaveBeenCalledWith('UK');
+  });
+
+  it('calls setSearchValue when the search input changes', () => {
+    const setSearchValue = vi.fn();
+    const { getByTestId } = render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US'])}
+        clearable
+        setSearchValue={setSearchValue}
+      />,
+    );
+    fireEvent.change(getByTestId('search-input'), { target: { value: 'un' } });
+    expect(setSearchValue).toHaveBeenCalledWith('un');
+  });
+
+  it('auto-selects the first option when not clearable and there is no selection', () => {
+    const onChange = vi.fn();
+    render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US', 'UK'])}
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).toHaveBeenCalledWith('US');
+  });
+
+  it('does not auto-select when clearable is true', () => {
+    const onChange = vi.fn();
+    render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US', 'UK'])}
+        clearable
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-select when a selectedValue is already set', () => {
+    const onChange = vi.fn();
+    render(
+      <SingleSelectFieldPro
+        dimension={country}
+        results={makeResults(['US', 'UK'])}
+        selectedValue="UK"
+        onChange={onChange}
+      />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-select when there are no options', () => {
+    const onChange = vi.fn();
+    render(
+      <SingleSelectFieldPro dimension={country} results={makeResults([])} onChange={onChange} />,
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/editors/SingleSelectFieldPro/index.tsx
+++ b/src/components/editors/SingleSelectFieldPro/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { DataResponse, Dimension } from '@embeddable.com/core';
 import { getThemeFormatter } from '../../../theme/formatter/formatter.utils';
 import { useTheme } from '@embeddable.com/react';
@@ -16,6 +17,7 @@ export type SingleSelectFieldProProps = {
   results: DataResponse;
   selectedValue?: string;
   maxOptions?: number;
+  clearable?: boolean;
   setSearchValue?: (search: string) => void;
   onChange?: (selectedValue: string | null) => void;
 } & EditorCardHeaderProps;
@@ -25,7 +27,8 @@ const SingleSelectFieldPro = (props: SingleSelectFieldProProps) => {
   const themeFormatter = getThemeFormatter(theme);
 
   const { title, description, dimension, placeholder, tooltip } = resolveI18nProps(props);
-  const { optionalSecondDimension, results, selectedValue, setSearchValue, onChange } = props;
+  const { optionalSecondDimension, results, selectedValue, clearable, setSearchValue, onChange } =
+    props;
 
   const options =
     results.data?.map((data) => {
@@ -37,10 +40,23 @@ const SingleSelectFieldPro = (props: SingleSelectFieldProProps) => {
 
   const showNoOptionsMessage = Boolean(!results.isLoading && (results.data?.length ?? 0) === 0);
 
+  // Auto-select first option when not clearable and there is no selection
+  useEffect(() => {
+    const autoSelectActive = !clearable && !selectedValue;
+
+    if (!autoSelectActive) return;
+
+    const firstOption = options?.[0];
+
+    if (firstOption) {
+      onChange?.(firstOption.value);
+    }
+  }, [clearable, selectedValue, options, onChange]);
+
   return (
     <EditorCard title={title} description={description} tooltip={tooltip}>
       <SingleSelectField
-        clearable
+        clearable={clearable}
         searchable
         isLoading={results.isLoading}
         value={selectedValue}


### PR DESCRIPTION
# Why is this pull-request needed?

The single and multi select field should also contain a field "can be cleared"

# Main changes

- add it
- use effect to pre select it is clear is OFF

# Test evidence

Can be tested here: https://app.us.embeddable.com/en/workspace/3e7fe2cf-cd34-43e8-a92d-9f0ccdc95e5f/preview/1699884d-447e-4e76-be89-40df61621d12?securityContext=All+artists


https://github.com/user-attachments/assets/390c70fa-7445-440b-a516-3b0fe6972965




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a clearable option to Single Select and Multi Select fields.
  * Non-clearable fields automatically select the first available option when no value is selected.
* **Bug Fixes**
  * Corrected clearable behavior so field controls consistently respect the configured setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->