### PR TITLE
Improve FillGaps Time Zone Handling

### DIFF
--- a/.changeset/tiny-pandas-unite.md
+++ b/.changeset/tiny-pandas-unite.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': patch
+---
+
+Improves time zone handling in chart fillGaps function

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@embeddable.com/remarkable-pro",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@embeddable.com/remarkable-pro",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@changesets/cli": "^2.29.6",
         "@embeddable.com/core": "^2.13.8",
@@ -29,6 +29,7 @@
         "@embeddable.com/sdk-react": "^4.3.13",
         "@embeddable.com/sdk-utils": "^0.9.1",
         "@eslint/css": "^0.13.0",
+        "@eslint/js": "^9.31.0",
         "@testing-library/react": "^16.3.2",
         "@types/chroma-js": "^3.1.1",
         "@types/react": "^19.1.9",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@embeddable.com/sdk-react": "^4.3.13",
     "@embeddable.com/sdk-utils": "^0.9.1",
     "@eslint/css": "^0.13.0",
+    "@eslint/js": "^9.31.0",
     "@testing-library/react": "^16.3.2",
     "@types/chroma-js": "^3.1.1",
     "@types/react": "^19.1.9",

--- a/src/components/charts/charts.fillGaps.hooks.test.ts
+++ b/src/components/charts/charts.fillGaps.hooks.test.ts
@@ -1,0 +1,157 @@
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import type { Dimension, DataResponse } from '@embeddable.com/core';
+import { useFillGaps } from './charts.fillGaps.hooks';
+import { defaultDateRangeOptions } from '../../theme/defaults/defaults.DateRanges.constants';
+import { getTimeRangeFromDateRange } from '../editors/dates/dates.utils';
+
+dayjs.extend(utc);
+
+const isoKey = (date: Date): string => dayjs.utc(date).toISOString().split('Z')[0]!;
+
+const mockUseTheme = vi.fn();
+
+vi.mock('@embeddable.com/react', () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+const makeTheme = (timezone?: string) => ({
+  clientContext: { timezone },
+  defaults: { dateRangesOptions: defaultDateRangeOptions },
+});
+
+const makeDimension = (overrides: Record<string, unknown> = {}): Dimension =>
+  ({
+    name: 'daily_listens.listened_date',
+    title: 'Listened Date',
+    nativeType: 'time',
+    __type__: 'dimension',
+    inputs: {
+      granularity: 'hour',
+      ...overrides,
+    },
+  }) as unknown as Dimension;
+
+const makeResults = (data: Record<string, unknown>[]): DataResponse => ({
+  isLoading: false,
+  data,
+});
+
+describe('useFillGaps', () => {
+  it('fills gaps correctly in UTC with no dateBounds (baseline, no regression)', () => {
+    mockUseTheme.mockReturnValue(makeTheme('UTC'));
+
+    const dimension = makeDimension();
+    const results = makeResults([
+      { 'daily_listens.listened_date': '2026-01-01T00:00:00.000', value: 1 },
+      { 'daily_listens.listened_date': '2026-01-01T02:00:00.000', value: 2 },
+    ]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    const keys = result.current.data?.map((r) => r['daily_listens.listened_date']);
+    expect(keys).toEqual([
+      '2026-01-01T00:00:00.000',
+      '2026-01-01T01:00:00.000',
+      '2026-01-01T02:00:00.000',
+    ]);
+  });
+
+  it('respects a day-precision preset dateBounds in a non-UTC timezone (PR #271 case, unchanged)', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    const todayOption = defaultDateRangeOptions.find((opt) => opt.value === 'Today')!;
+    const { from, to } = todayOption.getRange('America/Los_Angeles')!;
+
+    const dimension = makeDimension({
+      granularity: 'hour',
+      dateBounds: { from, to, relativeTimeString: 'Today' },
+    });
+
+    const results = makeResults([
+      {
+        'daily_listens.listened_date': isoKey(
+          dayjs
+            .utc(from as Date)
+            .add(3, 'hour')
+            .toDate(),
+        ),
+      },
+    ]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
+    expect(keys.length).toBe(24);
+    expect(keys[0]).toBe(isoKey(from as Date));
+    expect(keys[23]).toBe(
+      isoKey(
+        dayjs
+          .utc(from as Date)
+          .add(23, 'hour')
+          .toDate(),
+      ),
+    );
+  });
+
+  it('treats a manually-picked absolute range from the custom picker as already-safe (no double-conversion)', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    const pickedRange = getTimeRangeFromDateRange(
+      { from: new Date('2026-06-15T00:00:00.000Z'), to: new Date('2026-06-15T23:59:59.999Z') },
+      'America/Los_Angeles',
+    )!;
+
+    const dimension = makeDimension({
+      granularity: 'hour',
+      dateBounds: pickedRange,
+    });
+
+    const results = makeResults([
+      { 'daily_listens.listened_date': isoKey(pickedRange.from as Date), value: 1 },
+    ]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
+    // 24 hourly buckets spanning the picked local day, anchored exactly at pickedRange.from
+    expect(keys.length).toBe(24);
+    expect(keys[0]).toBe(isoKey(pickedRange.from as Date));
+  });
+
+  it('correctly fills an hour-granularity chart bound to a live/rolling range (regression for the reported bug)', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    // Real shape reproduced from the reported bug: 25 continuous naive-local hourly
+    // records (Cube already converted them to America/Los_Angeles wall-clock time),
+    // bound by a genuine real "last 24 hours" instant pair (PDT is UTC-7 in September,
+    // so the local 05:51:14 boundary is 12:51:14 in real UTC).
+    const data = Array.from({ length: 25 }, (_, i) => {
+      const stamp = dayjs.utc('2026-09-02T05:00:00.000').add(i, 'hour');
+      return { 'speed.timestamp': stamp.toISOString().split('Z')[0], value: i };
+    });
+
+    const dimension = makeDimension({
+      granularity: 'hour',
+      dateBounds: {
+        from: new Date('2026-09-02T12:51:14.000Z'),
+        to: new Date('2026-09-03T12:51:14.999Z'),
+        relativeTimeString: undefined,
+      },
+    });
+
+    const dimensionWithName = { ...dimension, name: 'speed.timestamp' } as unknown as Dimension;
+
+    const { result } = renderHook(() =>
+      useFillGaps({ results: makeResults(data), dimension: dimensionWithName }),
+    );
+
+    const rows = result.current.data ?? [];
+    const nullRows = rows.filter((r) => r.value === undefined);
+
+    expect(rows.length).toBe(25);
+    expect(nullRows.length).toBe(0);
+  });
+});

--- a/src/components/charts/charts.fillGaps.hooks.test.ts
+++ b/src/components/charts/charts.fillGaps.hooks.test.ts
@@ -154,4 +154,72 @@ describe('useFillGaps', () => {
     expect(rows.length).toBe(25);
     expect(nullRows.length).toBe(0);
   });
+
+  it('converts a live dateBounds provided as ISO strings with a "Z" offset (customer-reported regression)', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    // No relativeTimeString, so dateBoundsTmp is used as-is -- and here it arrives
+    // as plain strings rather than Date instances, exactly as reported.
+    const dimension = makeDimension({
+      dateBounds: {
+        from: '2026-09-04T13:55:09.000Z',
+        to: '2026-09-04T14:56:09.999Z',
+      },
+    });
+
+    const results = makeResults([
+      { 'daily_listens.listened_date': '2026-09-04T06:00:00.000', value: 1 },
+      { 'daily_listens.listened_date': '2026-09-04T07:00:00.000', value: 2 },
+    ]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    expect(result.current.data).toEqual(results.data);
+  });
+
+  it('converts a live dateBounds string with an explicit +/-HH:MM offset', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    // Same real instants as the "Z" test above, just spelled with an explicit
+    // numeric offset instead of "Z".
+    const dimension = makeDimension({
+      dateBounds: {
+        from: '2026-09-04T06:55:09.000-07:00',
+        to: '2026-09-04T07:56:09.999-07:00',
+      },
+    });
+
+    const results = makeResults([
+      { 'daily_listens.listened_date': '2026-09-04T06:00:00.000', value: 1 },
+      { 'daily_listens.listened_date': '2026-09-04T07:00:00.000', value: 2 },
+    ]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    expect(result.current.data).toEqual(results.data);
+  });
+
+  it('leaves a naive, offset-less string dateBounds unconverted (no regression)', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    // No "Z" or numeric offset -- this is how record data and the existing
+    // day-precision preset/picker output are shaped, and must not be re-converted.
+    const dimension = makeDimension({
+      dateBounds: {
+        from: '2026-01-01T00:00:00.000',
+        to: '2026-01-01T23:59:59.999',
+      },
+    });
+
+    const results = makeResults([
+      { 'daily_listens.listened_date': '2026-01-01T03:00:00.000', value: 1 },
+    ]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
+    expect(keys.length).toBe(24);
+    expect(keys[0]).toBe('2026-01-01T00:00:00.000');
+    expect(keys[23]).toBe('2026-01-01T23:00:00.000');
+  });
 });

--- a/src/components/charts/charts.fillGaps.hooks.test.ts
+++ b/src/components/charts/charts.fillGaps.hooks.test.ts
@@ -2,14 +2,25 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import type { Dimension, DataResponse } from '@embeddable.com/core';
 import { useFillGaps } from './charts.fillGaps.hooks';
 import { defaultDateRangeOptions } from '../../theme/defaults/defaults.DateRanges.constants';
 import { getTimeRangeFromDateRange } from '../editors/dates/dates.utils';
 
 dayjs.extend(utc);
+dayjs.extend(timezone);
 
-const isoKey = (date: Date): string => dayjs.utc(date).toISOString().split('Z')[0]!;
+// `dateBounds` values from a preset/picker are genuine real instants (e.g.
+// "Today" at midnight America/Los_Angeles is a real 07:00 UTC in PDT) -- not
+// raw UTC digits standing in for local ones. Mirror the same real-timezone
+// conversion `resolveBoundary` applies in charts.fillGaps.hooks.ts to compute
+// the local-digit key a matching record/bucket should have.
+const localAnchor = (date: Date, tz: string): dayjs.Dayjs =>
+  dayjs.utc(dayjs(date).tz(tz).format('YYYY-MM-DDTHH:mm:ss.SSS'));
+
+const localKey = (date: Date, tz: string): string =>
+  localAnchor(date, tz).toISOString().split('Z')[0]!;
 
 const mockUseTheme = vi.fn();
 
@@ -67,19 +78,10 @@ describe('useFillGaps', () => {
 
     // Compute every expected/seed key once, up front, and reuse the saved strings below
     // rather than re-deriving them after renderHook -- see PR discussion for why.
-    const firstKey = isoKey(from as Date);
-    const thirdHourKey = isoKey(
-      dayjs
-        .utc(from as Date)
-        .add(3, 'hour')
-        .toDate(),
-    );
-    const lastKey = isoKey(
-      dayjs
-        .utc(from as Date)
-        .add(23, 'hour')
-        .toDate(),
-    );
+    const anchor = localAnchor(from as Date, 'America/Los_Angeles');
+    const firstKey = anchor.toISOString().split('Z')[0]!;
+    const thirdHourKey = anchor.add(3, 'hour').toISOString().split('Z')[0]!;
+    const lastKey = anchor.add(23, 'hour').toISOString().split('Z')[0]!;
 
     const dimension = makeDimension({
       granularity: 'hour',
@@ -106,7 +108,7 @@ describe('useFillGaps', () => {
 
     // Compute the expected/seed key once, up front, and reuse the saved string below
     // rather than re-deriving it after renderHook -- see PR discussion for why.
-    const firstKey = isoKey(pickedRange.from as Date);
+    const firstKey = localKey(pickedRange.from as Date, 'America/Los_Angeles');
 
     const dimension = makeDimension({
       granularity: 'hour',

--- a/src/components/charts/charts.fillGaps.hooks.test.ts
+++ b/src/components/charts/charts.fillGaps.hooks.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc.js';
 import timezone from 'dayjs/plugin/timezone.js';
-import type { Dimension, DataResponse } from '@embeddable.com/core';
+import type { Dimension, DataResponse, TimeRange } from '@embeddable.com/core';
 import { useFillGaps } from './charts.fillGaps.hooks';
 import { defaultDateRangeOptions } from '../../theme/defaults/defaults.DateRanges.constants';
 import { getTimeRangeFromDateRange } from '../editors/dates/dates.utils';
@@ -51,6 +51,10 @@ const makeResults = (data: Record<string, unknown>[]): DataResponse => ({
 });
 
 describe('useFillGaps', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('fills gaps correctly in UTC with no dateBounds (baseline, no regression)', () => {
     mockUseTheme.mockReturnValue(makeTheme('UTC'));
 
@@ -72,6 +76,11 @@ describe('useFillGaps', () => {
 
   it('respects a day-precision preset dateBounds in a non-UTC timezone (PR #271 case, unchanged)', () => {
     mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    // "Today" reads the real clock internally -- pin it so this test is
+    // deterministic instead of depending on when it happens to run.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-09-08T18:00:00.000Z')); // 11:00 America/Los_Angeles, safely mid-day
 
     const todayOption = defaultDateRangeOptions.find((opt) => opt.value === 'Today')!;
     const { from, to } = todayOption.getRange('America/Los_Angeles')!;
@@ -98,7 +107,7 @@ describe('useFillGaps', () => {
     expect(keys[23]).toBe(lastKey);
   });
 
-  it('treats a manually-picked absolute range from the custom picker as already-safe (no double-conversion)', () => {
+  it('correctly converts a manually-picked absolute range from the custom picker', () => {
     mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
 
     const pickedRange = getTimeRangeFromDateRange(
@@ -121,6 +130,30 @@ describe('useFillGaps', () => {
 
     const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
     // 24 hourly buckets spanning the picked local day, anchored exactly at pickedRange.from
+    expect(keys.length).toBe(24);
+    expect(keys[0]).toBe(firstKey);
+  });
+
+  it('converts a host-app-supplied dateBounds that happens to land on a UTC day boundary', () => {
+    mockUseTheme.mockReturnValue(makeTheme('America/Los_Angeles'));
+
+    // Simulates a caller outside our own components building its own range as
+    // startOf('day')/endOf('day') in UTC -- landing exactly on 00:00:00.000Z /
+    // 23:59:59.999Z is systematic for that pattern, not a coincidence, and must
+    // still be converted like any other genuine instant.
+    const dimension = makeDimension({
+      dateBounds: {
+        from: new Date('2026-06-15T00:00:00.000Z'),
+        to: new Date('2026-06-15T23:59:59.999Z'),
+      },
+    });
+
+    const firstKey = localKey(new Date('2026-06-15T00:00:00.000Z'), 'America/Los_Angeles');
+    const results = makeResults([{ 'daily_listens.listened_date': firstKey, value: 1 }]);
+
+    const { result } = renderHook(() => useFillGaps({ results, dimension }));
+
+    const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
     expect(keys.length).toBe(24);
     expect(keys[0]).toBe(firstKey);
   });
@@ -225,5 +258,45 @@ describe('useFillGaps', () => {
     expect(keys.length).toBe(24);
     expect(keys[0]).toBe('2026-01-01T00:00:00.000');
     expect(keys[23]).toBe('2026-01-01T23:00:00.000');
+  });
+
+  it('honors externalDateBounds (the LineChartComparison* path) and recomputes when it changes', () => {
+    mockUseTheme.mockReturnValue(makeTheme('UTC'));
+
+    // No dimension.inputs.dateBounds -- externalDateBounds is the only bound source,
+    // exactly like LineChartComparisonWithKpiTabsPro/LineChartComparisonDefaultPro,
+    // which pass primaryDateRange/comparisonDateRange this way.
+    const dimension = makeDimension({ granularity: 'day' });
+    const results = makeResults([
+      { 'daily_listens.listened_date': '2026-09-01T00:00:00.000', value: 1 },
+      { 'daily_listens.listened_date': '2026-10-01T00:00:00.000', value: 2 },
+    ]);
+
+    const { result, rerender } = renderHook(
+      (externalDateBounds: TimeRange) => useFillGaps({ results, dimension, externalDateBounds }),
+      {
+        initialProps: {
+          from: new Date('2026-09-01T00:00:00.000Z'),
+          to: new Date('2026-09-01T23:59:59.999Z'),
+          relativeTimeString: undefined,
+        },
+      },
+    );
+
+    expect(result.current.data).toEqual([
+      { 'daily_listens.listened_date': '2026-09-01T00:00:00.000', value: 1 },
+    ]);
+
+    // Same dimension/results/theme -- only externalDateBounds changes. If it were
+    // missing from the useMemo dependency array, this would still show September.
+    rerender({
+      from: new Date('2026-10-01T00:00:00.000Z'),
+      to: new Date('2026-10-01T23:59:59.999Z'),
+      relativeTimeString: undefined,
+    });
+
+    expect(result.current.data).toEqual([
+      { 'daily_listens.listened_date': '2026-10-01T00:00:00.000', value: 2 },
+    ]);
   });
 });

--- a/src/components/charts/charts.fillGaps.hooks.test.ts
+++ b/src/components/charts/charts.fillGaps.hooks.test.ts
@@ -65,35 +65,35 @@ describe('useFillGaps', () => {
     const todayOption = defaultDateRangeOptions.find((opt) => opt.value === 'Today')!;
     const { from, to } = todayOption.getRange('America/Los_Angeles')!;
 
+    // Compute every expected/seed key once, up front, and reuse the saved strings below
+    // rather than re-deriving them after renderHook -- see PR discussion for why.
+    const firstKey = isoKey(from as Date);
+    const thirdHourKey = isoKey(
+      dayjs
+        .utc(from as Date)
+        .add(3, 'hour')
+        .toDate(),
+    );
+    const lastKey = isoKey(
+      dayjs
+        .utc(from as Date)
+        .add(23, 'hour')
+        .toDate(),
+    );
+
     const dimension = makeDimension({
       granularity: 'hour',
       dateBounds: { from, to, relativeTimeString: 'Today' },
     });
 
-    const results = makeResults([
-      {
-        'daily_listens.listened_date': isoKey(
-          dayjs
-            .utc(from as Date)
-            .add(3, 'hour')
-            .toDate(),
-        ),
-      },
-    ]);
+    const results = makeResults([{ 'daily_listens.listened_date': thirdHourKey }]);
 
     const { result } = renderHook(() => useFillGaps({ results, dimension }));
 
     const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
     expect(keys.length).toBe(24);
-    expect(keys[0]).toBe(isoKey(from as Date));
-    expect(keys[23]).toBe(
-      isoKey(
-        dayjs
-          .utc(from as Date)
-          .add(23, 'hour')
-          .toDate(),
-      ),
-    );
+    expect(keys[0]).toBe(firstKey);
+    expect(keys[23]).toBe(lastKey);
   });
 
   it('treats a manually-picked absolute range from the custom picker as already-safe (no double-conversion)', () => {
@@ -104,21 +104,23 @@ describe('useFillGaps', () => {
       'America/Los_Angeles',
     )!;
 
+    // Compute the expected/seed key once, up front, and reuse the saved string below
+    // rather than re-deriving it after renderHook -- see PR discussion for why.
+    const firstKey = isoKey(pickedRange.from as Date);
+
     const dimension = makeDimension({
       granularity: 'hour',
       dateBounds: pickedRange,
     });
 
-    const results = makeResults([
-      { 'daily_listens.listened_date': isoKey(pickedRange.from as Date), value: 1 },
-    ]);
+    const results = makeResults([{ 'daily_listens.listened_date': firstKey, value: 1 }]);
 
     const { result } = renderHook(() => useFillGaps({ results, dimension }));
 
     const keys = result.current.data?.map((r) => r['daily_listens.listened_date']) ?? [];
     // 24 hourly buckets spanning the picked local day, anchored exactly at pickedRange.from
     expect(keys.length).toBe(24);
-    expect(keys[0]).toBe(isoKey(pickedRange.from as Date));
+    expect(keys[0]).toBe(firstKey);
   });
 
   it('correctly fills an hour-granularity chart bound to a live/rolling range (regression for the reported bug)', () => {

--- a/src/components/charts/charts.fillGaps.hooks.ts
+++ b/src/components/charts/charts.fillGaps.hooks.ts
@@ -2,6 +2,7 @@ import { DataResponse, Dimension, TimeRange } from '@embeddable.com/core';
 import dayjs, { QUnitType } from 'dayjs';
 import isoWeek from 'dayjs/plugin/isoWeek.js';
 import utc from 'dayjs/plugin/utc.js';
+import timezone from 'dayjs/plugin/timezone.js';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore.js';
 import { Theme } from '../../theme/theme.types';
 import { useTheme } from '@embeddable.com/react';
@@ -11,11 +12,48 @@ import { defaultGranularitySelectFieldOptions } from '../../theme/defaults/defau
 
 dayjs.extend(utc);
 dayjs.extend(isoWeek);
+dayjs.extend(timezone);
 dayjs.extend(isSameOrBefore);
 dayjs.extend(quarterOfYear);
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DataRecord = { [key: string]: any };
+
+// A `from`/`to` bound reaching this hook is either a Date whose UTC-read digits
+// already equal the intended local wall-clock time (the day-precision date-range
+// presets and the custom range picker build these deliberately, so they line up
+// with how Cube returns record values for a given query timezone), or a genuine
+// real instant (e.g. a live/rolling range) that needs an actual timezone
+// conversion to land on those same local digits. The two can't be told apart from
+// the value alone, except that every existing local-digits-as-UTC bound sits
+// exactly on a clean unit boundary (00:00:00.000 or 23:59:59.999), while a genuine
+// live instant essentially never does by coincidence.
+const isCleanBoundary = (value: dayjs.Dayjs): boolean => {
+  const isStartOfDay =
+    value.hour() === 0 && value.minute() === 0 && value.second() === 0 && value.millisecond() === 0;
+  const isEndOfDay =
+    value.hour() === 23 &&
+    value.minute() === 59 &&
+    value.second() === 59 &&
+    value.millisecond() === 999;
+  return isStartOfDay || isEndOfDay;
+};
+
+const resolveBoundary = (rawValue: unknown, tz?: string): dayjs.Dayjs => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const asUtc = dayjs.utc(rawValue as any);
+  const isGenuineInstant = rawValue instanceof Date && tz && !isCleanBoundary(asUtc);
+
+  if (!isGenuineInstant) {
+    return asUtc;
+  }
+
+  return dayjs.utc(
+    dayjs(rawValue as Date)
+      .tz(tz)
+      .format('YYYY-MM-DDTHH:mm:ss.SSS'),
+  );
+};
 
 type UseFillGapsProps = {
   results: DataResponse | undefined;
@@ -66,15 +104,17 @@ export function useFillGaps(props: UseFillGapsProps): DataResponse {
     });
 
     // Determine the full date range even if data is empty
-    const from = dayjs.utc(
+    const from = resolveBoundary(
       externalDateBounds?.from ?? dateBounds?.from ?? sortedResults[0]?.[dimensionName],
+      theme.clientContext.timezone,
     );
 
-    const to = dayjs.utc(
+    const to = resolveBoundary(
       externalDateBounds?.to ??
         dateBounds?.to ??
         sortedResults[sortedResults.length - 1]?.[dimensionName] ??
         [...sortedResults].reverse().find((item) => item?.[dimensionName] != null)?.[dimensionName],
+      theme.clientContext.timezone,
     );
 
     // If we *still* don’t have valid date bounds, bail out safely
@@ -116,7 +156,7 @@ export function useFillGaps(props: UseFillGapsProps): DataResponse {
       ...results,
       data: filled,
     };
-  }, [results, dimension, orderDirection, theme]);
+  }, [results, dimension, orderDirection, theme, externalDateBounds]);
 
   return processed as DataResponse;
 }

--- a/src/components/charts/charts.fillGaps.hooks.ts
+++ b/src/components/charts/charts.fillGaps.hooks.ts
@@ -19,51 +19,31 @@ dayjs.extend(quarterOfYear);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type DataRecord = { [key: string]: any };
 
-// A `from`/`to` bound reaching this hook is either a Date whose UTC-read digits
-// already equal the intended local wall-clock time (the day-precision date-range
-// presets and the custom range picker build these deliberately, so they line up
-// with how Cube returns record values for a given query timezone), or a genuine
-// real instant (e.g. a live/rolling range) that needs an actual timezone
-// conversion to land on those same local digits. The two can't be told apart from
-// the value alone, except that every existing local-digits-as-UTC bound sits
-// exactly on a clean unit boundary (00:00:00.000 or 23:59:59.999), while a genuine
-// live instant essentially never does by coincidence.
-const isCleanBoundary = (value: dayjs.Dayjs): boolean => {
-  const isStartOfDay =
-    value.hour() === 0 && value.minute() === 0 && value.second() === 0 && value.millisecond() === 0;
-  const isEndOfDay =
-    value.hour() === 23 &&
-    value.minute() === 59 &&
-    value.second() === 59 &&
-    value.millisecond() === 999;
-  return isStartOfDay || isEndOfDay;
-};
-
-// A `Date` object always represents a genuine instant, but so does an ISO string
-// carrying an explicit offset (`Z` or `+HH:MM`/`-HH:MM`) — some callers (e.g. a
-// live/rolling date-range variable set outside our own picker components) hand
-// `dateBounds`/`externalDateBounds` through as plain strings rather than `Date`
-// instances, and that signal is just as valid as `instanceof Date`.
-const hasExplicitTimezoneOffset = (value: unknown): boolean =>
+// A `Date` object always represents a genuine real instant, but so does an ISO
+// string carrying an explicit offset (`Z` or `+HH:MM`/`-HH:MM`) — some callers
+// (e.g. a live/rolling date-range variable set outside our own picker
+// components, or a host app supplying its own dateBounds) hand `dateBounds`/
+// `externalDateBounds` through as plain strings rather than `Date` instances,
+// and that signal is just as valid as `instanceof Date`.
+const hasExplicitTimezoneOffset = (value: unknown): value is string =>
   typeof value === 'string' && /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value);
 
-const resolveBoundary = (rawValue: unknown, tz?: string): dayjs.Dayjs => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const asUtc = dayjs.utc(rawValue as any);
-  const isGenuineInstant =
-    (rawValue instanceof Date || hasExplicitTimezoneOffset(rawValue)) &&
-    tz &&
-    !isCleanBoundary(asUtc);
-
-  if (!isGenuineInstant) {
-    return asUtc;
+// Record values coming back from the query are timezone-naive local wall-clock
+// strings (no offset) — dayjs.utc() reads their digits as-is, which is correct.
+// A `from`/`to` bound, by contrast, is a real absolute instant whenever it's a
+// `Date` or an offset-bearing string, and must be converted via `.tz(tz)` to
+// land on the same local digits the record data uses. There's no "already
+// local, skip conversion" case to guess at here: every bound our own
+// components produce (presets, the custom range picker) is a genuine instant,
+// and a host app supplying its own bound is a genuine instant too, even if it
+// happens to land on a UTC day boundary (e.g. startOf('day') in UTC) --
+// converting unconditionally is always correct, never redundant.
+const resolveBoundary = (rawValue: Date | string | undefined, tz?: string): dayjs.Dayjs => {
+  if (!tz || !(rawValue instanceof Date || hasExplicitTimezoneOffset(rawValue))) {
+    return dayjs.utc(rawValue);
   }
 
-  return dayjs.utc(
-    dayjs(rawValue as Date | string)
-      .tz(tz)
-      .format('YYYY-MM-DDTHH:mm:ss.SSS'),
-  );
+  return dayjs.utc(dayjs(rawValue).tz(tz).format('YYYY-MM-DDTHH:mm:ss.SSS'));
 };
 
 type UseFillGapsProps = {

--- a/src/components/charts/charts.fillGaps.hooks.ts
+++ b/src/components/charts/charts.fillGaps.hooks.ts
@@ -39,17 +39,28 @@ const isCleanBoundary = (value: dayjs.Dayjs): boolean => {
   return isStartOfDay || isEndOfDay;
 };
 
+// A `Date` object always represents a genuine instant, but so does an ISO string
+// carrying an explicit offset (`Z` or `+HH:MM`/`-HH:MM`) — some callers (e.g. a
+// live/rolling date-range variable set outside our own picker components) hand
+// `dateBounds`/`externalDateBounds` through as plain strings rather than `Date`
+// instances, and that signal is just as valid as `instanceof Date`.
+const hasExplicitTimezoneOffset = (value: unknown): boolean =>
+  typeof value === 'string' && /(?:Z|[+-]\d{2}:?\d{2})$/i.test(value);
+
 const resolveBoundary = (rawValue: unknown, tz?: string): dayjs.Dayjs => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const asUtc = dayjs.utc(rawValue as any);
-  const isGenuineInstant = rawValue instanceof Date && tz && !isCleanBoundary(asUtc);
+  const isGenuineInstant =
+    (rawValue instanceof Date || hasExplicitTimezoneOffset(rawValue)) &&
+    tz &&
+    !isCleanBoundary(asUtc);
 
   if (!isGenuineInstant) {
     return asUtc;
   }
 
   return dayjs.utc(
-    dayjs(rawValue as Date)
+    dayjs(rawValue as Date | string)
       .tz(tz)
       .format('YYYY-MM-DDTHH:mm:ss.SSS'),
   );


### PR DESCRIPTION
# Fix timezone handling in `useFillGaps`

## Context

Date-bound charts in a non-UTC theme timezone (e.g. `America/Los_Angeles`) show real data for part of the range, then a solid block of null buckets exactly as wide as the timezone's UTC offset (7 hours in PDT). Reported on an hourly chart bound to a live/rolling date range.

**Root cause, confirmed by reproduction against real customer data (`sample_results_2.json` not included in this PR, a 25-row, gap-free hourly Cube response for `speed.timestamp`):**

- Cube returns time-dimension values as timezone-*naive* strings — the SQL does `toTimeZone(timestamp, 'America/Los_Angeles')`, so `"2026-09-02T05:00:00.000"` means 5am *local* time, with no UTC offset in the string. `useFillGaps` (`src/components/charts/charts.fillGaps.hooks.ts`) parses these with `dayjs.utc(value)`, which is correct *only* because the string has no offset to strip — it just reads the digits as given, and those digits are already the local wall-clock reading.
- The chart's `dateBounds.to` was a **live/rolling value** (not one of the built-in day-precision presets) — its actual `Date` object holds a genuine, correctly-resolved real instant (confirmed: the query's `dateRange` filter sent to Cube, `"...T05:51:14.999"`, is the *local*-timezone string form of that same real instant, and produced a complete, gap-free result — so whatever builds that query filter already converts real instants to local time correctly).
- `useFillGaps` line 73-78 does `dayjs.utc(dateBounds.to)` on that real instant — this reads its *real UTC* digits, not its *local* digits. I reproduced this exactly with the actual sample data and dayjs (script output below): treating the bound as a real instant and converting it correctly to local digits realigns every bucket with the real records; treating it the way `useFillGaps` currently does (`dayjs.utc()` on the raw real instant) reproduces the *exact* reported failure — 18 real hours followed by 7 null hours, where 7 = the PDT UTC offset.

```
=== reproduction (dayjs, real sample_results_2.json data) ===
Treating dateBounds.to as a real instant needing local-digit conversion:
  → all 25 buckets match real records, zero nulls

Treating dateBounds.to the way useFillGaps does today (dayjs.utc() on the real instant):
  2026-09-02T12:00 .. 2026-09-03T05:00  → 18 real buckets
  2026-09-03T06:00 .. 2026-09-03T12:00  → 7 <NULL> buckets   (exactly the UTC offset)
```

- This is *not* a query-filter or backend bug — the query returned complete, correct, gap-free data. It's not fixable by touching any `definition.ts` in this repo either — none of them construct a `dateRange` filter from `dimension.inputs.dateBounds`, confirming that translation happens entirely outside this repo (platform/SDK-side), and it already behaves correctly there. The defect is entirely inside `useFillGaps`'s client-side comparison.
- Critically: **not every `dateBounds`/`externalDateBounds` value uses the same convention.** The built-in day-precision presets (`theme.defaults.dateRangesOptions`, fixed by PR #271) and the custom absolute-range picker (`getTimeRangeFromDateRange` in `dates.utils.ts`) deliberately construct a Date whose UTC-read digits already equal the intended local wall-clock reading (a `dayjs.utc(getLocalDateString(date, tz)).startOf('day')` trick) — for those, `dayjs.utc()` is exactly the right way to read them back, and this is proven, recently-shipped, tested behavior I do not want to disturb. A live/rolling range (or anything else not produced by that trick) is a *genuine* real instant instead, and needs a real timezone conversion, not a literal digit read. There is no way to tell the two apart by inspecting the `Date` value itself — except that every existing trick-encoded value is, by construction, exactly at a clean unit boundary (`00:00:00.000`/`23:59:59.999`), while a genuine live instant essentially never lands on one by coincidence.

## Fix

**`src/components/charts/charts.fillGaps.hooks.ts` only** — no changes to PR #271's preset code.

1. Import the `timezone` dayjs plugin (already used elsewhere in the codebase: `dates.utils.ts`, `timeRange.utils.ts`).
2. Where `from`/`to` are resolved (current lines 69-78), for any bound that isn't going through the already-trusted `relativeTimeString` → `getRange(timezone)` path (lines 52-56, unchanged): check whether it already sits on a clean unit boundary read as UTC (`.millisecond() === 0 && .second() === 0` for the "start" side / the `.endOf`-shaped equivalent for the "end" side). If it does, treat it as already in the safe local-digit convention (unchanged behavior — this covers the custom absolute-range picker and any other day-precision-anchored value). If it doesn't, treat it as a genuine real instant and convert it via `dayjs.utc(dayjs(date).tz(timezone).format('YYYY-MM-DDTHH:mm:ss.SSS'))` before using it — this is the missing step that realigns a live/rolling bound with how the record data is actually keyed.
3. Leave record-value parsing (`dayjs.utc(value)`, building `recordsByDate`) untouched — already correct.
4. Leave bucket-walking (`current.startOf(granularity)` / `.add(1, granularity)`) as plain UTC duration arithmetic — once `from`/`to` are correctly normalized, this is timezone-invariant for `hour`/`minute`/`second`, and for `day`/`week`/`month`/`quarter`/`year` it's stepping across whole units of an already-local-anchored value, so no `.tz()` is needed in the walk itself.
5. Add a short code comment stating the underlying contract explicitly (a Date reaching this hook is either "local-digits-as-UTC" from a known preset/picker, or a genuine real instant — and the boundary-alignment check is how we tell them apart), since this is genuinely non-obvious and the whole fix hinges on it.

Out of scope / explicitly not doing: touching `dates.utils.ts`, `timeRange.utils.ts`, or `defaults.DateRanges.constants.ts` — their output is already correct for their current consumer (day-precision display alignment) and I don't want to risk PR #271's tested behavior for a fix that's fully achievable inside `useFillGaps` alone. Also out of scope: the separate, pre-existing performance concern that a date-bound chart's query fetches the *entire* unfiltered dataset regardless of `dateBounds` (confirmed via `sample_results.json`, 731 rows fetched to display 3 days) — real, but unrelated to this bug and not something `useFillGaps` controls.

Also out of scope, per earlier discussion: full gap-filling support for Embeddable's extended/custom granularities (e.g. `quarter_hour`, defined server-side per https://docs.embeddable.com/component-libraries/build-components/extending-types) — `useFillGaps` still bails out for any granularity outside the built-in 8 today. I'm not including a heuristic step-inference fallback for these in this fix, since it's an independent, separate gap (no interval metadata is exposed to the frontend for these at all) and mixing it into this timezone fix would blur two unrelated changes. Flagging it as a follow-up if wanted.

## Verification

- Add `src/components/charts/charts.fillGaps.hooks.test.ts` (none exists today despite ~15 chart components depending on this hook). Cover, using the real sample data pattern as a model:
  - Baseline UTC timezone — no regression.
  - Non-UTC timezone, day-precision preset-resolved `dateBounds` (the PR #271 case) — confirms unchanged behavior.
  - Non-UTC timezone, custom absolute-range `dateBounds` from the calendar picker (day-precision, `relativeTimeString: undefined`) — confirms the boundary-detection heuristic correctly treats it as already-safe and doesn't double-convert.
  - Non-UTC timezone, hour granularity, live/rolling `dateBounds` (reproducing this exact bug with the real `sample_results_2.json` shape) — confirms the fix.
- Run the existing suite for consuming components (`BarChartDefaultPro`, `AreaChartPro`, `LineChartComparison*`, `HeatMapPro`, `PivotTablePro`, etc.) to check for regressions.
- `npm run types:check` and `npm run eslint:check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart gap filling for date ranges in different time zones.
  - Corrected handling of manually selected and rolling time ranges.
  - Ensured hour-based charts consistently fill all expected data points without empty values.

- **Tests**
  - Added coverage for UTC, non-UTC, manually selected, and rolling date-range scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->