### PR TITLE
TPS-1459: anchor date ranges in target timezone, not UTC

### DIFF
--- a/.changeset/proud-phones-ring.md
+++ b/.changeset/proud-phones-ring.md
@@ -1,0 +1,5 @@
+---
+'@embeddable.com/remarkable-pro': minor
+---
+
+Fix timezone in date component

--- a/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.utils.test.ts
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.utils.test.ts
@@ -39,16 +39,22 @@ describe('getDateRangeSelectFieldProOptions', () => {
     });
   });
 
-  it('calls getTimeRangeLabel with the result of getRange and option.dateFormat', () => {
+  it('calls getTimeRangeLabel with the result of getRange, option.dateFormat, and the timezone', () => {
     const returned = range(new Date('2024-01-01'), new Date('2024-01-31'));
     const opt = makeOption('last_7_days', 'key|Last 7 days');
     vi.mocked(opt.getRange).mockReturnValue(returned);
     vi.mocked(resolveI18nString).mockReturnValue('Last 7 days');
     vi.mocked(getTimeRangeLabel).mockReturnValue('Jan 2024');
 
-    getDateRangeSelectFieldProOptions([opt]);
+    getDateRangeSelectFieldProOptions([opt], 'Australia/Sydney');
 
-    expect(getTimeRangeLabel).toHaveBeenCalledWith(returned, 'MMM YYYY');
+    expect(opt.getRange).toHaveBeenCalledWith('Australia/Sydney');
+    expect(getTimeRangeLabel).toHaveBeenCalledWith(
+      returned,
+      'MMM YYYY',
+      undefined,
+      'Australia/Sydney',
+    );
   });
 
   it('calls resolveI18nString with option.label', () => {

--- a/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.utils.ts
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/DateRangePickerPresetsPro.utils.ts
@@ -9,7 +9,12 @@ export const getDateRangeSelectFieldProOptions = (
 ): SelectListOptionProps[] => {
   return dateRangeSelectFieldProOptions.map((option) => {
     return {
-      rightLabel: getTimeRangeLabel(option.getRange(timezone), option.dateFormat),
+      rightLabel: getTimeRangeLabel(
+        option.getRange(timezone),
+        option.dateFormat,
+        undefined,
+        timezone,
+      ),
       value: option.value,
       label: resolveI18nString(option.label),
     };

--- a/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
+++ b/src/components/editors/dates/DateRangePickerPresetsPro/index.tsx
@@ -134,7 +134,7 @@ const DateRangePickerPresets = (props: DateRangePickerPresetsProps) => {
     }
 
     if (selectedValue?.from && selectedValue?.to) {
-      return getTimeRangeLabel(selectedValue, 'MMM DD');
+      return getTimeRangeLabel(selectedValue, 'MMM DD', dateRangeOptions, timezone);
     }
 
     return '';

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -280,4 +280,22 @@ describe('getTimeRangeLabel', () => {
     // unresolved → dateRange undefined → ''
     expect(getTimeRangeLabel(input, 'DD MMM', [opt])).toBe('');
   });
+
+  it('formats from/to in UTC when no timezone is given, even if that spans two UTC days', () => {
+    // Midnight-to-midnight 15 Jun in Australia/Sydney (AEST, UTC+10) is
+    // 14 Jun 14:00 UTC to 15 Jun 13:59:59.999 UTC — two different UTC days.
+    const sydneyDay = range(
+      new Date('2024-06-14T14:00:00.000Z'),
+      new Date('2024-06-15T13:59:59.999Z'),
+    );
+    expect(getTimeRangeLabel(sydneyDay, 'DD MMM')).toBe('14 Jun - 15 Jun');
+  });
+
+  it('formats from/to in the given timezone rather than UTC', () => {
+    const sydneyDay = range(
+      new Date('2024-06-14T14:00:00.000Z'),
+      new Date('2024-06-15T13:59:59.999Z'),
+    );
+    expect(getTimeRangeLabel(sydneyDay, 'DD MMM', undefined, 'Australia/Sydney')).toBe('15 Jun');
+  });
 });

--- a/src/components/editors/dates/dates.utils.test.ts
+++ b/src/components/editors/dates/dates.utils.test.ts
@@ -165,25 +165,28 @@ describe('getTimeRangeFromDateRange', () => {
   });
 
   it('anchors from/to using clientContext.timezone rather than UTC', () => {
-    // 02:00 UTC on 1 Mar is 29 Feb locally in America/Los_Angeles (UTC-8)
+    // 02:00 UTC on 1 Mar is 29 Feb locally in America/Los_Angeles (UTC-8),
+    // so the emitted range must be 29 Feb's midnight-to-midnight in that
+    // zone (08:00-1 Mar 07:59:59.999 UTC), not UTC midnight-to-midnight.
     const dateRange: DateRange = {
       from: new Date('2024-03-01T02:00:00.000Z'),
       to: new Date('2024-03-01T02:00:00.000Z'),
     };
     const result = getTimeRangeFromDateRange(dateRange, 'America/Los_Angeles');
-    expect(result?.from).toEqual(new Date('2024-02-29T00:00:00.000Z'));
-    expect(result?.to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
+    expect(result?.from).toEqual(new Date('2024-02-29T08:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2024-03-01T07:59:59.999Z'));
   });
 
   it('does not tip `to` into the next day when the calendar widget has already forced it to 23:59:59.999 UTC and timezone is ahead of UTC', () => {
-    // Naive re-projection through Europe/London (BST +1) would push this into "2 Sep".
+    // Naive re-projection through Europe/London (BST +1) must keep this on "1 Sep"
+    // locally, i.e. 31 Aug 23:00 UTC to 1 Sep 22:59:59.999 UTC, not "2 Sep".
     const dateRange: DateRange = {
       from: new Date('2026-09-01T00:00:00.000Z'),
       to: new Date('2026-09-01T23:59:59.999Z'),
     };
     const result = getTimeRangeFromDateRange(dateRange, 'Europe/London');
-    expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
-    expect(result?.to).toEqual(new Date('2026-09-01T23:59:59.999Z'));
+    expect(result?.from).toEqual(new Date('2026-08-31T23:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2026-09-01T22:59:59.999Z'));
   });
 
   it('resolves a genuine multi-day range correctly under a timezone ahead of UTC', () => {
@@ -192,8 +195,8 @@ describe('getTimeRangeFromDateRange', () => {
       to: new Date('2026-09-05T23:59:59.999Z'),
     };
     const result = getTimeRangeFromDateRange(dateRange, 'Europe/London');
-    expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
-    expect(result?.to).toEqual(new Date('2026-09-05T23:59:59.999Z'));
+    expect(result?.from).toEqual(new Date('2026-08-31T23:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2026-09-05T22:59:59.999Z'));
   });
 
   it('treats a single click (range not completed, `to` undefined) as a single-day pick instead of defaulting to "now"', () => {
@@ -202,8 +205,8 @@ describe('getTimeRangeFromDateRange', () => {
       to: undefined,
     };
     const result = getTimeRangeFromDateRange(dateRange, 'Australia/Sydney');
-    expect(result?.from).toEqual(new Date('2026-09-01T00:00:00.000Z'));
-    expect(result?.to).toEqual(new Date('2026-09-01T23:59:59.999Z'));
+    expect(result?.from).toEqual(new Date('2026-08-31T14:00:00.000Z'));
+    expect(result?.to).toEqual(new Date('2026-09-01T13:59:59.999Z'));
   });
 });
 

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -81,9 +81,11 @@ export const getDateRangeFromTimeRange = (
   return finalTimeRange;
 };
 
-// Matches defaults.DateRanges.constants.ts so manual picks line up with preset ranges.
-const getLocalDateString = (date: Date | undefined, tz?: string): string =>
-  tz ? dayjs.tz(date, tz).format('YYYY-MM-DD') : dayjs.utc(date).format('YYYY-MM-DD');
+// Anchors `date` to the start of its calendar day in `tz` (or in UTC when no
+// timezone is given). Matches defaults.DateRanges.constants.ts so manual
+// picks line up with preset ranges.
+const startOfDayIn = (date: Date | undefined, tz?: string) =>
+  tz ? dayjs(date).tz(tz).startOf('day') : dayjs.utc(date).startOf('day');
 
 export const getTimeRangeFromDateRange = (
   dateRange: DateRange | undefined,
@@ -102,7 +104,7 @@ export const getTimeRangeFromDateRange = (
 
   return {
     relativeTimeString: undefined,
-    from: dayjs.utc(getLocalDateString(dateRange.from, timezone)).startOf('day').toDate(),
-    to: dayjs.utc(getLocalDateString(toDayStart, timezone)).endOf('day').toDate(),
+    from: startOfDayIn(dateRange.from, timezone).toDate(),
+    to: startOfDayIn(toDayStart, timezone).endOf('day').toDate(),
   };
 };

--- a/src/components/editors/dates/dates.utils.ts
+++ b/src/components/editors/dates/dates.utils.ts
@@ -46,15 +46,18 @@ export const getTimeRangeLabel = (
 
   const { from, to } = dateRange;
 
-  const currentUTCYear = new Date().getUTCFullYear();
+  // Format in the target zone so the label reflects the same calendar day the
+  // range was anchored to — not the UTC day, which can differ near midnight.
+  const zoned = (date: Date | undefined) =>
+    timezone ? dayjs(date).tz(timezone) : dayjs(date).utc();
 
-  const isDifferentYear =
-    currentUTCYear !== from?.getUTCFullYear() || currentUTCYear !== to?.getUTCFullYear();
+  const currentYear = zoned(new Date()).year();
+  const isDifferentYear = currentYear !== zoned(from).year() || currentYear !== zoned(to).year();
 
   const format = isDifferentYear ? 'DD MMM YYYY' : dateFormat;
 
-  const labelFrom = dayjs(from).utc().format(format);
-  const labelTo = dayjs(to).utc().format(format);
+  const labelFrom = zoned(from).format(format);
+  const labelTo = zoned(to).format(format);
 
   if (labelFrom === labelTo) {
     return labelFrom;

--- a/src/theme/defaults/defaults.DateRanges.constants.test.ts
+++ b/src/theme/defaults/defaults.DateRanges.constants.test.ts
@@ -177,28 +177,28 @@ describe('defaultDateRangeOptions', () => {
       vi.useRealTimers();
     });
 
-    it('Today anchors to local date (Feb 16, not Feb 15)', () => {
+    it('Today anchors to local date (Feb 16, not Feb 15), in Auckland midnight-to-midnight', () => {
       const { from, to } = getOption('Today').getRange(
         'Pacific/Auckland',
       ) as TimeRangeDeserializedValue;
-      expect(from).toEqual(new Date('2024-02-16T00:00:00.000Z'));
-      expect(to).toEqual(new Date('2024-02-16T23:59:59.999Z'));
+      expect(from).toEqual(new Date('2024-02-15T11:00:00.000Z')); // Feb 16 00:00 NZDT (UTC+13)
+      expect(to).toEqual(new Date('2024-02-16T10:59:59.999Z')); // Feb 16 23:59:59.999 NZDT
     });
 
     it('Yesterday is Feb 15, not Feb 14', () => {
       const { from, to } = getOption('Yesterday').getRange(
         'Pacific/Auckland',
       ) as TimeRangeDeserializedValue;
-      expect(from).toEqual(new Date('2024-02-15T00:00:00.000Z'));
-      expect(to).toEqual(new Date('2024-02-15T23:59:59.999Z'));
+      expect(from).toEqual(new Date('2024-02-14T11:00:00.000Z')); // Feb 15 00:00 NZDT
+      expect(to).toEqual(new Date('2024-02-15T10:59:59.999Z')); // Feb 15 23:59:59.999 NZDT
     });
 
     it('Week to date ends on local today (Mon Feb 12 – Fri Feb 16)', () => {
       const { from, to } = getOption('Week to date').getRange(
         'Pacific/Auckland',
       ) as TimeRangeDeserializedValue;
-      expect(from).toEqual(new Date('2024-02-12T00:00:00.000Z'));
-      expect(to).toEqual(new Date('2024-02-16T23:59:59.999Z'));
+      expect(from).toEqual(new Date('2024-02-11T11:00:00.000Z')); // Feb 12 00:00 NZDT
+      expect(to).toEqual(new Date('2024-02-16T10:59:59.999Z')); // Feb 16 23:59:59.999 NZDT
     });
   });
 
@@ -220,24 +220,24 @@ describe('defaultDateRangeOptions', () => {
       const { from, to } = getOption('Today').getRange(
         'Atlantic/Cape_Verde',
       ) as TimeRangeDeserializedValue;
-      expect(from).toEqual(new Date('2024-02-29T00:00:00.000Z'));
-      expect(to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
+      expect(from).toEqual(new Date('2024-02-29T01:00:00.000Z')); // Feb 29 00:00 UTC-1
+      expect(to).toEqual(new Date('2024-03-01T00:59:59.999Z')); // Feb 29 23:59:59.999 UTC-1
     });
 
     it('This month is February (leap year), not March', () => {
       const { from, to } = getOption('This month').getRange(
         'Atlantic/Cape_Verde',
       ) as TimeRangeDeserializedValue;
-      expect(from).toEqual(new Date('2024-02-01T00:00:00.000Z'));
-      expect(to).toEqual(new Date('2024-02-29T23:59:59.999Z'));
+      expect(from).toEqual(new Date('2024-02-01T01:00:00.000Z')); // Feb 1 00:00 UTC-1
+      expect(to).toEqual(new Date('2024-03-01T00:59:59.999Z')); // Feb 29 23:59:59.999 UTC-1
     });
 
     it('Last month is January, not February', () => {
       const { from, to } = getOption('Last month').getRange(
         'Atlantic/Cape_Verde',
       ) as TimeRangeDeserializedValue;
-      expect(from).toEqual(new Date('2024-01-01T00:00:00.000Z'));
-      expect(to).toEqual(new Date('2024-01-31T23:59:59.999Z'));
+      expect(from).toEqual(new Date('2024-01-01T01:00:00.000Z')); // Jan 1 00:00 UTC-1
+      expect(to).toEqual(new Date('2024-02-01T00:59:59.999Z')); // Jan 31 23:59:59.999 UTC-1
     });
   });
 });

--- a/src/theme/defaults/defaults.DateRanges.constants.ts
+++ b/src/theme/defaults/defaults.DateRanges.constants.ts
@@ -12,10 +12,7 @@ dayjs.extend(quarterOfYear);
 
 const makeTimeRange = (from: Date, to: Date): TimeRange => ({ from, to, relativeTimeString: '' });
 
-const getLocalDateString = (date: Date, tz?: string): string =>
-  tz ? dayjs.tz(date, tz).format('YYYY-MM-DD') : dayjs.utc(date).format('YYYY-MM-DD');
-
-const getNow = (tz?: string) => dayjs.utc(getLocalDateString(new Date(), tz));
+const getNow = (tz?: string) => (tz ? dayjs().tz(tz) : dayjs.utc());
 
 const getDayBounds = (offset = 0, tz?: string): TimeRange => {
   const d = getNow(tz).add(offset, 'day');


### PR DESCRIPTION
# Why is this pull-request needed?

This PR is needed because date filters near a timezone boundary could pull in an extra day of data. A date picked for a dashboard in one timezone was still being searched for in UTC time, so it didn't always match the actual day the user picked.

Example: picking "Sept 4" on a dashboard set to Sydney time.

**Before:** searched Sept 4, 12:00am – 11:59pm UTC, which is actually Sept 4, 10:00am – Sept 5, 9:59am in Sydney time — so Sept 5 data was included too.

**After:** searches Sept 4, 12:00am – 11:59pm Sydney time. Only Sept 4 data is included.

# Main changes

- Date ranges are now worked out using the dashboard's own timezone the whole way through, instead of switching back to UTC partway through
- This covers both custom date picks and the built-in presets (Today, Yesterday, Last 7 days, etc.)

# Test evidence

https://github.com/user-attachments/assets/73a50ecb-a982-403f-a8e6-b23117e3f17d


