### PR TITLE
Add tracking to FilterBuilderWithGroupingPro

### DIFF
--- a/.changeset/tender-otters-fly.md
+++ b/.changeset/tender-otters-fly.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+FilterBuilderWithGroupingPro now dispatches `embeddable-user-interaction` events on user-driven edits (top-level and group-level), matching FilterBuilderPro. Adds `trackingId` input and `componentName` for consistency with other trackable components.

--- a/src/components/editors/filters/FilterBuilderWithGroupingPro/definition.ts
+++ b/src/components/editors/filters/FilterBuilderWithGroupingPro/definition.ts
@@ -46,6 +46,7 @@ const meta = {
     inputs.title,
     inputs.description,
     inputs.tooltip,
+    inputs.trackingId,
   ],
   events: [
     {
@@ -117,6 +118,7 @@ const props = (
     embeddableState: state,
     setEmbeddableState: setState,
     dimensionsAndMeasures: inputs.dimensionsAndMeasures ?? [],
+    componentName: meta.name,
     ...filterResults,
   };
 };

--- a/src/components/editors/filters/FilterBuilderWithGroupingPro/index.test.tsx
+++ b/src/components/editors/filters/FilterBuilderWithGroupingPro/index.test.tsx
@@ -640,4 +640,190 @@ describe('FilterBuilderWithGroupingPro', () => {
     );
     expect(defaultProps.setEmbeddableState).not.toHaveBeenCalled();
   });
+
+  describe('user-interaction tracking', () => {
+    const lastUserInteractionEvent = (spy: ReturnType<typeof vi.spyOn>) =>
+      (spy.mock.calls as unknown[][])
+        .map((call) => call[0] as CustomEvent)
+        .filter((event) => event.type === 'embeddable-user-interaction')
+        .at(-1);
+
+    it('dispatches a user-interaction event with componentName/trackingId/value on a top-level edit', () => {
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+      // Start from a filter that already has a dimension + operator, so completing
+      // it with a value produces a clause that actually differs from the last
+      // emitted one — the onChange effect (and thus the dispatch) is gated on that.
+      const embeddableState: FilterBuilderGroupingState = {
+        operator: filterBuilderAndOrOperator.AND,
+        items: [makeFilter({ id: 1, dimensionOrMeasure: makeDim('country'), operator: 'is' })],
+      };
+      const { rerender } = render(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-1"
+          embeddableState={embeddableState}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('select-val-1'));
+      const next = applyUpdater(defaultProps.setEmbeddableState, embeddableState);
+      rerender(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-1"
+          embeddableState={next}
+        />,
+      );
+
+      const event = lastUserInteractionEvent(dispatchSpy);
+      expect(event).toBeTruthy();
+      expect(event!.detail).toMatchObject({
+        componentName: 'FilterBuilderWithGroupingPro',
+        trackingId: 'track-1',
+      });
+    });
+
+    it('dispatches a user-interaction event on a group-level edit', () => {
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+      const groupState: FilterBuilderGroupingState = {
+        operator: filterBuilderAndOrOperator.AND,
+        items: [
+          {
+            id: 5,
+            operator: 'and',
+            filters: [
+              makeFilter({ id: 1, dimensionOrMeasure: makeDim('country'), operator: 'is' }),
+              makeFilter({ id: 2, dimensionOrMeasure: makeDim('country'), operator: 'is' }),
+            ],
+          },
+        ],
+      };
+      const { rerender } = render(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-2"
+          embeddableState={groupState}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('group-selval-5'));
+      const next = applyUpdater(defaultProps.setEmbeddableState, groupState);
+      rerender(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-2"
+          embeddableState={next}
+        />,
+      );
+
+      const event = lastUserInteractionEvent(dispatchSpy);
+      expect(event).toBeTruthy();
+      expect(event!.detail).toMatchObject({ componentName: 'FilterBuilderWithGroupingPro' });
+    });
+
+    it('does not dispatch on initial mount, even when a complete filter is seeded', () => {
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+      const embeddableState: FilterBuilderGroupingState = {
+        operator: filterBuilderAndOrOperator.AND,
+        items: [
+          makeFilter({
+            id: 1,
+            dimensionOrMeasure: makeDim('country'),
+            operator: 'is',
+            value: 'AU',
+          }),
+        ],
+      };
+      render(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-3"
+          embeddableState={embeddableState}
+        />,
+      );
+
+      // onChange still fires on mount (existing behaviour) — only the tracking
+      // dispatch is gated on a real user interaction.
+      expect(defaultProps.onChange).toHaveBeenCalled();
+      expect(lastUserInteractionEvent(dispatchSpy)).toBeUndefined();
+    });
+
+    it('does not dispatch when the host pushes a new defaultFilters with syncDefaultFilters on', () => {
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+      const existing: FilterBuilderGroupingState = {
+        operator: filterBuilderAndOrOperator.AND,
+        items: [
+          makeFilter({
+            id: 1,
+            dimensionOrMeasure: makeDim('country'),
+            operator: 'is',
+            value: 'UK',
+          }),
+        ],
+      };
+      const defaultFilters: FilterBuilderClause = {
+        operator: filterBuilderAndOrOperator.AND,
+        clauses: [{ property: 'country', operator: 'equals' as never, value: 'AU' }],
+      };
+      const { rerender } = render(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-4"
+          dimensionsAndMeasures={[makeDim('country')]}
+          embeddableState={existing}
+          syncDefaultFilters
+        />,
+      );
+
+      const adopted = applyUpdater(defaultProps.setEmbeddableState, existing);
+      rerender(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          trackingId="track-4"
+          dimensionsAndMeasures={[makeDim('country')]}
+          embeddableState={adopted}
+          defaultFilters={defaultFilters}
+          syncDefaultFilters
+        />,
+      );
+
+      expect(lastUserInteractionEvent(dispatchSpy)).toBeUndefined();
+    });
+
+    it('dispatches even when trackingId is not provided', () => {
+      const dispatchSpy = vi.spyOn(window, 'dispatchEvent');
+      const embeddableState: FilterBuilderGroupingState = {
+        operator: filterBuilderAndOrOperator.AND,
+        items: [makeFilter({ id: 1, dimensionOrMeasure: makeDim('country'), operator: 'is' })],
+      };
+      const { rerender } = render(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          embeddableState={embeddableState}
+        />,
+      );
+
+      fireEvent.click(screen.getByTestId('select-val-1'));
+      const next = applyUpdater(defaultProps.setEmbeddableState, embeddableState);
+      rerender(
+        <FilterBuilderWithGroupingPro
+          {...defaultProps}
+          componentName="FilterBuilderWithGroupingPro"
+          embeddableState={next}
+        />,
+      );
+
+      const event = lastUserInteractionEvent(dispatchSpy);
+      expect(event).toBeTruthy();
+      expect(event!.detail.trackingId).toBeUndefined();
+    });
+  });
 });

--- a/src/components/editors/filters/FilterBuilderWithGroupingPro/index.tsx
+++ b/src/components/editors/filters/FilterBuilderWithGroupingPro/index.tsx
@@ -34,6 +34,7 @@ import {
 import FilterBuilderWithGroupingItem from './components/FilterBuilderWithGroupingItem';
 import FilterBuilderWithGroupingGroup from './components/FilterBuilderWithGroupingGroup';
 import { FilterBuilderWithGroupingAndOrButton } from './components/FilterBuilderWithGroupingAndOrButton';
+import { dispatchEventUserInteraction } from '../../../../utils/events.utils';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
 import { getDimensionAndMeasureOptions } from '../../utils/dimensionsAndMeasures.utils';
 import { resolveI18nProps } from '../../../component.utils';
@@ -52,6 +53,8 @@ export type FilterBuilderWithGroupingProProps = {
   onChange?: (value: unknown) => void;
   defaultFilters?: FilterBuilderClause;
   syncDefaultFilters?: boolean;
+  componentName?: string;
+  trackingId?: string;
 } & EditorCardHeaderProps;
 
 const FilterBuilderWithGroupingPro = (props: FilterBuilderWithGroupingProProps) => {
@@ -66,10 +69,13 @@ const FilterBuilderWithGroupingPro = (props: FilterBuilderWithGroupingProProps) 
     onChange,
     defaultFilters,
     syncDefaultFilters = false,
+    componentName,
+    trackingId,
   } = props;
 
   const [searchNew, setSearchNew] = useState('');
   const prevFilterValueRef = useRef<unknown>(undefined);
+  const hasUserInteracted = useRef(false);
 
   const makeFilter = useCallback(
     (id: number, name: string | null = null): FilterBuilderFilter =>
@@ -114,11 +120,13 @@ const FilterBuilderWithGroupingPro = (props: FilterBuilderWithGroupingProProps) 
     });
 
   const handleOperatorChange = (value: FilterBuilderAndOrOperator) => {
+    hasUserInteracted.current = true;
     setEmbeddableState?.((prev) => ({ ...prev, operator: value }));
   };
 
   const updateItems = useCallback(
     (updater: (items: FilterBuilderNode[]) => FilterBuilderNode[]) => {
+      hasUserInteracted.current = true;
       setEmbeddableState?.((prev) => {
         const stored = getFilterNodes(prev);
         const base = stored.length ? stored : [makeFilter(1)];
@@ -241,6 +249,7 @@ const FilterBuilderWithGroupingPro = (props: FilterBuilderWithGroupingProProps) 
   };
 
   const handleClearAll = () => {
+    hasUserInteracted.current = true;
     setEmbeddableState?.((prev) => withItems(prev, [makeFilter(1)], { operator: AND }));
   };
 
@@ -255,6 +264,7 @@ const FilterBuilderWithGroupingPro = (props: FilterBuilderWithGroupingProProps) 
   const topDisabled = hasMixedDimensionsAndMeasures(allFilters);
 
   const sanitized = sanitizeMixedTypeOperators(items, operator);
+  const sanitizedClauseKey = JSON.stringify(itemsToClause(sanitized.operator, sanitized.items));
 
   useEffect(() => {
     if (!sanitized.changed) return;
@@ -270,9 +280,12 @@ const FilterBuilderWithGroupingPro = (props: FilterBuilderWithGroupingProProps) 
     const serialized = JSON.stringify(filterValue);
     if (serialized === JSON.stringify(prevFilterValueRef.current)) return;
     prevFilterValueRef.current = filterValue;
+    if (hasUserInteracted.current) {
+      dispatchEventUserInteraction({ componentName, trackingId, value: filterValue });
+    }
     onChange?.(filterValue);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(itemsToClause(sanitized.operator, sanitized.items)), onChange]);
+  }, [sanitizedClauseKey, onChange, componentName, trackingId]);
 
   const getResults = (id: number) =>
     (props as Record<string, unknown>)[`filterResults${id}`] as DataResponse | undefined;


### PR DESCRIPTION
# Why is this pull-request needed?

FilterBuilderPro already dispatches embeddable-user-interaction events on user edits (via dispatchEventUserInteraction), giving hosts an analytics/tracking hook for filter changes. FilterBuilderWithGroupingPro — its grouping-aware sibling — never got the same treatment, so hosts can track simple filter edits but not grouped ones. This PR closes that gap by porting the existing tracking pattern over.

# Main changes

Added trackingId input and componentName to FilterBuilderWithGroupingPro's definition, matching FilterBuilderPro.
Added a hasUserInteracted ref, set on every user-driven mutation path (top-level operator change, all filter/group edits via updateItems, clear-all) and dispatches embeddable-user-interaction from the existing onChange effect.
Explicitly not flagged as user interaction: host-driven defaultFilters adoption and automatic mixed-type-operator correction — both are programmatic, not user actions.
5 new tests covering top-level and group-level dispatch, no-dispatch-on-mount, no-dispatch-on-host-driven update (syncDefaultFilters), and behavior with trackingId omitted.

# Test evidence

https://github.com/user-attachments/assets/911d38bd-b4d1-454c-a7ba-f2c1dbb7014e




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional interaction tracking to the filter builder.
  - Added support for `trackingId` and consistent component identification.
  - Tracking events are emitted for user-driven filter changes, including grouped edits.
  - Initial and externally synchronized filter updates do not trigger interaction events.

- **Bug Fixes**
  - Improved consistency when identifying filter-builder interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->