### PR TITLE
RUI-302: KPI Comparison Bug

### DIFF
--- a/.changeset/mighty-seals-make.md
+++ b/.changeset/mighty-seals-make.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+remove lowercase transformation in KPI comparison label

--- a/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
+++ b/src/components/charts/kpis/KpiChartNumberComparisonPro/index.tsx
@@ -72,7 +72,7 @@ const KpiChartNumberComparisonPro = (props: KpiChartNumberComparisonProProp) => 
 
   const themeFormatter = getThemeFormatter(theme);
   const valueFormatter = (valueToFormat: number) => themeFormatter.data(measure, valueToFormat);
-  const comparisonLabel = `vs ${getComparisonPeriodLabel(comparisonPeriod, theme).toLowerCase()}`;
+  const comparisonLabel = `vs ${getComparisonPeriodLabel(comparisonPeriod, theme)}`;
 
   const resultsCombined: DataResponse = {
     isLoading: Boolean(results.isLoading || resultsComparison?.isLoading),


### PR DESCRIPTION
# Why is this pull-request needed?

Currently comparison label is being transformed to be lowercase, this overwrites capitalization.

## Main changes

remove ` toLowerCase()` method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comparison period labels in KPI charts by preserving the intended capitalization and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->