### PR TITLE
TPS-1440: sync presets and date range

### DIFF
--- a/.changeset/mighty-falcons-see.md
+++ b/.changeset/mighty-falcons-see.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Sync presets and date range selection

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -58,27 +58,26 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
   const [showDateRangePicker, setShowDateRangePicker] = useState(onlyDateRangePicker);
 
   const [isOpen, setIsOpen] = useState(false);
-  const [dateRange, setDateRange] = useState<DateRange | undefined>(
-    getDateRangeFromTimeRange(selectedValue),
-  );
 
   const dateRangeOptions = theme.defaults.dateRangesOptions;
+  const timezone = theme.clientContext.timezone;
+
+  const [dateRange, setDateRange] = useState<DateRange | undefined>(
+    getDateRangeFromTimeRange(selectedValue, dateRangeOptions, timezone),
+  );
 
   useEffect(() => {
     if (!dayjsLocaleReady) {
       return;
     }
     // Step 1: Convert relativeTimeString to actual time range (from/to)
-    const newTimeRange = getTimeRangeFromPresets(
-      selectedValue,
-      dateRangeOptions,
-      theme.clientContext.timezone,
-    );
+    const newTimeRange = getTimeRangeFromPresets(selectedValue, dateRangeOptions, timezone);
 
     if (!shallowEqual(newTimeRange, selectedValue)) {
       onChange(newTimeRange);
+      setDateRange({ from: newTimeRange?.from, to: newTimeRange?.to });
     }
-  }, [selectedValue, dayjsLocaleReady, onChange, dateRangeOptions, theme.clientContext.timezone]);
+  }, [selectedValue, dayjsLocaleReady, onChange, dateRangeOptions, timezone]);
 
   if (!dayjsLocaleReady) {
     return null;
@@ -86,18 +85,18 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
 
   const { description, placeholder, title, tooltip } = resolveI18nProps(props);
 
-  const options = getDateRangeSelectFieldProOptions(dateRangeOptions, theme.clientContext.timezone);
+  const options = getDateRangeSelectFieldProOptions(dateRangeOptions, timezone);
 
   const handleOptionChange = (newValue: string | undefined) => {
     const newTimeRange = getTimeRangeFromPresets(
       { relativeTimeString: newValue } as TimeRange,
       dateRangeOptions,
-      theme.clientContext.timezone,
+      timezone,
     );
 
     dispatchEventUserInteraction({ componentName, trackingId, value: newTimeRange });
     onChange(newTimeRange);
-    setDateRange(undefined);
+    setDateRange({ from: newTimeRange?.from, to: newTimeRange?.to });
   };
 
   const handleDateRangeChange = (newDateRange: DateRange | undefined) => {
@@ -133,7 +132,6 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
   const locale = theme.i18n.language ?? theme.formatter.locale;
   const isSubmitDisabled = isSameDateRange(dateRange, selectedValue);
   const numberOfMonths = showTwoMonths ? 2 : 1;
-
   return (
     <EditorCard title={title} description={description} tooltip={tooltip}>
       <Dropdown


### PR DESCRIPTION
# Why is this pull-request needed?

Fixes [TPS-1449](https://trevorio.atlassian.net/browse/TPS-1449): `DateRangeSelectFieldPro` custom calendar goes out of sync with `selectedValue`.

The trigger label reflected the latest `selectedValue`, but the internal `dateRange` state (used by the calendar and to enable/disable Apply) wasn't kept in sync with it. This caused:
- A preset like "Last quarter" opening Custom with nothing selected and Apply enabled.
- An externally updated `selectedValue` updating the label but not the calendar grid.
- Apply staying enabled, letting users submit an empty or previously discarded range.

# Main changes

In `src/components/editors/dates/DateRangePickerPresetsPro/index.tsx`:
- Initialize `dateRange` state using `dateRangeOptions`/`timezone` so it matches the resolved time range from the start.
- Update `dateRange` whenever `selectedValue` changes (both on the sync `useEffect` and on preset option change), instead of resetting it to `undefined`.
- Minor cleanup: hoist `timezone` into a local var and reuse it.

# Test evidence

Manual repro from the ticket:
1. Bind `selectedValue` to a preset (e.g. "Last quarter") on page load.
2. Open the picker, click Custom — calendar now reflects the preset's actual range instead of showing empty with Apply enabled.
3. Select a custom range, then update `selectedValue` externally to a preset — calendar and Apply state now follow the new `selectedValue`.


[TPS-1449]: https://trevorio.atlassian.net/browse/TPS-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ