### PR TITLE
TPS-1459: fix DateRange picker computing UTC day boundaries instead of clientContext.timezone

### DIFF
--- a/.changeset/sixty-coats-add.md
+++ b/.changeset/sixty-coats-add.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+fix DateRange picker computing UTC day boundaries instead of clientContext.timezone

--- a/src/components/editors/dates/DateRangePickerCustomPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerCustomPro/index.tsx
@@ -38,7 +38,10 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
   const { onChange, clearable, selectedValue, showTwoMonths, componentName, trackingId } = props;
 
   const handleChange = (newDateRange: DateRange | undefined) => {
-    const timeRange: TimeRange = getTimeRangeFromDateRange(newDateRange);
+    const timeRange: TimeRange = getTimeRangeFromDateRange(
+      newDateRange,
+      theme.clientContext.timezone,
+    );
     dispatchEventUserInteraction({ componentName, trackingId, value: timeRange });
     onChange(timeRange);
   };

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -105,7 +105,7 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
   };
 
   const handleDateRangeChange = (newDateRange: DateRange | undefined) => {
-    const newTimeRange = getTimeRangeFromDateRange(newDateRange);
+    const newTimeRange = getTimeRangeFromDateRange(newDateRange, timezone);
     dispatchEventUserInteraction({ componentName, trackingId, value: newTimeRange });
     onChange(newTimeRange);
     setIsOpen(false);

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -155,7 +155,6 @@ describe('getTimeRangeFromDateRange', () => {
   });
 
   it('falls back to UTC day boundaries when no timezone is provided', () => {
-    // 02:00 UTC on 1 Mar — with no timezone this should stay on the UTC calendar day
     const dateRange: DateRange = {
       from: new Date('2024-03-01T02:00:00.000Z'),
       to: new Date('2024-03-01T02:00:00.000Z'),
@@ -166,8 +165,7 @@ describe('getTimeRangeFromDateRange', () => {
   });
 
   it('anchors from/to using clientContext.timezone rather than UTC', () => {
-    // 02:00 UTC on 1 Mar is still 29 Feb (18:00) in America/Los_Angeles (UTC-8) —
-    // the resolved day boundaries should follow the local calendar day, not the UTC one
+    // 02:00 UTC on 1 Mar is 29 Feb locally in America/Los_Angeles (UTC-8)
     const dateRange: DateRange = {
       from: new Date('2024-03-01T02:00:00.000Z'),
       to: new Date('2024-03-01T02:00:00.000Z'),
@@ -178,10 +176,7 @@ describe('getTimeRangeFromDateRange', () => {
   });
 
   it('does not tip `to` into the next day when the calendar widget has already forced it to 23:59:59.999 UTC and timezone is ahead of UTC', () => {
-    // Mirrors what react-day-picker + remarkable-ui's endOfDayUTC actually hand us for a
-    // single-day pick of "1 Sep" with a UTC browser: from = day start, to = that SAME UTC
-    // day forced to 23:59:59.999. Naively re-projecting `to` through a timezone ahead of
-    // UTC (e.g. Europe/London, BST +1) would push 23:59:59.999 UTC into "2 Sep" local time.
+    // Naive re-projection through Europe/London (BST +1) would push this into "2 Sep".
     const dateRange: DateRange = {
       from: new Date('2026-09-01T00:00:00.000Z'),
       to: new Date('2026-09-01T23:59:59.999Z'),
@@ -202,10 +197,6 @@ describe('getTimeRangeFromDateRange', () => {
   });
 
   it('treats a single click (range not completed, `to` undefined) as a single-day pick instead of defaulting to "now"', () => {
-    // react-day-picker leaves `to` undefined until a 2nd click completes the range.
-    // Naively resolving that missing value with dayjs would silently substitute
-    // "right now", which can land on a different day than `from` in the target
-    // timezone and produce a bogus multi-day span.
     const dateRange: DateRange = {
       from: new Date('2026-09-01T00:00:00.000Z'),
       to: undefined,

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -200,6 +200,20 @@ describe('getTimeRangeFromDateRange', () => {
     expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
     expect(result?.to).toEqual(new Date('2026-09-05T23:59:59.999Z'));
   });
+
+  it('treats a single click (range not completed, `to` undefined) as a single-day pick instead of defaulting to "now"', () => {
+    // react-day-picker leaves `to` undefined until a 2nd click completes the range.
+    // Naively resolving that missing value with dayjs would silently substitute
+    // "right now", which can land on a different day than `from` in the target
+    // timezone and produce a bogus multi-day span.
+    const dateRange: DateRange = {
+      from: new Date('2026-09-01T00:00:00.000Z'),
+      to: undefined,
+    };
+    const result = getTimeRangeFromDateRange(dateRange, 'Australia/Sydney');
+    expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2026-09-01T23:59:59.999Z'));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -176,6 +176,30 @@ describe('getTimeRangeFromDateRange', () => {
     expect(result?.from).toEqual(new Date('2024-02-29T00:00:00.000Z'));
     expect(result?.to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
   });
+
+  it('does not tip `to` into the next day when the calendar widget has already forced it to 23:59:59.999 UTC and timezone is ahead of UTC', () => {
+    // Mirrors what react-day-picker + remarkable-ui's endOfDayUTC actually hand us for a
+    // single-day pick of "1 Sep" with a UTC browser: from = day start, to = that SAME UTC
+    // day forced to 23:59:59.999. Naively re-projecting `to` through a timezone ahead of
+    // UTC (e.g. Europe/London, BST +1) would push 23:59:59.999 UTC into "2 Sep" local time.
+    const dateRange: DateRange = {
+      from: new Date('2026-09-01T00:00:00.000Z'),
+      to: new Date('2026-09-01T23:59:59.999Z'),
+    };
+    const result = getTimeRangeFromDateRange(dateRange, 'Europe/London');
+    expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2026-09-01T23:59:59.999Z'));
+  });
+
+  it('resolves a genuine multi-day range correctly under a timezone ahead of UTC', () => {
+    const dateRange: DateRange = {
+      from: new Date('2026-09-01T00:00:00.000Z'),
+      to: new Date('2026-09-05T23:59:59.999Z'),
+    };
+    const result = getTimeRangeFromDateRange(dateRange, 'Europe/London');
+    expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2026-09-05T23:59:59.999Z'));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -153,6 +153,29 @@ describe('getTimeRangeFromDateRange', () => {
     expect(result?.from).toBeInstanceOf(Date);
     expect(result?.to).toBeInstanceOf(Date);
   });
+
+  it('falls back to UTC day boundaries when no timezone is provided', () => {
+    // 02:00 UTC on 1 Mar — with no timezone this should stay on the UTC calendar day
+    const dateRange: DateRange = {
+      from: new Date('2024-03-01T02:00:00.000Z'),
+      to: new Date('2024-03-01T02:00:00.000Z'),
+    };
+    const result = getTimeRangeFromDateRange(dateRange);
+    expect(result?.from).toEqual(new Date('2024-03-01T00:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2024-03-01T23:59:59.999Z'));
+  });
+
+  it('anchors from/to using clientContext.timezone rather than UTC', () => {
+    // 02:00 UTC on 1 Mar is still 29 Feb (18:00) in America/Los_Angeles (UTC-8) —
+    // the resolved day boundaries should follow the local calendar day, not the UTC one
+    const dateRange: DateRange = {
+      from: new Date('2024-03-01T02:00:00.000Z'),
+      to: new Date('2024-03-01T02:00:00.000Z'),
+    };
+    const result = getTimeRangeFromDateRange(dateRange, 'America/Los_Angeles');
+    expect(result?.from).toEqual(new Date('2024-02-29T00:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -92,16 +92,21 @@ export const getTimeRangeFromDateRange = (
   dateRange: DateRange | undefined,
   timezone?: string,
 ): TimeRange => {
-  if (!dateRange) {
+  if (!dateRange?.from) {
     return dateRange;
   }
+
+  // A single click (range not completed with a 2nd click) leaves `to` undefined.
+  // Treat that as a single-day pick — matching `from` — instead of letting dayjs
+  // silently resolve the missing value to "now".
+  const to = dateRange.to ?? dateRange.from;
 
   // The calendar widget (remarkable-ui's DateRangePicker) already forces `to` to
   // 23:59:59.999 UTC of its own UTC calendar day before we see it. Re-projecting that
   // near-midnight instant straight into `timezone` could tip it into the next day
   // whenever the timezone is ahead of UTC. Normalise it back to that day's UTC
   // start first, so it resolves the same way `from` does.
-  const toDayStart = dateRange.to ? dayjs.utc(dateRange.to).startOf('day').toDate() : dateRange.to;
+  const toDayStart = dayjs.utc(to).startOf('day').toDate();
 
   return {
     relativeTimeString: undefined,

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -92,7 +92,7 @@ export const getTimeRangeFromDateRange = (
   dateRange: DateRange | undefined,
   timezone?: string,
 ): TimeRange => {
-  if (!dateRange?.from) {
+  if (!dateRange) {
     return dateRange;
   }
 

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -96,9 +96,16 @@ export const getTimeRangeFromDateRange = (
     return dateRange;
   }
 
+  // The calendar widget (remarkable-ui's DateRangePicker) already forces `to` to
+  // 23:59:59.999 UTC of its own UTC calendar day before we see it. Re-projecting that
+  // near-midnight instant straight into `timezone` could tip it into the next day
+  // whenever the timezone is ahead of UTC. Normalise it back to that day's UTC
+  // start first, so it resolves the same way `from` does.
+  const toDayStart = dateRange.to ? dayjs.utc(dateRange.to).startOf('day').toDate() : dateRange.to;
+
   return {
     relativeTimeString: undefined,
     from: dayjs.utc(getLocalDateString(dateRange.from, timezone)).startOf('day').toDate(),
-    to: dayjs.utc(getLocalDateString(dateRange.to, timezone)).endOf('day').toDate(),
+    to: dayjs.utc(getLocalDateString(toDayStart, timezone)).endOf('day').toDate(),
   };
 };

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -81,10 +81,7 @@ export const getDateRangeFromTimeRange = (
   return finalTimeRange;
 };
 
-// Resolves the calendar day a Date instant falls on in the given timezone
-// (falling back to UTC when no timezone is provided), as a YYYY-MM-DD string.
-// Mirrors the convention in defaults.DateRanges.constants.ts so that
-// manually-picked ranges line up with the timezone-aware preset ranges.
+// Matches defaults.DateRanges.constants.ts so manual picks line up with preset ranges.
 const getLocalDateString = (date: Date | undefined, tz?: string): string =>
   tz ? dayjs.tz(date, tz).format('YYYY-MM-DD') : dayjs.utc(date).format('YYYY-MM-DD');
 
@@ -96,16 +93,11 @@ export const getTimeRangeFromDateRange = (
     return dateRange;
   }
 
-  // A single click (range not completed with a 2nd click) leaves `to` undefined.
-  // Treat that as a single-day pick — matching `from` — instead of letting dayjs
-  // silently resolve the missing value to "now".
+  // Single click leaves `to` undefined; treat it as a single-day pick instead of "now".
   const to = dateRange.to ?? dateRange.from;
 
-  // The calendar widget (remarkable-ui's DateRangePicker) already forces `to` to
-  // 23:59:59.999 UTC of its own UTC calendar day before we see it. Re-projecting that
-  // near-midnight instant straight into `timezone` could tip it into the next day
-  // whenever the timezone is ahead of UTC. Normalise it back to that day's UTC
-  // start first, so it resolves the same way `from` does.
+  // `to` arrives pre-forced to 23:59:59.999 UTC; re-derive its day start so it
+  // resolves through `timezone` the same way `from` does, instead of tipping over.
   const toDayStart = dayjs.utc(to).startOf('day').toDate();
 
   return {

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -2,9 +2,11 @@ import { TimeRange } from '@embeddable.com/core';
 import { DateRange } from '@embeddable.com/remarkable-ui';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import { DateRangeOption } from '../../../theme/defaults/defaults.DateRanges.constants';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const getTimeRangeFromPresets = (
   receivedTimeRange: TimeRange,
@@ -79,14 +81,24 @@ export const getDateRangeFromTimeRange = (
   return finalTimeRange;
 };
 
-export const getTimeRangeFromDateRange = (dateRange: DateRange | undefined): TimeRange => {
+// Resolves the calendar day a Date instant falls on in the given timezone
+// (falling back to UTC when no timezone is provided), as a YYYY-MM-DD string.
+// Mirrors the convention in defaults.DateRanges.constants.ts so that
+// manually-picked ranges line up with the timezone-aware preset ranges.
+const getLocalDateString = (date: Date | undefined, tz?: string): string =>
+  tz ? dayjs.tz(date, tz).format('YYYY-MM-DD') : dayjs.utc(date).format('YYYY-MM-DD');
+
+export const getTimeRangeFromDateRange = (
+  dateRange: DateRange | undefined,
+  timezone?: string,
+): TimeRange => {
   if (!dateRange) {
     return dateRange;
   }
 
   return {
     relativeTimeString: undefined,
-    from: dayjs.utc(dateRange.from).toDate(),
-    to: dayjs.utc(dateRange.to).toDate(),
+    from: dayjs.utc(getLocalDateString(dateRange.from, timezone)).startOf('day').toDate(),
+    to: dayjs.utc(getLocalDateString(dateRange.to, timezone)).endOf('day').toDate(),
   };
 };


### PR DESCRIPTION
# Why is this pull-request needed?

[TPS-1459](https://trevorio.atlassian.net/browse/TPS-1459): manually picking a date range in the DateRange picker could resolve to the wrong calendar day whenever `clientContext.timezone` differed from the dashboard viewer's implicit timezone assumption.

Root cause: `getTimeRangeFromDateRange` (`src/components/editors/dates/dates.utils.ts`) converted the calendar picker's selected dates with a plain `dayjs.utc(date).toDate()`, an identity pass-through that never accounted for timezone at all. This broke the invariant the rest of the date-range system relies on — that a resolved `TimeRange.from`/`to` always represents the correct *local* (`clientContext.timezone`) calendar day, the same way the "Today"/"Last 7 days"/etc. presets already do in `defaults.DateRanges.constants.ts`.

# Main changes

- `getTimeRangeFromDateRange` now takes a `timezone` parameter and resolves the picked day using that timezone, matching the existing preset convention. Two edge cases in the underlying calendar widget (`remarkable-ui`'s `DateRangePicker`) needed handling for this to be correct in all cases:
  - It forces `to` to `23:59:59.999 UTC` of its own day before we see it. Re-projecting that near-midnight instant into a timezone ahead of UTC could tip it into the next day — fixed by normalising `to` back to its own day-start first.
  - A single click (range not completed with a second click) leaves `to` as `undefined`. Resolving that with `dayjs` silently defaulted to "right now" instead of the picked day — fixed by treating a missing `to` as the same day as `from`.
- `DateRangePickerPresetsPro` and `DateRangePickerCustomPro` now pass `theme.clientContext.timezone` through to `getTimeRangeFromDateRange`.
- Added `dayjs/plugin/timezone.js` to `dates.utils.ts`.
- Added test coverage for all of the above: timezone-aware resolution, UTC fallback, the day-tipping edge case, a genuine multi-day range, and the incomplete-range (`to === undefined`) case.

# Test evidence

- `npx tsc --noEmit --incremental false`, `npx eslint --fix --quiet .`, `npx prettier . --check` — all clean.
- `npx vitest run` — full suite passing, including 6 new/updated cases in `dates.utils.test.ts` covering the scenarios above.
- Manually verified against a live dashboard with `clientContext.timezone` set to `Europe/London` and `Australia/Sydney`: the custom picker now stays consistent with the presets in every case tested (single day, multi-day, single click).


[TPS-1459]: https://trevorio.atlassian.net/browse/TPS-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ