### PR TITLE
RUI-306: fix filter builder

### DIFF
--- a/.changeset/rui-306-fix-filter-builder.md
+++ b/.changeset/rui-306-fix-filter-builder.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+FilterBuilderPro and FilterBuilderWithGroupingPro: fix `syncDefaultFilters` not re-applying a previously adopted `defaultFilters` value after the filter list was cleared. Deleting the last filter emits `null`, which was leaving stale adoption state behind — so pushing the same clause back in from the host was silently ignored. The host can now revert to or re-push a filter set after it's been cleared, and it will be re-applied as expected.

--- a/src/components/editors/filters/filters.hooks.test.ts
+++ b/src/components/editors/filters/filters.hooks.test.ts
@@ -90,6 +90,44 @@ describe('useAdoptDefaultFilters', () => {
     rerender({ defaultFilters: { ...(emitted as object) } as FilterBuilderClause });
     expect(adopt).toHaveBeenCalledTimes(1);
   });
+
+  it('clears adoption history even while dimensionsAndMeasures is empty, so a later re-push re-adopts', () => {
+    const adopt = vi.fn();
+    const lastEmittedRef = { current: undefined as unknown };
+    const initialProps: { defaultFilters?: FilterBuilderClause; dims: DimensionOrMeasure[] } = {
+      defaultFilters: group,
+      dims: dimensionsAndMeasures,
+    };
+    const { rerender } = renderHook(
+      ({
+        defaultFilters,
+        dims,
+      }: {
+        defaultFilters?: FilterBuilderClause;
+        dims: DimensionOrMeasure[];
+      }) =>
+        useAdoptDefaultFilters({
+          defaultFilters,
+          dimensionsAndMeasures: dims,
+          lastEmittedRef,
+          adopt,
+        }),
+      { initialProps },
+    );
+    expect(adopt).toHaveBeenCalledTimes(1);
+
+    // Filter cleared and dimensions go away in the same beat (e.g. the host
+    // swaps datasets). The invalid-default branch must still run and reset
+    // lastAdoptedRef, even though the dimensions guard would otherwise
+    // short-circuit first.
+    rerender({ defaultFilters: undefined, dims: [] });
+    expect(adopt).toHaveBeenCalledTimes(1);
+
+    // Dimensions come back and the host re-pushes the same group — it must
+    // be re-adopted, not dropped as "already applied".
+    rerender({ defaultFilters: group, dims: dimensionsAndMeasures });
+    expect(adopt).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('useFilterBuilderScroll', () => {

--- a/src/components/editors/filters/filters.hooks.test.ts
+++ b/src/components/editors/filters/filters.hooks.test.ts
@@ -63,7 +63,7 @@ describe('useAdoptDefaultFilters', () => {
     expect(adopt).toHaveBeenCalledTimes(1);
   });
 
-  it('re-adopts a previously adopted value after the filters were cleared (RUI-306)', () => {
+  it('re-adopts a previously adopted value after the filters were cleared', () => {
     const { adopt, lastEmittedRef, rerender } = setup();
     expect(adopt).toHaveBeenCalledTimes(1);
 

--- a/src/components/editors/filters/filters.hooks.test.ts
+++ b/src/components/editors/filters/filters.hooks.test.ts
@@ -1,5 +1,7 @@
 import { renderHook, act } from '@testing-library/react';
-import { useFilterBuilderScroll } from './filters.hooks';
+import { DimensionOrMeasure } from '@embeddable.com/core';
+import { FilterBuilderClause } from './filters.utils';
+import { useAdoptDefaultFilters, useFilterBuilderScroll } from './filters.hooks';
 
 const simulateScrollState = (
   el: HTMLDivElement,
@@ -33,6 +35,62 @@ const attachScrollRef = (result: {
   result.current.scrollRef.current = el;
   return el;
 };
+
+describe('useAdoptDefaultFilters', () => {
+  const dimensionsAndMeasures = [{ name: 'theme' }] as unknown as DimensionOrMeasure[];
+  const group = {
+    operator: 'and',
+    clauses: [{ property: { name: 'theme' }, operator: 'equals', value: 'X' }],
+  } as unknown as FilterBuilderClause;
+
+  const setup = () => {
+    const adopt = vi.fn();
+    const lastEmittedRef = { current: undefined as unknown };
+    const initialProps: { defaultFilters?: FilterBuilderClause } = { defaultFilters: group };
+    const hook = renderHook(
+      ({ defaultFilters }: { defaultFilters?: FilterBuilderClause }) =>
+        useAdoptDefaultFilters({ defaultFilters, dimensionsAndMeasures, lastEmittedRef, adopt }),
+      { initialProps },
+    );
+    return { adopt, lastEmittedRef, ...hook };
+  };
+
+  it('adopts defaultFilters on mount and ignores a re-push of the same value', () => {
+    const { adopt, rerender } = setup();
+    expect(adopt).toHaveBeenCalledTimes(1);
+
+    rerender({ defaultFilters: { ...(group as object) } as FilterBuilderClause });
+    expect(adopt).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-adopts a previously adopted value after the filters were cleared (RUI-306)', () => {
+    const { adopt, lastEmittedRef, rerender } = setup();
+    expect(adopt).toHaveBeenCalledTimes(1);
+
+    // User deletes the filter in the UI: the builder emits `null`, which
+    // echoes back through the shared variable as a non-group value.
+    lastEmittedRef.current = null;
+    rerender({ defaultFilters: undefined });
+    expect(adopt).toHaveBeenCalledTimes(1);
+
+    // Host pushes the original value again — it must be re-applied, not
+    // dropped as "already adopted".
+    rerender({ defaultFilters: group });
+    expect(adopt).toHaveBeenCalledTimes(2);
+  });
+
+  it('still records its own group echo without re-applying it', () => {
+    const { adopt, lastEmittedRef, rerender } = setup();
+
+    const emitted = {
+      operator: 'and',
+      clauses: [{ property: { name: 'theme' }, operator: 'equals', value: 'Y' }],
+    } as unknown as FilterBuilderClause;
+    lastEmittedRef.current = emitted;
+    rerender({ defaultFilters: { ...(emitted as object) } as FilterBuilderClause });
+    expect(adopt).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('useFilterBuilderScroll', () => {
   it('starts with scroll buttons hidden', () => {

--- a/src/components/editors/filters/filters.hooks.ts
+++ b/src/components/editors/filters/filters.hooks.ts
@@ -39,7 +39,14 @@ export function useAdoptDefaultFilters(opts: {
 
   useEffect(() => {
     if (!dimensionsAndMeasures?.length) return;
-    if (!isClauseGroup(defaultFilters)) return;
+    if (!isClauseGroup(defaultFilters)) {
+      // Clearing the last filter emits `null`, which echoes back here as a
+      // non-group value (e.g. `Value.noFilter()`). It still supersedes whatever
+      // we last adopted — forget it, so the host re-pushing the previously
+      // adopted clause group is seen as a genuine change and re-applied (RUI-306).
+      lastAdoptedRef.current = null;
+      return;
+    }
 
     const serialized = JSON.stringify(defaultFilters);
 

--- a/src/components/editors/filters/filters.hooks.ts
+++ b/src/components/editors/filters/filters.hooks.ts
@@ -38,15 +38,18 @@ export function useAdoptDefaultFilters(opts: {
   const lastAdoptedRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (!dimensionsAndMeasures?.length) return;
     if (!isClauseGroup(defaultFilters)) {
       // Clearing the last filter emits `null`, which echoes back here as a
       // non-group value (e.g. `Value.noFilter()`). It still supersedes whatever
       // we last adopted — forget it, so the host re-pushing the previously
       // adopted clause group is seen as a genuine change and re-applied (RUI-306).
+      // Must run even while dimensionsAndMeasures is still empty, otherwise a
+      // group cleared before dimensions load leaves lastAdoptedRef stale and a
+      // later re-push of that same group is wrongly seen as already-applied.
       lastAdoptedRef.current = null;
       return;
     }
+    if (!dimensionsAndMeasures?.length) return;
 
     const serialized = JSON.stringify(defaultFilters);
 

--- a/src/components/editors/filters/filters.hooks.ts
+++ b/src/components/editors/filters/filters.hooks.ts
@@ -1,4 +1,4 @@
-import { MutableRefObject, useCallback, useEffect, useRef, useState } from 'react';
+import { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { DimensionOrMeasure } from '@embeddable.com/core';
 import { FilterBuilderClause } from './filters.utils';
 
@@ -31,7 +31,7 @@ const isClauseGroup = (value: unknown): value is FilterBuilderClauseGroup =>
 export function useAdoptDefaultFilters(opts: {
   defaultFilters: FilterBuilderClause | undefined;
   dimensionsAndMeasures: DimensionOrMeasure[];
-  lastEmittedRef: MutableRefObject<unknown>;
+  lastEmittedRef: RefObject<unknown>;
   adopt: (clause: FilterBuilderClauseGroup) => void;
 }): void {
   const { defaultFilters, dimensionsAndMeasures, lastEmittedRef, adopt } = opts;
@@ -39,13 +39,10 @@ export function useAdoptDefaultFilters(opts: {
 
   useEffect(() => {
     if (!isClauseGroup(defaultFilters)) {
-      // Clearing the last filter emits `null`, which echoes back here as a
-      // non-group value (e.g. `Value.noFilter()`). It still supersedes whatever
-      // we last adopted — forget it, so the host re-pushing the previously
-      // adopted clause group is seen as a genuine change and re-applied (RUI-306).
-      // Must run even while dimensionsAndMeasures is still empty, otherwise a
-      // group cleared before dimensions load leaves lastAdoptedRef stale and a
-      // later re-push of that same group is wrongly seen as already-applied.
+      // A cleared filter echoes back as a non-group value (e.g. `Value.noFilter()`).
+      // Forget what we adopted so a later re-push of that group is treated as new,
+      // not "already applied". Runs before the dimensions guard so a clear that
+      // races with dimensions loading isn't missed.
       lastAdoptedRef.current = null;
       return;
     }


### PR DESCRIPTION
# Why is this pull-request needed?

[RUI-306](https://trevorio.atlassian.net/browse/RUI-306): a client reported that after they revert to a `defaultFilters` value the component had already adopted once, and the filter list gets emptied in between, the update does not get re-applied.

Repro:
1. Load with `defaultFilters = {operator: 'and', clauses: [{property: 'theme', operator: 'equals', value: 'X'}]}` (with `syncDefaultFilters` on) — filter shows as expected.
2. Delete that filter in the UI — the component emits `null`.
3. The host pushes the step-1 value back into the bound variable — the component ignores it and the filter list stays empty.

Root cause, in `useAdoptDefaultFilters` (`filters.hooks.ts`): the `null` echo from step 2 fails the `isClauseGroup` check and returns early, before `lastAdoptedRef` is updated. So `lastAdoptedRef` still holds the step-1 clause. In step 3 the incoming value matches `lastAdoptedRef` and gets dropped as "already applied."

# Main changes

- `filters.hooks.ts`: when an incoming `defaultFilters` value isn't a valid clause group (e.g. the `null` emitted on delete, or `Value.noFilter()`), clear `lastAdoptedRef` instead of returning untouched. This makes the shared hook used by both `FilterBuilderPro` and `FilterBuilderWithGroupingPro` treat a later re-push of a previously adopted clause as genuinely new, so it gets re-applied.
- Added a changeset (patch).

# Test evidence

Added `filters.hooks.test.ts` coverage for `useAdoptDefaultFilters`:
- adopts `defaultFilters` on mount, ignores a re-push of the same value
- re-adopts a previously adopted value after the filters were cleared (RUI-306 regression case)
- still records its own onChange echo without re-applying it

```
npx vitest run src/components/editors/filters/filters.hooks.test.ts
✓ 9 tests passed
```

Full filters suite also green (266 tests).


[RUI-306]: https://trevorio.atlassian.net/browse/RUI-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ