### PR TITLE
RUI-000: improvements on date range picker

### DIFF
--- a/.changeset/lazy-herons-jump.md
+++ b/.changeset/lazy-herons-jump.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Fix DateRangePickerPresetsPro not syncing when `selectedValue` changes to a custom `{from, to}` range, and discard unapplied date range edits when the picker closes without pressing Apply

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.3.27",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.3.27",
+      "version": "0.4.0",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.8",
         "@embeddable.com/react": "^2.13.8",
-        "@embeddable.com/remarkable-ui": "^3.1.0",
+        "@embeddable.com/remarkable-ui": "^3.1.1",
         "@tabler/icons-react": "^3.34.1",
         "chart.js": "^4.5.0",
         "chartjs-plugin-datalabels": "^2.2.0",
@@ -916,9 +916,9 @@
       }
     },
     "node_modules/@embeddable.com/remarkable-ui": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.1.0.tgz",
-      "integrity": "sha512-bP0m2903DndVzEk4oLM6BejZr/ZwnUclgcYFU3Fdb5rc3gtp8bQEvPUGqfQw+WJf9qP+xUI6rsH5Cn9vd4P1Hw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@embeddable.com/remarkable-ui/-/remarkable-ui-3.1.1.tgz",
+      "integrity": "sha512-5B1sXkb5yDWeNpRkW6zNXyFZIdl+EbwewV9mHQdMt+hOcmuCjaz4cBl/HfAzdNHRbUkvZYiKGgsfbAsBNMU8lA==",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
@@ -1791,14 +1791,14 @@
       "license": "MIT"
     },
     "node_modules/@happy-dom/global-registrator": {
-      "version": "20.11.6",
-      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.11.6.tgz",
-      "integrity": "sha512-ZQ47qUTeNbGhHkCGExJ1oZhruoxKRaxO44RgFETl3T4c1rRxIBlAOnM3SAH4XHu7Ue2owJXP+jOx1vOuKuxcSg==",
+      "version": "20.11.8",
+      "resolved": "https://registry.npmjs.org/@happy-dom/global-registrator/-/global-registrator-20.11.8.tgz",
+      "integrity": "sha512-lkgRN26nWeYCsoron3bup+egcmpUTV3VsLS/d4rDyo/hwKivUIl8mkLtuk+sVaIdPZUpGFzcdOpt/1CPaW5Bpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": ">=20.0.0",
-        "happy-dom": "^20.11.6"
+        "happy-dom": "^20.11.8"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -3982,9 +3982,9 @@
       "license": "MIT"
     },
     "node_modules/@stencil/core": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.44.1.tgz",
-      "integrity": "sha512-OaFtMODcDcKswPbJC6An6xAcNmeuBggxyUTVKSX1UY7bPtWgIR5mGy1jZ6JkyFGgIxZCj/9wp2r97KBQow9wOQ==",
+      "version": "4.44.2",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.44.2.tgz",
+      "integrity": "sha512-TNaYdlyHfy8UF7glvZwaY6pM0AhgCOXuW5Kx3+AO+ITeaipCHWXi5tkZ6P/3HCL+hUySc60lPKSnZ4xdYIFb4g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -4726,9 +4726,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.3.0.tgz",
-      "integrity": "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw==",
+      "version": "26.4.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.4.0.tgz",
+      "integrity": "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -5277,14 +5277,14 @@
       }
     },
     "node_modules/@vue/compiler-core": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.41.tgz",
-      "integrity": "sha512-q0Xtv/F9w2YO/7htQhtiL+Ev2WCJbe5N2hc+XfgyKkEKqWpSxknmT8QOuGdEKNdjPq0c3F7rNpFkTo3Kfrm7pg==",
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.42.tgz",
+      "integrity": "sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.8",
-        "@vue/shared": "3.5.41",
+        "@vue/shared": "3.5.42",
         "entities": "^7.0.1",
         "estree-walker": "^2.0.2",
         "source-map-js": "^1.2.1"
@@ -5298,28 +5298,28 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-dom": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.41.tgz",
-      "integrity": "sha512-oKacVfNglLvGjnS6BXOlGL7EyG2h8X03pqXCjzotRZUaXGjbrTJUnVAQjrCqUnS+lyu31nwQjZY/d817GmCnfw==",
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.42.tgz",
+      "integrity": "sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-core": "3.5.41",
-        "@vue/shared": "3.5.41"
+        "@vue/compiler-core": "3.5.42",
+        "@vue/shared": "3.5.42"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.41.tgz",
-      "integrity": "sha512-XJhip7R2wy6vX3knCxdZN4KracFaZUef58s1KYewqluedHIJaPIVfXoYT7MF1F8nCvv6k8bWWxDC8opMkg1VTQ==",
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.42.tgz",
+      "integrity": "sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.8",
-        "@vue/compiler-core": "3.5.41",
-        "@vue/compiler-dom": "3.5.41",
-        "@vue/compiler-ssr": "3.5.41",
-        "@vue/shared": "3.5.41",
+        "@vue/compiler-core": "3.5.42",
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/compiler-ssr": "3.5.42",
+        "@vue/shared": "3.5.42",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.21",
         "postcss": "^8.5.19",
@@ -5334,20 +5334,20 @@
       "license": "MIT"
     },
     "node_modules/@vue/compiler-ssr": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.41.tgz",
-      "integrity": "sha512-U3v5OejKEGqOI0Wy0+Sz7hGuIFZHA4LSXzrNM3IMIeDyJEBBfTpX26n3SDgToRpP2bLc9FfI2j/kSgcJ8Emq5A==",
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.42.tgz",
+      "integrity": "sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vue/compiler-dom": "3.5.41",
-        "@vue/shared": "3.5.41"
+        "@vue/compiler-dom": "3.5.42",
+        "@vue/shared": "3.5.42"
       }
     },
     "node_modules/@vue/shared": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
-      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
+      "version": "3.5.42",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.42.tgz",
+      "integrity": "sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==",
       "dev": true,
       "license": "MIT"
     },
@@ -8527,9 +8527,9 @@
       "license": "ISC"
     },
     "node_modules/happy-dom": {
-      "version": "20.11.6",
-      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.6.tgz",
-      "integrity": "sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==",
+      "version": "20.11.8",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.11.8.tgz",
+      "integrity": "sha512-TeAoM8pTDKNVcP5z3MptRTb7UH9q126GrjTFOgormgA19tmT30JTiIxb1CVXs7xljpItypUp/yHSPFD4QRHMsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9646,9 +9646,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",
@@ -12630,9 +12630,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@changesets/cli": "^2.29.6",
     "@embeddable.com/core": "^2.13.8",
     "@embeddable.com/react": "^2.13.8",
-    "@embeddable.com/remarkable-ui": "^3.1.0",
+    "@embeddable.com/remarkable-ui": "^3.1.1",
     "@tabler/icons-react": "^3.34.1",
     "chart.js": "^4.5.0",
     "chartjs-plugin-datalabels": "^2.2.0",

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -19,7 +19,7 @@ import { resolveI18nProps } from '../../../component.utils';
 import { EditorCard, EditorCardHeaderProps } from '../../shared/EditorCard/EditorCard';
 import { IconCalendarFilled, IconChevronLeft, IconChevronRight } from '@tabler/icons-react';
 import { i18n, i18nSetup } from '../../../../theme/i18n/i18n';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styles from './DateRangePickerPresetsPro.module.css';
 import {
   getDateRangeFromTimeRange,
@@ -66,6 +66,9 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
     getDateRangeFromTimeRange(selectedValue, dateRangeOptions, timezone),
   );
 
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
   useEffect(() => {
     if (!dayjsLocaleReady) {
       return;
@@ -74,11 +77,12 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
     const newTimeRange = getTimeRangeFromPresets(selectedValue, dateRangeOptions, timezone);
 
     if (!shallowEqual(newTimeRange, selectedValue)) {
-      onChange(newTimeRange);
+      onChangeRef.current(newTimeRange);
     }
 
     setDateRange({ from: newTimeRange?.from, to: newTimeRange?.to });
-  }, [selectedValue, dayjsLocaleReady, onChange, dateRangeOptions, timezone]);
+    // onChange is read via ref so the draft isn't reset just because the parent passed a new callback identity
+  }, [selectedValue, dayjsLocaleReady, dateRangeOptions, timezone]);
 
   if (!dayjsLocaleReady) {
     return null;

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -75,8 +75,9 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
 
     if (!shallowEqual(newTimeRange, selectedValue)) {
       onChange(newTimeRange);
-      setDateRange({ from: newTimeRange?.from, to: newTimeRange?.to });
     }
+
+    setDateRange({ from: newTimeRange?.from, to: newTimeRange?.to });
   }, [selectedValue, dayjsLocaleReady, onChange, dateRangeOptions, timezone]);
 
   if (!dayjsLocaleReady) {
@@ -104,6 +105,14 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
     dispatchEventUserInteraction({ componentName, trackingId, value: newTimeRange });
     onChange(newTimeRange);
     setIsOpen(false);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      // Discard unapplied edits: revert the draft grid to the applied value
+      setDateRange(getDateRangeFromTimeRange(selectedValue, dateRangeOptions, timezone));
+    }
+    setIsOpen(open);
   };
 
   const handleClear = () => {
@@ -136,7 +145,7 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
     <EditorCard title={title} description={description} tooltip={tooltip}>
       <Dropdown
         open={isOpen}
-        onOpenChange={setIsOpen}
+        onOpenChange={handleOpenChange}
         avoidCollisions={false}
         triggerComponent={
           <SelectFieldTrigger


### PR DESCRIPTION
## Summary
- Sync the picker's draft `dateRange` whenever `selectedValue` changes to a custom `{from, to}` value, not just when it needs preset normalization
- Discard unapplied date range edits when the picker closes without pressing Apply, so reopening shows the applied value instead of the abandoned draft

## Test plan
- [ ] Push a preset `selectedValue` after another selection is applied — grid/Apply state update (regression check)
- [ ] Push a custom `{from, to}` `selectedValue` after another selection is applied — grid/Apply state now update
- [ ] Open the picker, change the range, close without clicking Apply, reopen — grid shows the previously applied value, not the discarded edit
- [ ] Open the picker, change the range, click Apply — value applies and closes as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Date range picker presets now stay synchronized when custom date selections change.
  - Closing the picker without applying changes now discards unapplied edits and restores the last selected range.
  - Improved consistency when reopening the date range picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->